### PR TITLE
Added basic Dockerfile support & documentation

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,4 @@
+FROM        sdurrheimer/alpine-golang-make-onbuild
+MAINTAINER  The Prometheus Authors <prometheus-developers@googlegroups.com>
+
+EXPOSE      9115

--- a/README.md
+++ b/README.md
@@ -5,11 +5,18 @@ HTTP, HTTPS and TCP.
 
 ## Building and running
 
+### Local Build
+
     make
     ./blackbox_exporter <flags>
 
 Visiting [http://localhost:9115/probe?target=google.com&module=http_2xx](http://localhost:9115/probe?target=google.com&module=http_2xx)
 will return metrics for a HTTP probe against google.com.
+
+### Building with Docker
+
+    docker build -t blackbox_exporter .
+    docker run -d -p 9115:9115 --name blackbox_exporter -v `pwd`:/config blackbox_exporter -config.file=/config/blackbox.yml
 
 ## Configuration
 


### PR DESCRIPTION
The other official tools all seem to have a dockerfile (and be on the hub), and we use this capability (along with docker-compose) to deploy prometheus.

This adds the Dockerfile and basic documentation in a way which seems consistent with the other `prom/` projects. 