### PR TITLE
Expose HTTP version of probe

### DIFF
--- a/CONFIGURATION.md
+++ b/CONFIGURATION.md
@@ -38,6 +38,9 @@ The other placeholders are specified separately.
   # Accepted status codes for this probe. Defaults to 2xx.
   [ valid_status_codes: <string>, ... | default = "2xx" ]
 
+  # Accepted HTTP versions for this probe.
+  [ valid_http_versions: <string>, ... ]
+
   # The HTTP method the probe will use.
   [ method: <string> | default = "GET" ]
 

--- a/config.go
+++ b/config.go
@@ -35,17 +35,18 @@ type Module struct {
 
 type HTTPProbe struct {
 	// Defaults to 2xx.
-	ValidStatusCodes       []int                   `yaml:"valid_status_codes"`
-	PreferredIPProtocol    string                  `yaml:"preferred_ip_protocol"`
-	NoFollowRedirects      bool                    `yaml:"no_follow_redirects"`
-	FailIfSSL              bool                    `yaml:"fail_if_ssl"`
-	FailIfNotSSL           bool                    `yaml:"fail_if_not_ssl"`
-	Method                 string                  `yaml:"method"`
-	Headers                map[string]string       `yaml:"headers"`
-	FailIfMatchesRegexp    []string                `yaml:"fail_if_matches_regexp"`
-	FailIfNotMatchesRegexp []string                `yaml:"fail_if_not_matches_regexp"`
-	Body                   string                  `yaml:"body"`
-	HTTPClientConfig       config.HTTPClientConfig `yaml:"http_client_config,inline"`
+	ValidStatusCodes       []int                   `yaml:"valid_status_codes,omitempty"`
+	ValidHTTPVersions      []string                `yaml:"valid_http_versions,omitempty"`
+	PreferredIPProtocol    string                  `yaml:"preferred_ip_protocol,omitempty"`
+	NoFollowRedirects      bool                    `yaml:"no_follow_redirects,omitempty"`
+	FailIfSSL              bool                    `yaml:"fail_if_ssl,omitempty"`
+	FailIfNotSSL           bool                    `yaml:"fail_if_not_ssl,omitempty"`
+	Method                 string                  `yaml:"method,omitempty"`
+	Headers                map[string]string       `yaml:"headers,omitempty"`
+	FailIfMatchesRegexp    []string                `yaml:"fail_if_matches_regexp,omitempty"`
+	FailIfNotMatchesRegexp []string                `yaml:"fail_if_not_matches_regexp,omitempty"`
+	Body                   string                  `yaml:"body,omitempty"`
+	HTTPClientConfig       config.HTTPClientConfig `yaml:"http_client_config,inline,omitempty"`
 
 	// Catches all undefined fields and must be empty after parsing.
 	XXX map[string]interface{} `yaml:",inline"`

--- a/example.yml
+++ b/example.yml
@@ -3,6 +3,7 @@ modules:
     prober: http
     timeout: 5s
     http:
+      valid_http_versions: ["HTTP/1.1", "HTTP/2"]
       valid_status_codes: []  # Defaults to 2xx
       method: GET
       headers:

--- a/http_test.go
+++ b/http_test.go
@@ -58,6 +58,33 @@ func TestHTTPStatusCodes(t *testing.T) {
 	}
 }
 
+func TestValidHTTPVersion(t *testing.T) {
+	tests := []struct {
+		ValidHTTPVersions []string
+		ShouldSucceed     bool
+	}{
+		{[]string{}, true},
+		{[]string{"HTTP/1.1"}, true},
+		{[]string{"HTTP/1.1", "HTTP/2"}, true},
+		{[]string{"HTTP/2"}, false},
+	}
+	for i, test := range tests {
+		ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		}))
+		defer ts.Close()
+		recorder := httptest.NewRecorder()
+		registry := prometheus.NewRegistry()
+		result := probeHTTP(ts.URL,
+			Module{Timeout: time.Second, HTTP: HTTPProbe{
+				ValidHTTPVersions: test.ValidHTTPVersions,
+			}}, registry)
+		body := recorder.Body.String()
+		if result != test.ShouldSucceed {
+			t.Fatalf("Test %v had unexpected result: %s", i, body)
+		}
+	}
+}
+
 func TestRedirectFollowed(t *testing.T) {
 	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if r.URL.Path == "/" {


### PR DESCRIPTION
Implements #162.

Exposes HTTP version via `probe_http_version` gauge and probes can now have set valid HTTP versions that will fail if not met.