### PR TITLE
Add httptrace based prober

### DIFF
--- a/prober/dns.go
+++ b/prober/dns.go
@@ -118,7 +118,7 @@ func ProbeDNS(ctx context.Context, target string, module config.Module, registry
 			port = "53"
 			targetAddr = target
 		}
-		ip, err = chooseProtocol(module.DNS.PreferredIPProtocol, targetAddr, registry, logger)
+		ip, _, err = chooseProtocol(module.DNS.PreferredIPProtocol, targetAddr, registry, logger)
 		if err != nil {
 			level.Error(logger).Log("msg", "Error resolving address", "err", err)
 			return false

--- a/prober/http.go
+++ b/prober/http.go
@@ -338,6 +338,10 @@ func ProbeHTTP(ctx context.Context, target string, module config.Module, registr
 		if i != 0 {
 			durationGaugeVec.WithLabelValues("resolve").Add(trace.dnsDone.Sub(trace.start).Seconds())
 		}
+		// Skip trace if we never got a connection because a request failed.
+		if trace.gotConn.IsZero() {
+			continue
+		}
 		if trace.tls {
 			durationGaugeVec.WithLabelValues("connect").Add(trace.connectDone.Sub(trace.dnsDone).Seconds())
 			durationGaugeVec.WithLabelValues("tls").Add(trace.gotConn.Sub(trace.dnsDone).Seconds())

--- a/prober/http.go
+++ b/prober/http.go
@@ -173,6 +173,10 @@ func ProbeHTTP(ctx context.Context, target string, module config.Module, registr
 		})
 	)
 
+	for _, lv := range []string{"resolve", "connect", "tls", "processing", "transfer"} {
+		durationGaugeVec.WithLabelValues(lv)
+	}
+
 	registry.MustRegister(durationGaugeVec)
 	registry.MustRegister(contentLengthGauge)
 	registry.MustRegister(redirectsGauge)

--- a/prober/icmp.go
+++ b/prober/icmp.go
@@ -52,7 +52,7 @@ func ProbeICMP(ctx context.Context, target string, module config.Module, registr
 	timeoutDeadline, _ := ctx.Deadline()
 	deadline := time.Now().Add(timeoutDeadline.Sub(time.Now()))
 
-	ip, err := chooseProtocol(module.ICMP.PreferredIPProtocol, target, registry, logger)
+	ip, _, err := chooseProtocol(module.ICMP.PreferredIPProtocol, target, registry, logger)
 	if err != nil {
 		level.Warn(logger).Log("msg", "Error resolving address", "err", err)
 		return false

--- a/prober/tcp.go
+++ b/prober/tcp.go
@@ -38,7 +38,7 @@ func dialTCP(ctx context.Context, target string, module config.Module, registry 
 		return nil, err
 	}
 
-	ip, err := chooseProtocol(module.TCP.PreferredIPProtocol, targetAddress, registry, logger)
+	ip, _, err := chooseProtocol(module.TCP.PreferredIPProtocol, targetAddress, registry, logger)
 	if err != nil {
 		level.Error(logger).Log("msg", "Error resolving address", "err", err)
 		return nil, err

--- a/prober/utils.go
+++ b/prober/utils.go
@@ -12,8 +12,6 @@ import (
 
 // Returns the preferedIPProtocol, the dialProtocol, and sets the probeIPProtocolGauge.
 func chooseProtocol(preferredIPProtocol string, target string, registry *prometheus.Registry, logger log.Logger) (*net.IPAddr, error) {
-	var fallbackProtocol string
-
 	probeDNSLookupTimeSeconds := prometheus.NewGauge(prometheus.GaugeOpts{
 		Name: "probe_dns_lookup_time_seconds",
 		Help: "Returns the time taken for probe dns lookup in seconds",
@@ -25,6 +23,12 @@ func chooseProtocol(preferredIPProtocol string, target string, registry *prometh
 	})
 	registry.MustRegister(probeIPProtocolGauge)
 	registry.MustRegister(probeDNSLookupTimeSeconds)
+
+	return chooseProtocolMetrics(preferredIPProtocol, target, probeDNSLookupTimeSeconds, probeIPProtocolGauge, logger)
+}
+
+func chooseProtocolMetrics(preferredIPProtocol string, target string, probeDNSLookupTimeSeconds, probeIPProtocolGauge prometheus.Gauge, logger log.Logger) (*net.IPAddr, error) {
+	var fallbackProtocol string
 
 	if preferredIPProtocol == "ip6" || preferredIPProtocol == "" {
 		preferredIPProtocol = "ip6"

--- a/prober/utils.go
+++ b/prober/utils.go
@@ -10,7 +10,7 @@ import (
 	"github.com/prometheus/client_golang/prometheus"
 )
 
-// Returns the preferedIPProtocol, the dialProtocol, and sets the probeIPProtocolGauge.
+// Returns the IP for the preferedIPProtocol and lookup time.
 func chooseProtocol(preferredIPProtocol string, target string, registry *prometheus.Registry, logger log.Logger) (*net.IPAddr, float64, error) {
 	var fallbackProtocol string
 	probeDNSLookupTimeSeconds := prometheus.NewGauge(prometheus.GaugeOpts{


### PR DESCRIPTION
Hi,

this is pretty much the prober I use for the latency.at exporters. I've added it as a new module here although in my exporters I replaced the http module which might make sense, given that it basically only adds one new metric.

Beside that I still need refactor and move over some tests. But wanted to get feedback early. I expected especially the redirect stuff to something to discuss.