### PR TITLE
Fix panic in ICMP on DNS lookup failure

### DIFF
--- a/icmp.go
+++ b/icmp.go
@@ -79,6 +79,7 @@ func probeICMP(target string, w http.ResponseWriter, module Module) (success boo
 	}
 	if err != nil {
 		log.Errorf("Error resolving address %s: %s", target, err)
+		return
 	}
 
 	if ip.IP.To4() == nil {


### PR DESCRIPTION
Panic:

    ERRO[0003] Error resolving address bbc.co.uk: no suitable address found
    source="icmp.go:81"
    2017/01/27 16:40:42 http: panic serving 127.0.0.1:57487: runtime error:
    invalid memory address or nil pointer dereference
    goroutine 12 [running]:
    net/http.(*conn).serve.func1(0xc420086700)
    	/usr/local/go/src/net/http/server.go:1491 +0x12a
    panic(0x84e600, 0xc4200100e0)
    	/usr/local/go/src/runtime/panic.go:458 +0x243
    main.probeICMP(0xc420017752, 0x9, 0xabc7c0, 0xc4200f0d00, 0xc4200f64e8,
    0x4, 0x12a05f200, 0x0, 0x0, 0x0, ...)
    	/home/luke/git/blackbox_exporter/icmp.go:84 +0x1fc
    main.probeHandler(0xabc7c0, 0xc4200f0d00, 0xc42001c1e0, 0xc420030090)
    	/home/luke/git/blackbox_exporter/main.go:130 +0x218
    main.main.func1(0xabc7c0, 0xc4200f0d00, 0xc42001c1e0)
    	/home/luke/git/blackbox_exporter/main.go:170 +0x4a
    net/http.HandlerFunc.ServeHTTP(0xc4200f7010, 0xabc7c0, 0xc4200f0d00,
    0xc42001c1e0)
    	/usr/local/go/src/net/http/server.go:1726 +0x44
    net/http.(*ServeMux).ServeHTTP(0xadd3c0, 0xabc7c0, 0xc4200f0d00,
    0xc42001c1e0)
    	/usr/local/go/src/net/http/server.go:2022 +0x7f
    net/http.serverHandler.ServeHTTP(0xc420086680, 0xabc7c0, 0xc4200f0d00,
    0xc42001c1e0)
    	/usr/local/go/src/net/http/server.go:2202 +0x7d
    net/http.(*conn).serve(0xc420086700, 0xabd140, 0xc4200173c0)
    	/usr/local/go/src/net/http/server.go:1579 +0x4b7
    created by net/http.(*Server).Serve
    	/usr/local/go/src/net/http/server.go:2293 +0x44d

The ICMP module panics when there is no IP address returned from the DNS
lookup.