### PR TITLE
Fillout the dns default port `53` if there is no setup.

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,6 +101,12 @@ modules:
       protocol: "tcp" # accepts "tcp/tcp4/tcp6/udp/udp4/udp6", defaults to "udp"
       preferred_ip_protocol: "ip4" # used for "udp/tcp", defaults to "ip6"
       query_name: "www.prometheus.io"
+  dns_default_target_port_example:
+    prober: dns
+    dns:
+      default_target_port: "53" # set default dns server port while `target` doesn't setup it
+      preferred_ip_protocol: "ip4" # used for "udp/tcp", defaults to "ip6"
+      query_name: "www.prometheus.io"
 ```
 
 HTTP, HTTPS (via the `http` prober), DNS, TCP socket and ICMP (v4 only, see permissions section) are currently supported.

--- a/dns.go
+++ b/dns.go
@@ -134,7 +134,7 @@ func probeDNS(target string, w http.ResponseWriter, module Module, registry *pro
 	if targetPort == "" {
 		// missingPort could be fixed by fallbacking to the default port.
 		targetAddress = target
-		targetPort = "53"
+		targetPort = module.DNS.DefaultTargetPort
 		log.Debugf("Fixing missingPort error, targetAddress %v, targetPort %v", targetAddress, targetPort)
 		target = net.JoinHostPort(targetAddress, targetPort)
 	}

--- a/dns.go
+++ b/dns.go
@@ -82,8 +82,12 @@ func validRcode(rcode int, valid []string) bool {
 }
 
 func probeDNS(target string, w http.ResponseWriter, module Module, registry *prometheus.Registry) bool {
-	var numAnswer, numAuthority, numAdditional int
-	var dialProtocol, fallbackProtocol string
+	var (
+		numAnswer, numAuthority, numAdditional int
+		dialProtocol, fallbackProtocol         string
+		targetAddress, targetPort              string
+	)
+
 	probeIPProtocolGauge := prometheus.NewGauge(prometheus.GaugeOpts{
 		Name: "probe_ip_protocol",
 		Help: "Specifies whether probe ip protocl is IP4 or IP6",
@@ -126,9 +130,17 @@ func probeDNS(target string, w http.ResponseWriter, module Module, registry *pro
 		fallbackProtocol = "ip6"
 	}
 
+	targetAddress, targetPort, _ = net.SplitHostPort(target)
+	if targetPort == "" {
+		// missingPort could be fixed by fallbacking to the default port.
+		targetAddress = target
+		targetPort = "53"
+		log.Debugf("Fixing missingPort error, targetAddress %v, targetPort %v", targetAddress, targetPort)
+		target = net.JoinHostPort(targetAddress, targetPort)
+	}
+
 	dialProtocol = module.DNS.Protocol
 	if module.DNS.Protocol == "udp" || module.DNS.Protocol == "tcp" {
-		targetAddress, _, _ := net.SplitHostPort(target)
 		ip, err := net.ResolveIPAddr(module.DNS.PreferredIPProtocol, targetAddress)
 		if err != nil {
 			ip, err = net.ResolveIPAddr(fallbackProtocol, targetAddress)

--- a/dns_test.go
+++ b/dns_test.go
@@ -29,12 +29,12 @@ import (
 
 var PROTOCOLS = [...]string{"udp", "tcp"}
 
-// startDNSServer starts a DNS server with a given handler function on a random port.
+// startDNSServer starts a DNS server with a given handler function on port `53`.
 // Returns the Server object itself as well as the net.Addr corresponding to the server port.
 func startDNSServer(protocol string, handler func(dns.ResponseWriter, *dns.Msg)) (*dns.Server, net.Addr) {
 	h := dns.NewServeMux()
 	h.HandleFunc(".", handler)
-	server := &dns.Server{Addr: ":0", Net: protocol, Handler: h}
+	server := &dns.Server{Addr: ":53", Net: protocol, Handler: h}
 	go server.ListenAndServe()
 	// Wait until PacketConn becomes available, but give up after 1 second.
 	for i := 0; server.PacketConn == nil && i < 200; i++ {

--- a/dns_test.go
+++ b/dns_test.go
@@ -401,7 +401,7 @@ func TestDNSProtocol(t *testing.T) {
 		registry = prometheus.NewRegistry()
 		result = probeDNS(net.JoinHostPort("localhost", port), recorder, module, registry)
 		if !result {
-			t.Fatalf("DNS protocol: \"%v\" with localhost:%v, expected success.", protocol, port)
+			t.Fatalf("DNS protocol: \"%v\" with localhost:%v test failed, expected success.", protocol, port)
 		}
 
 		// Force IPv4

--- a/dns_test.go
+++ b/dns_test.go
@@ -378,15 +378,16 @@ func TestDNSProtocol(t *testing.T) {
 		module := Module{
 			Timeout: time.Second,
 			DNS: DNSProbe{
-				QueryName: "example.com",
-				Protocol:  protocol,
+				QueryName:         "example.com",
+				Protocol:          protocol,
+				DefaultTargetPort: port,
 			},
 		}
 		recorder := httptest.NewRecorder()
 		registry := prometheus.NewRegistry()
 		result := probeDNS("localhost", recorder, module, registry)
-		if result {
-			t.Fatalf("DNS protocol: \"%v\" with localhost:53 succeeded, expected failure.", protocol)
+		if !result {
+			t.Fatalf("DNS protocol: \"%v\" with default target port %v failed, expected success.", protocol, port)
 		}
 
 		// DNS Server with `addr` port

--- a/dns_test.go
+++ b/dns_test.go
@@ -374,7 +374,7 @@ func TestDNSProtocol(t *testing.T) {
 
 		_, port, _ := net.SplitHostPort(addr.String())
 
-		// Default DNS Server port
+		// DNS Server with default port
 		module := Module{
 			Timeout: time.Second,
 			DNS: DNSProbe{
@@ -389,7 +389,7 @@ func TestDNSProtocol(t *testing.T) {
 			t.Fatalf("DNS protocol: \"%v\" with localhost:53 succeeded, expected failure.", protocol)
 		}
 
-		// Set DNS Server target with port
+		// DNS Server with `addr` port
 		module = Module{
 			Timeout: time.Second,
 			DNS: DNSProbe{

--- a/main.go
+++ b/main.go
@@ -95,6 +95,7 @@ type DNSProbe struct {
 	ValidateAuthority   DNSRRValidator `yaml:"validate_authority_rrs"`
 	ValidateAdditional  DNSRRValidator `yaml:"validate_additional_rrs"`
 	PreferredIPProtocol string         `yaml:"preferred_ip_protocol"` // Defaults to "ip6".
+	DefaultTargetPort   string         `yaml:"default_target_port"`   // Default target dns server port.
 }
 
 type DNSRRValidator struct {


### PR DESCRIPTION
Fixed #155 .