### PR TITLE
Add config parameter to cover blackbox config

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ HTTP, HTTPS, DNS, TCP and ICMP.
     make
     ./blackbox_exporter <flags>
 
-Visiting [http://localhost:9115/probe?target=google.com&module=http_2xx](http://localhost:9115/probe?target=google.com&module=http_2xx)
+Visiting [http://localhost:9115/probe?target=google.com&module=http_2xx&config={%22http%22:{%22FailIfNotMatchesRegexp%22:[%22google%22],%22NoFollowRedirects%22:true}}](http://localhost:9115/probe?target=google.com&module=http_2xx&config={%22http%22:{%22FailIfNotMatchesRegexp%22:[%22google%22],%22NoFollowRedirects%22:true}})
 will return metrics for a HTTP probe against google.com. The `probe_success` metric indicates if the probe succeeded.
 
 ### Building with Docker
@@ -58,11 +58,16 @@ scrape_configs:
         - http://prometheus.io    # Target to probe with http.
         - https://prometheus.io   # Target to probe with https.
         - http://example.com:8080 # Target to probe with http on port 8080.
+        labels:
+          config: "{\"http\":{\"Method\":\"GET\",\"NoFollowRedirects\":true}}"
+
     relabel_configs:
       - source_labels: [__address__]
         target_label: __param_target
       - source_labels: [__param_target]
         target_label: instance
+      - source_labels: [config]
+        target_label: __param_config
       - target_label: __address__
         replacement: 127.0.0.1:9115  # Blackbox exporter.
 ```
@@ -80,3 +85,5 @@ The ICMP probe requires elevated privileges to function:
 [hub]: https://hub.docker.com/r/prom/blackbox-exporter/
 [travis]: https://travis-ci.org/prometheus/blackbox_exporter
 [quay]: https://quay.io/repository/prometheus/blackbox-exporter
+
+

--- a/config/config.go
+++ b/config/config.go
@@ -10,6 +10,7 @@ import (
 
 	yaml "gopkg.in/yaml.v2"
 
+	"encoding/json"
 	"github.com/prometheus/common/config"
 )
 
@@ -131,6 +132,23 @@ func checkOverflow(m map[string]interface{}, ctx string) error {
 		return fmt.Errorf("unknown fields in %s: %s", ctx, strings.Join(keys, ", "))
 	}
 	return nil
+}
+
+func RecoverConfig(configData string, s *Module) (Module, error) {
+	recoverModule := Module{}
+	copyConfig, err := json.Marshal(s)
+	if err != nil {
+		return Module{}, err
+	}
+	err = json.Unmarshal([]byte(copyConfig), &recoverModule)
+	if err != nil {
+		return Module{}, err
+	}
+	err = json.Unmarshal([]byte(configData), &recoverModule)
+	if err != nil {
+		return Module{}, errors.New("Config parameter formatting error")
+	}
+	return recoverModule, nil
 }
 
 // UnmarshalYAML implements the yaml.Unmarshaler interface.

--- a/main.go
+++ b/main.go
@@ -94,9 +94,18 @@ func probeHandler(w http.ResponseWriter, r *http.Request, c *config.Config) {
 	})
 	params := r.URL.Query()
 	target := params.Get("target")
+	configData := params.Get("config")
 	if target == "" {
 		http.Error(w, "Target parameter is missing", 400)
 		return
+	}
+	if configData != "" {
+		recoverModule, err := config.RecoverConfig(configData, &module)
+		if err != nil {
+			http.Error(w, err.Error(), 400)
+			return
+		}
+		module = recoverModule
 	}
 
 	prober, ok := Probers[module.Prober]

--- a/main_test.go
+++ b/main_test.go
@@ -25,7 +25,7 @@ func TestPrometheusTimeoutHTTP(t *testing.T) {
 	}))
 	defer ts.Close()
 
-	req, err := http.NewRequest("GET", "?target="+ts.URL, nil)
+	req, err := http.NewRequest("GET", "?target="+ts.URL+"&config={\"http\":{\"method\":\"POST\"}}", nil)
 	if err != nil {
 		t.Fatal(err)
 	}


### PR DESCRIPTION
# Add config parameter to cover blackbox config
You can cover blackbox config user config parameter like: [http://localhost:9115/probe?target=google.com&module=http_2xx&config={%22http%22:{%22FailIfNotMatchesRegexp%22:[%22google%22],%22NoFollowRedirects%22:true}}](http://localhost:9115/probe?target=google.com&module=http_2xx&config={%22http%22:{%22FailIfNotMatchesRegexp%22:[%22google%22],%22NoFollowRedirects%22:true}})

Example Blackbox exporter Configuration:
```yml
modules:
  http_2xx:
    prober: http
    http:
```

Example Prometheus Configuration:
```yml
scrape_configs:
  - job_name: 'blackbox'
    metrics_path: /probe
    params:
      module: [http_2xx]  # Look for a HTTP 200 response.
    static_configs:
      - targets:
        - http://prometheus.io    # Target to probe with http.
        - https://prometheus.io   # Target to probe with https.
        - http://example.com:8080 # Target to probe with http on port 8080.
        labels:
          config: "{\"http\":{\"Method\":\"GET\",\"NoFollowRedirects\":true}}"

    relabel_configs:
      - source_labels: [__address__]
        target_label: __param_target
      - source_labels: [__param_target]
        target_label: instance
      - source_labels: [config]
        target_label: __param_config
      - target_label: __address__
        replacement: 127.0.0.1:9115  # Blackbox exporter.
```
