### PR TITLE
http: implement TLS and InsecureSkipVerify

### DIFF
--- a/http.go
+++ b/http.go
@@ -61,6 +61,16 @@ func probeHTTP(target string, w http.ResponseWriter, module Module) (success boo
 	client := &http.Client{
 		Timeout: module.Timeout,
 	}
+	if module.HTTP.TLS {
+		config, err := module.HTTP.TLSConfig.GenerateConfig()
+		if err != nil {
+			log.Errorf("Error configtls request for target %s", err)
+			return
+		}
+		client.Transport = &http.Transport{
+			TLSClientConfig: config,
+		}
+	}
 
 	client.CheckRedirect = func(_ *http.Request, via []*http.Request) error {
 		redirects = len(via)

--- a/http_test.go
+++ b/http_test.go
@@ -15,6 +15,7 @@ package main
 
 import (
 	"fmt"
+	"github.com/prometheus/common/config"
 	"net/http"
 	"net/http/httptest"
 	"strings"
@@ -266,5 +267,45 @@ func TestHTTPHeaders(t *testing.T) {
 	}})
 	if !result {
 		t.Fatalf("Probe failed unexpectedly.")
+	}
+}
+
+func TestFailIfSelfSignedCA(t *testing.T) {
+	ts := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+	}))
+	defer ts.Close()
+
+	recorder := httptest.NewRecorder()
+	result := probeHTTP(ts.URL, recorder,
+		Module{Timeout: time.Second, HTTP: HTTPProbe{
+			TLS:       true,
+			TLSConfig: config.TLSConfig{InsecureSkipVerify: false},
+		}})
+	body := recorder.Body.String()
+	if result {
+		t.Fatalf("Fail if selfsigned CA test suceeded unexpectedly, got %s", body)
+	}
+	if !strings.Contains(body, "probe_http_ssl 0\n") {
+		t.Fatalf("Expected HTTP without SSL because of CA failure, got %s", body)
+	}
+}
+
+func TestSucceedIfSelfSignedCA(t *testing.T) {
+	ts := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+	}))
+	defer ts.Close()
+
+	recorder := httptest.NewRecorder()
+	result := probeHTTP(ts.URL, recorder,
+		Module{Timeout: time.Second, HTTP: HTTPProbe{
+			TLS:       true,
+			TLSConfig: config.TLSConfig{InsecureSkipVerify: true},
+		}})
+	body := recorder.Body.String()
+	if !result {
+		t.Fatalf("Fail if (not strict) selfsigned CA test fails unexpectedly, got %s", body)
+	}
+	if !strings.Contains(body, "probe_http_ssl 1\n") {
+		t.Fatalf("Expected HTTP with SSL, got %s", body)
 	}
 }


### PR DESCRIPTION
As we talked yesterday in: 
[https://github.com/prometheus/blackbox_exporter/issues/41](url) "Please support custom CAs for http prober" 