### PR TITLE
configureable http headers for the http probe

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,9 @@ modules:
     http:
       valid_status_codes: []  # Defaults to 2xx
       method: GET
+      headers:
+        Host: vhost.example.com
+        Accept-Language: en-US
       no_follow_redirects: false
       fail_if_ssl: false
       fail_if_not_ssl: false

--- a/http.go
+++ b/http.go
@@ -53,9 +53,8 @@ func probeHTTP(target string, w http.ResponseWriter, module Module) (success boo
 		redirects = len(via)
 		if redirects > 10 || config.NoFollowRedirects {
 			return errors.New("Don't follow redirects")
-		} else {
-			return nil
 		}
+		return nil
 	}
 
 	if !strings.HasPrefix(target, "http://") && !strings.HasPrefix(target, "https://") {
@@ -69,6 +68,14 @@ func probeHTTP(target string, w http.ResponseWriter, module Module) (success boo
 	if err != nil {
 		log.Errorf("Error creating request for target %s: %s", target, err)
 		return
+	}
+
+	for key, value := range config.Headers {
+		if strings.Title(key) == "Host" {
+			request.Host = value
+			continue
+		}
+		request.Header.Set(key, value)
 	}
 
 	resp, err := client.Do(request)

--- a/main.go
+++ b/main.go
@@ -31,13 +31,14 @@ type Module struct {
 
 type HTTPProbe struct {
 	// Defaults to 2xx.
-	ValidStatusCodes       []int    `yaml:"valid_status_codes"`
-	NoFollowRedirects      bool     `yaml:"no_follow_redirects"`
-	FailIfSSL              bool     `yaml:"fail_if_ssl"`
-	FailIfNotSSL           bool     `yaml:"fail_if_not_ssl"`
-	Method                 string   `yaml:"method"`
-	FailIfMatchesRegexp    []string `yaml:"fail_if_matches_regexp"`
-	FailIfNotMatchesRegexp []string `yaml:"fail_if_not_matches_regexp"`
+	ValidStatusCodes       []int             `yaml:"valid_status_codes"`
+	NoFollowRedirects      bool              `yaml:"no_follow_redirects"`
+	FailIfSSL              bool              `yaml:"fail_if_ssl"`
+	FailIfNotSSL           bool              `yaml:"fail_if_not_ssl"`
+	Method                 string            `yaml:"method"`
+	Headers                map[string]string `yaml:"headers"`
+	FailIfMatchesRegexp    []string          `yaml:"fail_if_matches_regexp"`
+	FailIfNotMatchesRegexp []string          `yaml:"fail_if_not_matches_regexp"`
 }
 
 type QueryResponse struct {


### PR DESCRIPTION
Another try. This CL makes https://github.com/prometheus/blackbox_exporter/pull/35 obsolete and adds a more general headers map as discussed before.