### PR TITLE
support postgres-style in-band explicit 'STARTTLS'

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,6 +101,14 @@ modules:
       protocol: "tcp" # accepts "tcp/tcp4/tcp6/udp/udp4/udp6", defaults to "udp"
       preferred_ip_protocol: "ip4" # used for "udp/tcp", defaults to "ip6"
       query_name: "www.prometheus.io"
+  pg_ssl_connect:
+    prober: tcp
+    timeout: 5s
+    tcp:
+      tls: true
+      tls_config:
+        insecure_skip_verify: true
+        starttls: postgres
 ```
 
 HTTP, HTTPS (via the `http` prober), DNS, TCP socket and ICMP (v4 only, see permissions section) are currently supported.

--- a/vendor/github.com/prometheus/common/config/tls_config.go
+++ b/vendor/github.com/prometheus/common/config/tls_config.go
@@ -30,6 +30,8 @@ type TLSConfig struct {
 	KeyFile string `yaml:"key_file,omitempty"`
 	// Disable target certificate validation.
 	InsecureSkipVerify bool `yaml:"insecure_skip_verify"`
+	// The STARTTLS mode to initiate
+	StartTLS string `yaml:"starttls,omitempty"`
 
 	// Catches all undefined fields and must be empty after parsing.
 	XXX map[string]interface{} `yaml:",inline"`


### PR DESCRIPTION
I'm interested in capturing the expiry time of Postgres server's SSL certificates. Postgres uses a `STARTTLS`-style connection setup: you have to speak some Postgres protocol before you can speak TLS.

This change adds support for explicitly talking that protocol, if requested, before doing the normal TLS work. This is similar to `openssl s_client -starttls smtp -connect ..` (although openssl currently doesn't support Postgres).

I have not tested:
- deadlines
- full cert chain verification (this is uncommon in the Postgres world; the official client defaults to limited validation)
