### PR TITLE
Add error to probe failures

### DIFF
--- a/dns_test.go
+++ b/dns_test.go
@@ -123,7 +123,7 @@ func TestRecursiveDNSResponse(t *testing.T) {
 		for i, test := range tests {
 			test.Probe.Protocol = protocol
 			recorder := httptest.NewRecorder()
-			result := probeDNS(addr.String(), recorder, Module{Timeout: time.Second, DNS: test.Probe})
+			result, _ := probeDNS(addr.String(), recorder, Module{Timeout: time.Second, DNS: test.Probe})
 			if result != test.ShouldSucceed {
 				t.Fatalf("Test %d had unexpected result: %v", i, result)
 			}
@@ -249,7 +249,7 @@ func TestAuthoritativeDNSResponse(t *testing.T) {
 		for i, test := range tests {
 			test.Probe.Protocol = protocol
 			recorder := httptest.NewRecorder()
-			result := probeDNS(addr.String(), recorder, Module{Timeout: time.Second, DNS: test.Probe})
+			result, _ := probeDNS(addr.String(), recorder, Module{Timeout: time.Second, DNS: test.Probe})
 			if result != test.ShouldSucceed {
 				t.Fatalf("Test %d had unexpected result: %v", i, result)
 			}
@@ -306,7 +306,7 @@ func TestServfailDNSResponse(t *testing.T) {
 		for i, test := range tests {
 			test.Probe.Protocol = protocol
 			recorder := httptest.NewRecorder()
-			result := probeDNS(addr.String(), recorder, Module{Timeout: time.Second, DNS: test.Probe})
+			result, _ := probeDNS(addr.String(), recorder, Module{Timeout: time.Second, DNS: test.Probe})
 			if result != test.ShouldSucceed {
 				t.Fatalf("Test %d had unexpected result: %v", i, result)
 			}
@@ -347,7 +347,7 @@ func TestDNSProtocol(t *testing.T) {
 			},
 		}
 		recorder := httptest.NewRecorder()
-		result := probeDNS(net.JoinHostPort("localhost", port), recorder, module)
+		result, _ := probeDNS(net.JoinHostPort("localhost", port), recorder, module)
 		body := recorder.Body.String()
 		if !result {
 			t.Fatalf("DNS protocol: \"%v4\" connection test failed, expected success.", protocol)
@@ -365,7 +365,7 @@ func TestDNSProtocol(t *testing.T) {
 			},
 		}
 		recorder = httptest.NewRecorder()
-		result = probeDNS(net.JoinHostPort("localhost", port), recorder, module)
+		result, _ = probeDNS(net.JoinHostPort("localhost", port), recorder, module)
 		body = recorder.Body.String()
 		if !result {
 			t.Fatalf("DNS protocol: \"%v6\" connection test failed, expected success.", protocol)
@@ -384,7 +384,7 @@ func TestDNSProtocol(t *testing.T) {
 			},
 		}
 		recorder = httptest.NewRecorder()
-		result = probeDNS(net.JoinHostPort("localhost", port), recorder, module)
+		result, _ = probeDNS(net.JoinHostPort("localhost", port), recorder, module)
 		body = recorder.Body.String()
 		if !result {
 			t.Fatalf("DNS protocol: \"%v\", preferred \"ip6\" connection test failed, expected success.", protocol)
@@ -403,7 +403,7 @@ func TestDNSProtocol(t *testing.T) {
 			},
 		}
 		recorder = httptest.NewRecorder()
-		result = probeDNS(net.JoinHostPort("localhost", port), recorder, module)
+		result, _ = probeDNS(net.JoinHostPort("localhost", port), recorder, module)
 		body = recorder.Body.String()
 		if !result {
 			t.Fatalf("DNS protocol: \"%v\", preferred \"ip4\" connection test failed, expected success.", protocol)
@@ -421,7 +421,7 @@ func TestDNSProtocol(t *testing.T) {
 			},
 		}
 		recorder = httptest.NewRecorder()
-		result = probeDNS(net.JoinHostPort("localhost", port), recorder, module)
+		result, _ = probeDNS(net.JoinHostPort("localhost", port), recorder, module)
 		body = recorder.Body.String()
 		if !result {
 			t.Fatalf("DNS protocol: \"%v\" connection test failed, expected success.", protocol)
@@ -438,7 +438,7 @@ func TestDNSProtocol(t *testing.T) {
 			},
 		}
 		recorder = httptest.NewRecorder()
-		result = probeDNS(net.JoinHostPort("localhost", port), recorder, module)
+		result, _ = probeDNS(net.JoinHostPort("localhost", port), recorder, module)
 		body = recorder.Body.String()
 		if protocol == "udp" {
 			if !result {

--- a/http_test.go
+++ b/http_test.go
@@ -47,7 +47,7 @@ func TestHTTPStatusCodes(t *testing.T) {
 		}))
 		defer ts.Close()
 		recorder := httptest.NewRecorder()
-		result := probeHTTP(ts.URL, recorder,
+		result, _ := probeHTTP(ts.URL, recorder,
 			Module{Timeout: time.Second, HTTP: HTTPProbe{ValidStatusCodes: test.ValidStatusCodes}})
 		body := recorder.Body.String()
 		if result != test.ShouldSucceed {
@@ -66,7 +66,7 @@ func TestRedirectFollowed(t *testing.T) {
 
 	// Follow redirect, should succeed with 200.
 	recorder := httptest.NewRecorder()
-	result := probeHTTP(ts.URL, recorder, Module{Timeout: time.Second, HTTP: HTTPProbe{}})
+	result, _ := probeHTTP(ts.URL, recorder, Module{Timeout: time.Second, HTTP: HTTPProbe{}})
 	body := recorder.Body.String()
 	if !result {
 		t.Fatalf("Redirect test failed unexpectedly, got %s", body)
@@ -85,7 +85,7 @@ func TestRedirectNotFollowed(t *testing.T) {
 
 	// Follow redirect, should succeed with 200.
 	recorder := httptest.NewRecorder()
-	result := probeHTTP(ts.URL, recorder,
+	result, _ := probeHTTP(ts.URL, recorder,
 		Module{Timeout: time.Second, HTTP: HTTPProbe{NoFollowRedirects: true, ValidStatusCodes: []int{302}}})
 	body := recorder.Body.String()
 	if !result {
@@ -103,7 +103,7 @@ func TestPost(t *testing.T) {
 	defer ts.Close()
 
 	recorder := httptest.NewRecorder()
-	result := probeHTTP(ts.URL, recorder,
+	result, _ := probeHTTP(ts.URL, recorder,
 		Module{Timeout: time.Second, HTTP: HTTPProbe{Method: "POST"}})
 	body := recorder.Body.String()
 	if !result {
@@ -117,7 +117,7 @@ func TestFailIfNotSSL(t *testing.T) {
 	defer ts.Close()
 
 	recorder := httptest.NewRecorder()
-	result := probeHTTP(ts.URL, recorder,
+	result, _ := probeHTTP(ts.URL, recorder,
 		Module{Timeout: time.Second, HTTP: HTTPProbe{FailIfNotSSL: true}})
 	body := recorder.Body.String()
 	if result {
@@ -135,7 +135,7 @@ func TestFailIfMatchesRegexp(t *testing.T) {
 	defer ts.Close()
 
 	recorder := httptest.NewRecorder()
-	result := probeHTTP(ts.URL, recorder,
+	result, _ := probeHTTP(ts.URL, recorder,
 		Module{Timeout: time.Second, HTTP: HTTPProbe{FailIfMatchesRegexp: []string{"could not connect to database"}}})
 	body := recorder.Body.String()
 	if result {
@@ -148,7 +148,7 @@ func TestFailIfMatchesRegexp(t *testing.T) {
 	defer ts.Close()
 
 	recorder = httptest.NewRecorder()
-	result = probeHTTP(ts.URL, recorder,
+	result, _ = probeHTTP(ts.URL, recorder,
 		Module{Timeout: time.Second, HTTP: HTTPProbe{FailIfMatchesRegexp: []string{"could not connect to database"}}})
 	body = recorder.Body.String()
 	if !result {
@@ -163,7 +163,7 @@ func TestFailIfMatchesRegexp(t *testing.T) {
 	defer ts.Close()
 
 	recorder = httptest.NewRecorder()
-	result = probeHTTP(ts.URL, recorder,
+	result, _ = probeHTTP(ts.URL, recorder,
 		Module{Timeout: time.Second, HTTP: HTTPProbe{FailIfMatchesRegexp: []string{"could not connect to database", "internal error"}}})
 	body = recorder.Body.String()
 	if result {
@@ -176,7 +176,7 @@ func TestFailIfMatchesRegexp(t *testing.T) {
 	defer ts.Close()
 
 	recorder = httptest.NewRecorder()
-	result = probeHTTP(ts.URL, recorder,
+	result, _ = probeHTTP(ts.URL, recorder,
 		Module{Timeout: time.Second, HTTP: HTTPProbe{FailIfMatchesRegexp: []string{"could not connect to database", "internal error"}}})
 	body = recorder.Body.String()
 	if !result {
@@ -191,7 +191,7 @@ func TestFailIfNotMatchesRegexp(t *testing.T) {
 	defer ts.Close()
 
 	recorder := httptest.NewRecorder()
-	result := probeHTTP(ts.URL, recorder,
+	result, _ := probeHTTP(ts.URL, recorder,
 		Module{Timeout: time.Second, HTTP: HTTPProbe{FailIfNotMatchesRegexp: []string{"Download the latest version here"}}})
 	body := recorder.Body.String()
 	if result {
@@ -204,7 +204,7 @@ func TestFailIfNotMatchesRegexp(t *testing.T) {
 	defer ts.Close()
 
 	recorder = httptest.NewRecorder()
-	result = probeHTTP(ts.URL, recorder,
+	result, _ = probeHTTP(ts.URL, recorder,
 		Module{Timeout: time.Second, HTTP: HTTPProbe{FailIfNotMatchesRegexp: []string{"Download the latest version here"}}})
 	body = recorder.Body.String()
 	if !result {
@@ -219,7 +219,7 @@ func TestFailIfNotMatchesRegexp(t *testing.T) {
 	defer ts.Close()
 
 	recorder = httptest.NewRecorder()
-	result = probeHTTP(ts.URL, recorder,
+	result, _ = probeHTTP(ts.URL, recorder,
 		Module{Timeout: time.Second, HTTP: HTTPProbe{FailIfNotMatchesRegexp: []string{"Download the latest version here", "Copyright 2015"}}})
 	body = recorder.Body.String()
 	if result {
@@ -232,7 +232,7 @@ func TestFailIfNotMatchesRegexp(t *testing.T) {
 	defer ts.Close()
 
 	recorder = httptest.NewRecorder()
-	result = probeHTTP(ts.URL, recorder,
+	result, _ = probeHTTP(ts.URL, recorder,
 		Module{Timeout: time.Second, HTTP: HTTPProbe{FailIfNotMatchesRegexp: []string{"Download the latest version here", "Copyright 2015"}}})
 	body = recorder.Body.String()
 	if !result {
@@ -262,7 +262,7 @@ func TestHTTPHeaders(t *testing.T) {
 	}))
 	defer ts.Close()
 	recorder := httptest.NewRecorder()
-	result := probeHTTP(ts.URL, recorder, Module{Timeout: time.Second, HTTP: HTTPProbe{
+	result, _ := probeHTTP(ts.URL, recorder, Module{Timeout: time.Second, HTTP: HTTPProbe{
 		Headers: headers,
 	}})
 	if !result {
@@ -276,7 +276,7 @@ func TestFailIfSelfSignedCA(t *testing.T) {
 	defer ts.Close()
 
 	recorder := httptest.NewRecorder()
-	result := probeHTTP(ts.URL, recorder,
+	result, _ := probeHTTP(ts.URL, recorder,
 		Module{Timeout: time.Second, HTTP: HTTPProbe{
 			TLSConfig: config.TLSConfig{InsecureSkipVerify: false},
 		}})
@@ -295,7 +295,7 @@ func TestSucceedIfSelfSignedCA(t *testing.T) {
 	defer ts.Close()
 
 	recorder := httptest.NewRecorder()
-	result := probeHTTP(ts.URL, recorder,
+	result, _ := probeHTTP(ts.URL, recorder,
 		Module{Timeout: time.Second, HTTP: HTTPProbe{
 			TLSConfig: config.TLSConfig{InsecureSkipVerify: true},
 		}})
@@ -314,7 +314,7 @@ func TestTLSConfigIsIgnoredForPlainHTTP(t *testing.T) {
 	defer ts.Close()
 
 	recorder := httptest.NewRecorder()
-	result := probeHTTP(ts.URL, recorder,
+	result, _ := probeHTTP(ts.URL, recorder,
 		Module{Timeout: time.Second, HTTP: HTTPProbe{
 			TLSConfig: config.TLSConfig{InsecureSkipVerify: false},
 		}})

--- a/main.go
+++ b/main.go
@@ -92,7 +92,7 @@ type DNSRRValidator struct {
 	FailIfNotMatchesRegexp []string `yaml:"fail_if_not_matches_regexp"`
 }
 
-var Probers = map[string]func(string, http.ResponseWriter, Module) bool{
+var Probers = map[string]func(string, http.ResponseWriter, Module) (bool, string){
 	"http": probeHTTP,
 	"tcp":  probeTCP,
 	"icmp": probeICMP,
@@ -123,12 +123,12 @@ func probeHandler(w http.ResponseWriter, r *http.Request, config *Config) {
 	}
 
 	start := time.Now()
-	success := prober(target, w, module)
+	success, probe_error := prober(target, w, module)
 	fmt.Fprintf(w, "probe_duration_seconds %f\n", time.Since(start).Seconds())
 	if success {
-		fmt.Fprintln(w, "probe_success 1")
+		fmt.Fprintln(w, "probe_success{error=\"\"} 1")
 	} else {
-		fmt.Fprintln(w, "probe_success 0")
+		fmt.Fprintln(w, fmt.Sprintf("probe_success{error=%q} 0", probe_error))
 	}
 }
 

--- a/tcp_test.go
+++ b/tcp_test.go
@@ -40,7 +40,8 @@ func TestTCPConnection(t *testing.T) {
 		ch <- struct{}{}
 	}()
 	recorder := httptest.NewRecorder()
-	if !probeTCP(ln.Addr().String(), recorder, Module{Timeout: time.Second}) {
+	result, _ := probeTCP(ln.Addr().String(), recorder, Module{Timeout: time.Second})
+	if !result {
 		t.Fatalf("TCP module failed, expected success.")
 	}
 	<-ch
@@ -49,7 +50,8 @@ func TestTCPConnection(t *testing.T) {
 func TestTCPConnectionFails(t *testing.T) {
 	// Invalid port number.
 	recorder := httptest.NewRecorder()
-	if probeTCP(":0", recorder, Module{Timeout: time.Second}) {
+	result, _ := probeTCP(":0", recorder, Module{Timeout: time.Second})
+	if result {
 		t.Fatalf("TCP module suceeded, expected failure.")
 	}
 }
@@ -87,7 +89,8 @@ func TestTCPConnectionQueryResponseIRC(t *testing.T) {
 		ch <- struct{}{}
 	}()
 	recorder := httptest.NewRecorder()
-	if !probeTCP(ln.Addr().String(), recorder, module) {
+	result, _ := probeTCP(ln.Addr().String(), recorder, module)
+	if !result {
 		t.Fatalf("TCP module failed, expected success.")
 	}
 	<-ch
@@ -105,7 +108,8 @@ func TestTCPConnectionQueryResponseIRC(t *testing.T) {
 		conn.Close()
 		ch <- struct{}{}
 	}()
-	if probeTCP(ln.Addr().String(), recorder, module) {
+	result, _ = probeTCP(ln.Addr().String(), recorder, module)
+	if result {
 		t.Fatalf("TCP module succeeded, expected failure.")
 	}
 	<-ch
@@ -144,7 +148,8 @@ func TestTCPConnectionQueryResponseMatching(t *testing.T) {
 		ch <- version
 	}()
 	recorder := httptest.NewRecorder()
-	if !probeTCP(ln.Addr().String(), recorder, module) {
+	result, _ := probeTCP(ln.Addr().String(), recorder, module)
+	if !result {
 		t.Fatalf("TCP module failed, expected success.")
 	}
 	if got, want := <-ch, "OpenSSH_6.9p1"; got != want {
@@ -181,7 +186,7 @@ func TestTCPConnectionProtocol(t *testing.T) {
 	}
 
 	recorder := httptest.NewRecorder()
-	result := probeTCP(net.JoinHostPort("localhost", port), recorder, module)
+	result, _ := probeTCP(net.JoinHostPort("localhost", port), recorder, module)
 	body := recorder.Body.String()
 	if !result {
 		t.Fatalf("TCP protocol: \"tcp4\" connection test failed, expected success.")
@@ -199,7 +204,7 @@ func TestTCPConnectionProtocol(t *testing.T) {
 	}
 
 	recorder = httptest.NewRecorder()
-	result = probeTCP(net.JoinHostPort("localhost", port), recorder, module)
+	result, _ = probeTCP(net.JoinHostPort("localhost", port), recorder, module)
 	body = recorder.Body.String()
 	if !result {
 		t.Fatalf("TCP protocol: \"tcp6\" connection test failed, expected success.")
@@ -218,7 +223,7 @@ func TestTCPConnectionProtocol(t *testing.T) {
 	}
 
 	recorder = httptest.NewRecorder()
-	result = probeTCP(net.JoinHostPort("localhost", port), recorder, module)
+	result, _ = probeTCP(net.JoinHostPort("localhost", port), recorder, module)
 	body = recorder.Body.String()
 	if !result {
 		t.Fatalf("TCP protocol: \"tcp\", prefer: \"ip4\" connection test failed, expected success.")
@@ -237,7 +242,7 @@ func TestTCPConnectionProtocol(t *testing.T) {
 	}
 
 	recorder = httptest.NewRecorder()
-	result = probeTCP(net.JoinHostPort("localhost", port), recorder, module)
+	result, _ = probeTCP(net.JoinHostPort("localhost", port), recorder, module)
 	body = recorder.Body.String()
 	if !result {
 		t.Fatalf("TCP protocol: \"tcp\", prefer: \"ip6\" connection test failed, expected success.")
@@ -255,7 +260,7 @@ func TestTCPConnectionProtocol(t *testing.T) {
 	}
 
 	recorder = httptest.NewRecorder()
-	result = probeTCP(net.JoinHostPort("localhost", port), recorder, module)
+	result, _ = probeTCP(net.JoinHostPort("localhost", port), recorder, module)
 	body = recorder.Body.String()
 	if !result {
 		t.Fatalf("TCP protocol: \"tcp\" connection test failed, expected success.")
@@ -271,7 +276,7 @@ func TestTCPConnectionProtocol(t *testing.T) {
 	}
 
 	recorder = httptest.NewRecorder()
-	result = probeTCP(net.JoinHostPort("localhost", port), recorder, module)
+	result, _ = probeTCP(net.JoinHostPort("localhost", port), recorder, module)
 	body = recorder.Body.String()
 	if !result {
 		t.Fatalf("TCP connection test with protocol unspecified failed, expected success.")


### PR DESCRIPTION
When a probe fails, include the error in as a label so
different errors can be classified separately.

Also, be explicit about returning `true` and `false` for all return cases.