### PR TITLE
Fix wrong config flag name in 0.8.0 (--config-flag=..)

### DIFF
--- a/main.go
+++ b/main.go
@@ -38,7 +38,7 @@ var (
 		C: &Config{},
 	}
 
-	configFile    = kingpin.Flag("config.flag", "Blackbox exporter configuration file.").Default("blackbox.yml").String()
+	configFile    = kingpin.Flag("config.file", "Blackbox exporter configuration file.").Default("blackbox.yml").String()
 	listenAddress = kingpin.Flag("web.listen-address", "The address to listen on for HTTP requests.").Default(":9115").String()
 	timeoutOffset = kingpin.Flag("timeout-offset", "Offset to subtract from timeout in seconds.").Default("0.5").Float64()
 )


### PR DESCRIPTION
Some minutes ago, my monitoring system notified me about problems with the blackbox_exporter which updates automatically on new releases. It seems that in version 0.8.0, the flag for the config file was accidentally renamed to `--config-flag`.