### PR TITLE
IPv6 support for all modules

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,9 +45,14 @@ modules:
       - "Download the latest version here"
       tls_config:
         insecure_skip_verify: false
+      protocol: "tcp" # accepts "tcp/tcp4/tcp6", defaults to "tcp"
+      preferred_ip_protocol: "ip4" # used for "tcp", defaults to "ip6"
   tcp_connect:
     prober: tcp
     timeout: 5s
+    tcp:
+      protocol: "tcp"
+      preferred_ip_protocol: "ip4"
   pop3s_banner:
     prober: tcp
     tcp:
@@ -75,6 +80,9 @@ modules:
   icmp:
     prober: icmp
     timeout: 5s
+    icmp:
+      protocol: "icmp"
+      preferred_ip_protocol: "ip4"
   dns_udp:
     prober: dns
     timeout: 5s
@@ -97,7 +105,8 @@ modules:
   dns_tcp:
     prober: dns
     dns:
-      protocol: "tcp"  # can also be something like "udp4" or "tcp6"
+      protocol: "tcp" # accepts "tcp/tcp4/tcp6/udp/udp4/udp6", defaults to "udp"
+      preferred_ip_protocol: "ip4" # used for "udp/tcp", defaults to "ip6"
       query_name: "www.prometheus.io"
 ```
 

--- a/dns_test.go
+++ b/dns_test.go
@@ -16,6 +16,7 @@ package main
 import (
 	"net"
 	"net/http/httptest"
+	"runtime"
 	"strings"
 	"testing"
 	"time"
@@ -315,6 +316,141 @@ func TestServfailDNSResponse(t *testing.T) {
 					t.Fatalf("Did not find expected output in test %d: %q", i, line)
 				}
 			}
+		}
+	}
+}
+
+func TestDNSProtocol(t *testing.T) {
+	// This test assumes that listening "tcp" listens both IPv6 and IPv4 traffic and
+	// localhost resolves to both 127.0.0.1 and ::1. we must skip the test if either
+	// of these isn't true. This should be true for modern Linux systems.
+	if runtime.GOOS == "dragonfly" || runtime.GOOS == "openbsd" {
+		t.Skip("IPv6 socket isn't able to accept IPv4 traffic in the system.")
+	}
+	_, err := net.ResolveIPAddr("ip6", "localhost")
+	if err != nil {
+		t.Skip("\"localhost\" doesn't resolve to ::1.")
+	}
+
+	for _, protocol := range PROTOCOLS {
+		server, addr := startDNSServer(protocol, recursiveDNSHandler)
+		defer server.Shutdown()
+
+		_, port, _ := net.SplitHostPort(addr.String())
+
+		// Force IPv4
+		module := Module{
+			Timeout: time.Second,
+			DNS: DNSProbe{
+				QueryName: "example.com",
+				Protocol:  protocol + "4",
+			},
+		}
+		recorder := httptest.NewRecorder()
+		result := probeDNS(net.JoinHostPort("localhost", port), recorder, module)
+		body := recorder.Body.String()
+		if !result {
+			t.Fatalf("DNS protocol: \"%v4\" connection test failed, expected success.", protocol)
+		}
+		if !strings.Contains(body, "probe_ip_protocol 4\n") {
+			t.Fatalf("Expected IPv4, got %s", body)
+		}
+
+		// Force IPv6
+		module = Module{
+			Timeout: time.Second,
+			DNS: DNSProbe{
+				QueryName: "example.com",
+				Protocol:  protocol + "6",
+			},
+		}
+		recorder = httptest.NewRecorder()
+		result = probeDNS(net.JoinHostPort("localhost", port), recorder, module)
+		body = recorder.Body.String()
+		if !result {
+			t.Fatalf("DNS protocol: \"%v6\" connection test failed, expected success.", protocol)
+		}
+		if !strings.Contains(body, "probe_ip_protocol 6\n") {
+			t.Fatalf("Expected IPv6, got %s", body)
+		}
+
+		// Prefer IPv6
+		module = Module{
+			Timeout: time.Second,
+			DNS: DNSProbe{
+				QueryName:           "example.com",
+				Protocol:            protocol,
+				PreferredIpProtocol: "ip6",
+			},
+		}
+		recorder = httptest.NewRecorder()
+		result = probeDNS(net.JoinHostPort("localhost", port), recorder, module)
+		body = recorder.Body.String()
+		if !result {
+			t.Fatalf("DNS protocol: \"%v\", preferred \"ip6\" connection test failed, expected success.", protocol)
+		}
+		if !strings.Contains(body, "probe_ip_protocol 6\n") {
+			t.Fatalf("Expected IPv6, got %s", body)
+		}
+
+		// Prefer IPv4
+		module = Module{
+			Timeout: time.Second,
+			DNS: DNSProbe{
+				QueryName:           "example.com",
+				Protocol:            protocol,
+				PreferredIpProtocol: "ip4",
+			},
+		}
+		recorder = httptest.NewRecorder()
+		result = probeDNS(net.JoinHostPort("localhost", port), recorder, module)
+		body = recorder.Body.String()
+		if !result {
+			t.Fatalf("DNS protocol: \"%v\", preferred \"ip4\" connection test failed, expected success.", protocol)
+		}
+		if !strings.Contains(body, "probe_ip_protocol 4\n") {
+			t.Fatalf("Expected IPv4, got %s", body)
+		}
+
+		// Prefer none
+		module = Module{
+			Timeout: time.Second,
+			DNS: DNSProbe{
+				QueryName: "example.com",
+				Protocol:  protocol,
+			},
+		}
+		recorder = httptest.NewRecorder()
+		result = probeDNS(net.JoinHostPort("localhost", port), recorder, module)
+		body = recorder.Body.String()
+		if !result {
+			t.Fatalf("DNS protocol: \"%v\" connection test failed, expected success.", protocol)
+		}
+		if !strings.Contains(body, "probe_ip_protocol 6\n") {
+			t.Fatalf("Expected IPv6, got %s", body)
+		}
+
+		// No protocol
+		module = Module{
+			Timeout: time.Second,
+			DNS: DNSProbe{
+				QueryName: "example.com",
+			},
+		}
+		recorder = httptest.NewRecorder()
+		result = probeDNS(net.JoinHostPort("localhost", port), recorder, module)
+		body = recorder.Body.String()
+		if protocol == "udp" {
+			if !result {
+				t.Fatalf("DNS test connection with protocol unspecified failed, expected success.", protocol)
+			}
+		} else {
+			if result {
+				t.Fatalf("DNS test connection with protocol unspecified succeeded, expected failure.", protocol)
+			}
+		}
+		if !strings.Contains(body, "probe_ip_protocol 6\n") {
+			t.Fatalf("Expected IPv6, got %s", body)
 		}
 	}
 }

--- a/main.go
+++ b/main.go
@@ -59,6 +59,8 @@ type HTTPProbe struct {
 	FailIfMatchesRegexp    []string          `yaml:"fail_if_matches_regexp"`
 	FailIfNotMatchesRegexp []string          `yaml:"fail_if_not_matches_regexp"`
 	TLSConfig              config.TLSConfig  `yaml:"tls_config"`
+	Protocol               string            `yaml:"protocol"`              // Defaults to "tcp".
+	PreferredIpProtocol    string            `yaml:"preferred_ip_protocol"` // Defaults to "ip6".
 }
 
 type QueryResponse struct {
@@ -67,22 +69,27 @@ type QueryResponse struct {
 }
 
 type TCPProbe struct {
-	QueryResponse []QueryResponse  `yaml:"query_response"`
-	TLS           bool             `yaml:"tls"`
-	TLSConfig     config.TLSConfig `yaml:"tls_config"`
+	QueryResponse       []QueryResponse  `yaml:"query_response"`
+	TLS                 bool             `yaml:"tls"`
+	TLSConfig           config.TLSConfig `yaml:"tls_config"`
+	Protocol            string           `yaml:"protocol"`              // Defaults to "tcp".
+	PreferredIpProtocol string           `yaml:"preferred_ip_protocol"` // Defaults to "ip6".
 }
 
 type ICMPProbe struct {
+	Protocol            string `yaml:"protocol"`              // Defaults to "icmp4".
+	PreferredIpProtocol string `yaml:"preferred_ip_protocol"` // Defaults to "ip6".
 }
 
 type DNSProbe struct {
-	Protocol           string         `yaml:"protocol"` // Defaults to "udp".
-	QueryName          string         `yaml:"query_name"`
-	QueryType          string         `yaml:"query_type"`   // Defaults to ANY.
-	ValidRcodes        []string       `yaml:"valid_rcodes"` // Defaults to NOERROR.
-	ValidateAnswer     DNSRRValidator `yaml:"validate_answer_rrs"`
-	ValidateAuthority  DNSRRValidator `yaml:"validate_authority_rrs"`
-	ValidateAdditional DNSRRValidator `yaml:"validate_additional_rrs"`
+	Protocol            string         `yaml:"protocol"` // Defaults to "udp".
+	QueryName           string         `yaml:"query_name"`
+	QueryType           string         `yaml:"query_type"`   // Defaults to ANY.
+	ValidRcodes         []string       `yaml:"valid_rcodes"` // Defaults to NOERROR.
+	ValidateAnswer      DNSRRValidator `yaml:"validate_answer_rrs"`
+	ValidateAuthority   DNSRRValidator `yaml:"validate_authority_rrs"`
+	ValidateAdditional  DNSRRValidator `yaml:"validate_additional_rrs"`
+	PreferredIpProtocol string         `yaml:"preferred_ip_protocol"` // Defaults to "ip6".
 }
 
 type DNSRRValidator struct {

--- a/tcp_test.go
+++ b/tcp_test.go
@@ -16,6 +16,9 @@ package main
 import (
 	"fmt"
 	"net"
+	"net/http/httptest"
+	"runtime"
+	"strings"
 	"testing"
 	"time"
 )
@@ -36,7 +39,8 @@ func TestTCPConnection(t *testing.T) {
 		conn.Close()
 		ch <- struct{}{}
 	}()
-	if !probeTCP(ln.Addr().String(), nil, Module{Timeout: time.Second}) {
+	recorder := httptest.NewRecorder()
+	if !probeTCP(ln.Addr().String(), recorder, Module{Timeout: time.Second}) {
 		t.Fatalf("TCP module failed, expected success.")
 	}
 	<-ch
@@ -44,7 +48,8 @@ func TestTCPConnection(t *testing.T) {
 
 func TestTCPConnectionFails(t *testing.T) {
 	// Invalid port number.
-	if probeTCP(":0", nil, Module{Timeout: time.Second}) {
+	recorder := httptest.NewRecorder()
+	if probeTCP(":0", recorder, Module{Timeout: time.Second}) {
 		t.Fatalf("TCP module suceeded, expected failure.")
 	}
 }
@@ -81,7 +86,8 @@ func TestTCPConnectionQueryResponseIRC(t *testing.T) {
 		conn.Close()
 		ch <- struct{}{}
 	}()
-	if !probeTCP(ln.Addr().String(), nil, module) {
+	recorder := httptest.NewRecorder()
+	if !probeTCP(ln.Addr().String(), recorder, module) {
 		t.Fatalf("TCP module failed, expected success.")
 	}
 	<-ch
@@ -99,7 +105,7 @@ func TestTCPConnectionQueryResponseIRC(t *testing.T) {
 		conn.Close()
 		ch <- struct{}{}
 	}()
-	if probeTCP(ln.Addr().String(), nil, module) {
+	if probeTCP(ln.Addr().String(), recorder, module) {
 		t.Fatalf("TCP module succeeded, expected failure.")
 	}
 	<-ch
@@ -137,10 +143,140 @@ func TestTCPConnectionQueryResponseMatching(t *testing.T) {
 		conn.Close()
 		ch <- version
 	}()
-	if !probeTCP(ln.Addr().String(), nil, module) {
+	recorder := httptest.NewRecorder()
+	if !probeTCP(ln.Addr().String(), recorder, module) {
 		t.Fatalf("TCP module failed, expected success.")
 	}
 	if got, want := <-ch, "OpenSSH_6.9p1"; got != want {
 		t.Fatalf("Read unexpected version: got %q, want %q", got, want)
+	}
+}
+
+func TestTCPConnectionProtocol(t *testing.T) {
+	// This test assumes that listening "tcp" listens both IPv6 and IPv4 traffic and
+	// localhost resolves to both 127.0.0.1 and ::1. we must skip the test if either
+	// of these isn't true. This should be true for modern Linux systems.
+	if runtime.GOOS == "dragonfly" || runtime.GOOS == "openbsd" {
+		t.Skip("IPv6 socket isn't able to accept IPv4 traffic in the system.")
+	}
+	_, err := net.ResolveIPAddr("ip6", "localhost")
+	if err != nil {
+		t.Skip("\"localhost\" doesn't resolve to ::1.")
+	}
+
+	ln, err := net.Listen("tcp", ":0")
+	if err != nil {
+		t.Fatalf("Error listening on socket: %s", err)
+	}
+	defer ln.Close()
+
+	_, port, _ := net.SplitHostPort(ln.Addr().String())
+
+	// Force IPv4
+	module := Module{
+		Timeout: time.Second,
+		TCP: TCPProbe{
+			Protocol: "tcp4",
+		},
+	}
+
+	recorder := httptest.NewRecorder()
+	result := probeTCP(net.JoinHostPort("localhost", port), recorder, module)
+	body := recorder.Body.String()
+	if !result {
+		t.Fatalf("TCP protocol: \"tcp4\" connection test failed, expected success.")
+	}
+	if !strings.Contains(body, "probe_ip_protocol 4\n") {
+		t.Fatalf("Expected IPv4, got %s", body)
+	}
+
+	// Force IPv6
+	module = Module{
+		Timeout: time.Second,
+		TCP: TCPProbe{
+			Protocol: "tcp6",
+		},
+	}
+
+	recorder = httptest.NewRecorder()
+	result = probeTCP(net.JoinHostPort("localhost", port), recorder, module)
+	body = recorder.Body.String()
+	if !result {
+		t.Fatalf("TCP protocol: \"tcp6\" connection test failed, expected success.")
+	}
+	if !strings.Contains(body, "probe_ip_protocol 6\n") {
+		t.Fatalf("Expected IPv6, got %s", body)
+	}
+
+	// Prefer IPv4
+	module = Module{
+		Timeout: time.Second,
+		TCP: TCPProbe{
+			Protocol:            "tcp",
+			PreferredIpProtocol: "ip4",
+		},
+	}
+
+	recorder = httptest.NewRecorder()
+	result = probeTCP(net.JoinHostPort("localhost", port), recorder, module)
+	body = recorder.Body.String()
+	if !result {
+		t.Fatalf("TCP protocol: \"tcp\", prefer: \"ip4\" connection test failed, expected success.")
+	}
+	if !strings.Contains(body, "probe_ip_protocol 4\n") {
+		t.Fatalf("Expected IPv4, got %s", body)
+	}
+
+	// Prefer IPv6
+	module = Module{
+		Timeout: time.Second,
+		TCP: TCPProbe{
+			Protocol:            "tcp",
+			PreferredIpProtocol: "ip6",
+		},
+	}
+
+	recorder = httptest.NewRecorder()
+	result = probeTCP(net.JoinHostPort("localhost", port), recorder, module)
+	body = recorder.Body.String()
+	if !result {
+		t.Fatalf("TCP protocol: \"tcp\", prefer: \"ip6\" connection test failed, expected success.")
+	}
+	if !strings.Contains(body, "probe_ip_protocol 6\n") {
+		t.Fatalf("Expected IPv6, got %s", body)
+	}
+
+	// Prefer nothing
+	module = Module{
+		Timeout: time.Second,
+		TCP: TCPProbe{
+			Protocol: "tcp",
+		},
+	}
+
+	recorder = httptest.NewRecorder()
+	result = probeTCP(net.JoinHostPort("localhost", port), recorder, module)
+	body = recorder.Body.String()
+	if !result {
+		t.Fatalf("TCP protocol: \"tcp\" connection test failed, expected success.")
+	}
+	if !strings.Contains(body, "probe_ip_protocol 6\n") {
+		t.Fatalf("Expected IPv6, got %s", body)
+	}
+
+	// No protocol
+	module = Module{
+		Timeout: time.Second,
+		TCP:     TCPProbe{},
+	}
+
+	recorder = httptest.NewRecorder()
+	result = probeTCP(net.JoinHostPort("localhost", port), recorder, module)
+	body = recorder.Body.String()
+	if !result {
+		t.Fatalf("TCP connection test with protocol unspecified failed, expected success.")
+	}
+	if !strings.Contains(body, "probe_ip_protocol 6\n") {
+		t.Fatalf("Expected IPv6, got %s", body)
 	}
 }


### PR DESCRIPTION
Introduce protocol field for every module which can be used to force
probe to IPv4 (tcp4 or icmp4) or IPv6 (tcp6 or icmp6). Default for tcp
and http modules is current behaviour - let stack decide. Default for
icmp is also current behaviour - IPv4.