### PR TITLE
added headers support

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,8 @@ modules:
     http:
       valid_status_codes: []  # Defaults to 2xx
       method: GET
+      headers:
+        header_title: header_content
       no_follow_redirects: false
       fail_if_ssl: false
       fail_if_not_ssl: false

--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ modules:
     http:
       valid_status_codes: []  # Defaults to 2xx
       headers:
-        header_title: header_content
+        header_name: header_content
       method: GET
       no_follow_redirects: false
       fail_if_ssl: false

--- a/README.md
+++ b/README.md
@@ -28,9 +28,9 @@ modules:
     timeout: 5s
     http:
       valid_status_codes: []  # Defaults to 2xx
-      method: GET
       headers:
         header_title: header_content
+      method: GET
       no_follow_redirects: false
       fail_if_ssl: false
       fail_if_not_ssl: false

--- a/http.go
+++ b/http.go
@@ -83,6 +83,12 @@ func probeHTTP(target string, w http.ResponseWriter, module Module) (success boo
 		return
 	}
 
+	if len(config.Headers) > 0 {
+		for key, value := range config.Headers {
+			request.Header.Add(key, value)
+		}
+	}
+
 	resp, err := client.Do(request)
 	// Err won't be nil if redirects were turned off. See https://github.com/golang/go/issues/3795
 	if err != nil && resp == nil {
@@ -119,6 +125,7 @@ func probeHTTP(target string, w http.ResponseWriter, module Module) (success boo
 	} else if config.FailIfNotSSL {
 		success = false
 	}
+
 	fmt.Fprintf(w, "probe_http_status_code %d\n", resp.StatusCode)
 	fmt.Fprintf(w, "probe_http_content_length %d\n", resp.ContentLength)
 	fmt.Fprintf(w, "probe_http_redirects %d\n", redirects)

--- a/http.go
+++ b/http.go
@@ -83,10 +83,8 @@ func probeHTTP(target string, w http.ResponseWriter, module Module) (success boo
 		return
 	}
 
-	if len(config.Headers) > 0 {
-		for key, value := range config.Headers {
-			request.Header.Add(key, value)
-		}
+	for key, value := range config.Headers {
+		request.Header.Add(key, value)
 	}
 
 	resp, err := client.Do(request)

--- a/http_test.go
+++ b/http_test.go
@@ -238,3 +238,20 @@ func TestFailIfNotMatchesRegexp(t *testing.T) {
 		t.Fatalf("Regexp test failed unexpectedly, got %s", body)
 	}
 }
+func TestHttpHeaders(t *testing.T) {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		fmt.Fprintf(w, "Header Test Here")
+	}))
+	defer ts.Close()
+
+	recorder := httptest.NewRecorder()
+	headers := make(map[string]string)
+	headers["Authorization"] = "Bearer 8GvSFu9XTXZ75e2GmGwVjY4d69jcq8AZum8sgHE9q2H3ebVa"
+	result := probeHTTP(ts.URL, recorder,
+		Module{Timeout: time.Second, HTTP: HTTPProbe{Headers: headers}})
+	rcvHeaders := recorder.Header().Get("Authorization")
+	if !result {
+		t.Fatalf("Headers test failed unexceptedly, got %s", rcvHeaders)
+	}
+
+}

--- a/main.go
+++ b/main.go
@@ -30,13 +30,14 @@ type Module struct {
 
 type HTTPProbe struct {
 	// Defaults to 2xx.
-	ValidStatusCodes       []int    `yaml:"valid_status_codes"`
-	NoFollowRedirects      bool     `yaml:"no_follow_redirects"`
-	FailIfSSL              bool     `yaml:"fail_if_ssl"`
-	FailIfNotSSL           bool     `yaml:"fail_if_not_ssl"`
-	Method                 string   `yaml:"method"`
-	FailIfMatchesRegexp    []string `yaml:"fail_if_matches_regexp"`
-	FailIfNotMatchesRegexp []string `yaml:"fail_if_not_matches_regexp"`
+	ValidStatusCodes       []int             `yaml:"valid_status_codes"`
+	NoFollowRedirects      bool              `yaml:"no_follow_redirects"`
+	FailIfSSL              bool              `yaml:"fail_if_ssl"`
+	FailIfNotSSL           bool              `yaml:"fail_if_not_ssl"`
+	Method                 string            `yaml:"method"`
+	Headers                map[string]string `yaml:"headers"`
+	FailIfMatchesRegexp    []string          `yaml:"fail_if_matches_regexp"`
+	FailIfNotMatchesRegexp []string          `yaml:"fail_if_not_matches_regexp"`
 }
 
 type QueryResponse struct {


### PR DESCRIPTION
added headers support in the blackbox_exporter config yml,
Headers located under HTTPProbe in http.go.

updated readme accordingly.