### PR TITLE
Adds feature to proxy metric endpoints

### DIFF
--- a/blackbox.yml
+++ b/blackbox.yml
@@ -8,6 +8,15 @@ modules:
     timeout: 5s
     http:
       method: POST
+  events_proxy:
+    prober: proxy
+    timeout: 5s
+    proxy:
+      valid_targets:
+      - https://127.0.0.1:2359/metrics
+      - https://127.0.0.1:2359/metrics
+      tls_config:
+        insecure_skip_verify: false
   tcp_connect:
     prober: tcp
     timeout: 5s

--- a/main.go
+++ b/main.go
@@ -43,6 +43,7 @@ type Module struct {
 	Prober  string        `yaml:"prober"`
 	Timeout time.Duration `yaml:"timeout"`
 	HTTP    HTTPProbe     `yaml:"http"`
+	Proxy   ProxyProbe    `yaml:"proxy"`
 	TCP     TCPProbe      `yaml:"tcp"`
 	ICMP    ICMPProbe     `yaml:"icmp"`
 	DNS     DNSProbe      `yaml:"dns"`
@@ -62,6 +63,12 @@ type HTTPProbe struct {
 	Protocol               string            `yaml:"protocol"`              // Defaults to "tcp".
 	PreferredIpProtocol    string            `yaml:"preferred_ip_protocol"` // Defaults to "ip6".
 	Body                   string            `yaml:"body"`
+}
+
+type ProxyProbe struct {
+	// Defaults to 2xx.
+	ValidTargets []string         `yaml:"valid_targets"`
+	TLSConfig    config.TLSConfig `yaml:"tls_config"`
 }
 
 type QueryResponse struct {
@@ -99,10 +106,11 @@ type DNSRRValidator struct {
 }
 
 var Probers = map[string]func(string, http.ResponseWriter, Module) bool{
-	"http": probeHTTP,
-	"tcp":  probeTCP,
-	"icmp": probeICMP,
-	"dns":  probeDNS,
+	"http":  probeHTTP,
+	"tcp":   probeTCP,
+	"icmp":  probeICMP,
+	"dns":   probeDNS,
+	"proxy": probePROXY,
 }
 
 func probeHandler(w http.ResponseWriter, r *http.Request, config *Config) {

--- a/proxy.go
+++ b/proxy.go
@@ -1,0 +1,73 @@
+package main
+
+import (
+	"github.com/prometheus/common/log"
+	"io/ioutil"
+	"net/http"
+)
+
+func probePROXY(target string, w http.ResponseWriter, module Module) bool {
+
+	if len(module.Proxy.ValidTargets) > 0 {
+		allowed := false
+		for _, validTarget := range module.Proxy.ValidTargets {
+			if target == validTarget {
+				allowed = true
+				break
+			}
+		}
+		if !allowed {
+			log.Errorf("Target '%s' not part of valid targets: %+v", target, module.Proxy.ValidTargets)
+			return false
+		}
+	}
+
+	client := &http.Client{
+		Timeout: module.Timeout,
+	}
+
+	tlsconfig, err := module.Proxy.TLSConfig.GenerateConfig()
+	if err != nil {
+		log.Errorf("Error generating TLS config: %s", err)
+		return false
+	}
+
+	client.Transport = &http.Transport{
+		TLSClientConfig:   tlsconfig,
+		Proxy:             http.ProxyFromEnvironment,
+		DisableKeepAlives: true,
+	}
+
+	request, err := http.NewRequest("GET", target, nil)
+	if err != nil {
+		log.Errorf("Error creating request for target %s: %s", target, err)
+		return false
+	}
+
+	resp, err := client.Do(request)
+	if err != nil {
+		log.Warnf("Error sending HTTP request to %s: %s", target, err)
+		return false
+	}
+
+	if resp.StatusCode != 200 {
+		log.Warnf("Error invalid status code %d, expected 200", resp.StatusCode)
+		return false
+	}
+
+	defer resp.Body.Close()
+	bytes, err := ioutil.ReadAll(resp.Body)
+	if err != nil {
+		log.Warnf("Error for Proxy body read from %s: %s", target, err)
+		return false
+	}
+
+	bytes = append(bytes, []byte("\n")...)
+	_, err = w.Write(bytes)
+	if err != nil {
+		log.Warnf("Error for Proxy body write from %s: %s", target, err)
+		return false
+	}
+
+	return true
+}


### PR DESCRIPTION
This helps to proxy local metrics endpoint (which could possibly need some custom TLS configuration to access them) to expose to the prometheus server.

Would this be a worth feature?

I can create some tests in that case