### PR TITLE
timeout is not a valid field

### DIFF
--- a/example.yml
+++ b/example.yml
@@ -1,7 +1,6 @@
 modules:
   http_2xx_example:
     prober: http
-    timeout: 5s
     http:
       valid_http_versions: ["HTTP/1.1", "HTTP/2"]
       valid_status_codes: []  # Defaults to 2xx
@@ -21,7 +20,6 @@ modules:
       preferred_ip_protocol: "ip4" # defaults to "ip6"
   http_post_2xx:
     prober: http
-    timeout: 5s
     http:
       method: POST
       headers:
@@ -29,7 +27,6 @@ modules:
       body: '{}'
   http_basic_auth_example:
     prober: http
-    timeout: 5s
     http:
       method: POST
       headers:


### PR DESCRIPTION
The `timeout` field is no longer a valid field. The timeout value is automatically determined from the `scrape_timeout` in the Prometheus config.

```
ERRO[0000] Error parsing config file: unknown fields in http probe: timeout  source="main.go:63"                                                      
```