### PR TITLE
http: add "http_host" param to test back-ends and virtual hosts

### DIFF
--- a/http.go
+++ b/http.go
@@ -6,6 +6,7 @@ import (
 	"io"
 	"io/ioutil"
 	"net/http"
+	"net/url"
 	"regexp"
 	"strings"
 
@@ -41,7 +42,7 @@ func matchRegularExpressions(reader io.Reader, config HTTPProbe) bool {
 	return true
 }
 
-func probeHTTP(target string, w http.ResponseWriter, module Module) (success bool) {
+func probeHTTP(target string, w http.ResponseWriter, module Module, params url.Values) (success bool) {
 	var isSSL, redirects int
 	config := module.HTTP
 
@@ -69,6 +70,9 @@ func probeHTTP(target string, w http.ResponseWriter, module Module) (success boo
 	if err != nil {
 		log.Errorf("Error creating request for target %s: %s", target, err)
 		return
+	}
+	if host := params.Get("http_host"); host != "" {
+		request.Host = host
 	}
 
 	resp, err := client.Do(request)

--- a/icmp.go
+++ b/icmp.go
@@ -2,13 +2,15 @@ package main
 
 import (
 	"bytes"
-	"golang.org/x/net/icmp"
-	"golang.org/x/net/ipv4"
 	"net"
 	"net/http"
+	"net/url"
 	"os"
 	"sync"
 	"time"
+
+	"golang.org/x/net/icmp"
+	"golang.org/x/net/ipv4"
 
 	"github.com/prometheus/log"
 )
@@ -25,7 +27,7 @@ func getICMPSequence() uint16 {
 	return icmpSequence
 }
 
-func probeICMP(target string, w http.ResponseWriter, module Module) (success bool) {
+func probeICMP(target string, w http.ResponseWriter, module Module, params url.Values) (success bool) {
 	deadline := time.Now().Add(module.Timeout)
 	socket, err := icmp.ListenPacket("ip4:icmp", "0.0.0.0")
 	if err != nil {

--- a/main.go
+++ b/main.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"io/ioutil"
 	"net/http"
+	"net/url"
 	"time"
 
 	"gopkg.in/yaml.v2"
@@ -54,7 +55,7 @@ type TCPProbe struct {
 type ICMPProbe struct {
 }
 
-var Probers = map[string]func(string, http.ResponseWriter, Module) bool{
+var Probers = map[string]func(string, http.ResponseWriter, Module, url.Values) bool{
 	"http": probeHTTP,
 	"tcp":  probeTCP,
 	"icmp": probeICMP,
@@ -82,7 +83,7 @@ func probeHandler(w http.ResponseWriter, r *http.Request, config *Config) {
 		return
 	}
 	start := time.Now()
-	success := prober(target, w, module)
+	success := prober(target, w, module, params)
 	fmt.Fprintf(w, "probe_duration_seconds %f\n", float64(time.Now().Sub(start))/1e9)
 	if success {
 		fmt.Fprintf(w, "probe_success %d\n", 1)

--- a/tcp.go
+++ b/tcp.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"net"
 	"net/http"
+	"net/url"
 	"regexp"
 	"time"
 
@@ -24,7 +25,7 @@ func dialTCP(target string, module Module) (net.Conn, error) {
 	return tls.DialWithDialer(dialer, "tcp", target, config)
 }
 
-func probeTCP(target string, w http.ResponseWriter, module Module) bool {
+func probeTCP(target string, w http.ResponseWriter, module Module, params url.Values) bool {
 	deadline := time.Now().Add(module.Timeout)
 	conn, err := dialTCP(target, module)
 	if err != nil {


### PR DESCRIPTION
This CL adds a http_host parameter (similarly to the target parameter) which can be used to set the "Host" header of the HTTP request.

This feature allows the blackbox_exporter to test back-ends and servers with virtual hosts.