### PR TITLE
doc: Rename protocol to transport_protocol

### DIFF
--- a/example.yml
+++ b/example.yml
@@ -77,6 +77,6 @@ modules:
   dns_tcp_example:
     prober: dns
     dns:
-      protocol: "tcp" # defaults to "udp"
+      transport_protocol: "tcp" # defaults to "udp"
       preferred_ip_protocol: "ip4" #  defaults to "ip6"
       query_name: "www.prometheus.io"


### PR DESCRIPTION
Hi here, this PR fixes this issue with default config. « Error parsing config file: unknown fields in dns probe: protocol »

Refs: https://github.com/prometheus/blackbox_exporter/blob/master/CONFIGURATION.md#dns_probe