### PR TITLE
Improve gzip support

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,6 +47,7 @@ modules:
         insecure_skip_verify: false
       protocol: "tcp" # accepts "tcp/tcp4/tcp6", defaults to "tcp"
       preferred_ip_protocol: "ip4" # used for "tcp", defaults to "ip6"
+      disable_gzip_encoding: false
   tcp_connect_v4_example:
     prober: tcp
     timeout: 5s

--- a/main.go
+++ b/main.go
@@ -61,6 +61,7 @@ type HTTPProbe struct {
 	TLSConfig              config.TLSConfig  `yaml:"tls_config"`
 	Protocol               string            `yaml:"protocol"`              // Defaults to "tcp".
 	PreferredIpProtocol    string            `yaml:"preferred_ip_protocol"` // Defaults to "ip6".
+	DisableGzipEncoding    bool              `yaml:"disable_gzip_encoding"`
 }
 
 type QueryResponse struct {


### PR DESCRIPTION
So, this PR adds `probe_http_content_compressed` and also calculates the `content_length` of the compressed content. Additionally, it exposes a new option on the HTTP module for disabling the built-in support for gzip altogether.