### PR TITLE
Fix typo

### DIFF
--- a/main.go
+++ b/main.go
@@ -66,7 +66,7 @@ func probeHandler(w http.ResponseWriter, r *http.Request, config *Config) {
 		return
 	}
 	if moduleName == "" {
-		moduleName = "http2xx"
+		moduleName = "http_2xx"
 	}
 	module, ok := config.Modules[moduleName]
 	if !ok {


### PR DESCRIPTION
In all examples the module is named with underscore