### PR TITLE
Use golang-builder base image for tests in CircleCI

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -2,7 +2,7 @@ machine:
   environment:
     DOCKER_IMAGE_NAME: prom/blackbox-exporter
     QUAY_IMAGE_NAME: quay.io/prometheus/blackbox-exporter
-    DOCKER_TEST_IMAGE_NAME: quay.io/prometheus/golang-builder:1.6-main
+    DOCKER_TEST_IMAGE_NAME: quay.io/prometheus/golang-builder:1.6-base
     REPO_PATH: github.com/prometheus/blackbox_exporter
   pre:
     - sudo curl -L -o /usr/bin/docker 'https://s3-external-1.amazonaws.com/circle-downloads/docker-1.9.1-circleci'


### PR DESCRIPTION
Must be merged after prometheus/golang-builder#13 and prometheus/promu#41 have been merged and successfully built.