### PR TITLE
[prober/tcp] get servername for TLS from target

### DIFF
--- a/example.yml
+++ b/example.yml
@@ -37,6 +37,11 @@ modules:
       basic_auth:
         username: "username"
         password: "mysecret"
+  tls_connect:
+    prober: tcp
+    timeout: 5s
+    tcp:
+      tls: true
   tcp_connect_example:
     prober: tcp
     timeout: 5s

--- a/prober/tcp.go
+++ b/prober/tcp.go
@@ -60,6 +60,17 @@ func dialTCP(ctx context.Context, target string, module config.Module, registry 
 		level.Error(logger).Log("msg", "Error creating TLS configuration", "err", err)
 		return nil, err
 	}
+
+	if len(tlsConfig.ServerName) == 0 {
+		// If there is no `server_name` in tls_config, use
+		// targetAddress as TLS-servername. Normally tls.DialWithDialer
+		// would do this for us, but we pre-resolved the name by
+		// `chooseProtocol` and pass the IP-address for dialing (prevents
+		// resolving twice).
+		// For this reason we need to specify the original targetAddress
+		// via tlsConfig to enable hostname verification.
+		tlsConfig.ServerName = targetAddress
+	}
 	timeoutDeadline, _ := ctx.Deadline()
 	dialer.Deadline = timeoutDeadline
 

--- a/prober/tcp_test.go
+++ b/prober/tcp_test.go
@@ -85,13 +85,13 @@ func TestTCPConnectionWithTLS(t *testing.T) {
 	// CAFile must be passed via filesystem, use a tempfile.
 	tmpCaFile, err := ioutil.TempFile("", "cafile.pem")
 	if err != nil {
-		panic(fmt.Sprintf("Error creating CA tempfile: %s", err))
+		t.Fatalf(fmt.Sprintf("Error creating CA tempfile: %s", err))
 	}
 	if _, err := tmpCaFile.Write(testcert_pem); err != nil {
-		panic(fmt.Sprintf("Error writing CA tempfile: %s", err))
+		t.Fatalf(fmt.Sprintf("Error writing CA tempfile: %s", err))
 	}
 	if err := tmpCaFile.Close(); err != nil {
-		panic(fmt.Sprintf("Error closing CA tempfile: %s", err))
+		t.Fatalf(fmt.Sprintf("Error closing CA tempfile: %s", err))
 	}
 	defer os.Remove(tmpCaFile.Name())
 
@@ -156,7 +156,7 @@ func TestTCPConnectionWithTLS(t *testing.T) {
 
 	registry = prometheus.NewRegistry()
 	go serverFunc()
-	// Test name-verification against name from tls_config
+	// Test name-verification against name from tls_config.
 	module.TCP.TLSConfig.ServerName = "localhost"
 	if !ProbeTCP(testCTX, ln.Addr().String(), module, registry, log.NewNopLogger()) {
 		t.Fatalf("TCP module failed, expected success.")
@@ -191,13 +191,13 @@ func TestTCPConnectionQueryResponseStartTLS(t *testing.T) {
 	// CAFile must be passed via filesystem, use a tempfile.
 	tmpCaFile, err := ioutil.TempFile("", "cafile.pem")
 	if err != nil {
-		panic(fmt.Sprintf("Error creating CA tempfile: %s", err))
+		t.Fatalf(fmt.Sprintf("Error creating CA tempfile: %s", err))
 	}
 	if _, err := tmpCaFile.Write(testcert_pem); err != nil {
-		panic(fmt.Sprintf("Error writing CA tempfile: %s", err))
+		t.Fatalf(fmt.Sprintf("Error writing CA tempfile: %s", err))
 	}
 	if err := tmpCaFile.Close(); err != nil {
-		panic(fmt.Sprintf("Error closing CA tempfile: %s", err))
+		t.Fatalf(fmt.Sprintf("Error closing CA tempfile: %s", err))
 	}
 	defer os.Remove(tmpCaFile.Name())
 

--- a/prober/utils_test.go
+++ b/prober/utils_test.go
@@ -35,7 +35,7 @@ func checkRegistryResults(expRes map[string]float64, mfs []*dto.MetricFamily, t 
 // Create test certificate with specified expiry date
 // Certificate will be self-signed and use localhost/127.0.0.1
 // Generated certificate and key are returned in PEM encoding
-func generateTestCertificate(expiry time.Time) ([]byte, []byte) {
+func generateTestCertificate(expiry time.Time, IPAddressSAN bool) ([]byte, []byte) {
 	privatekey, err := rsa.GenerateKey(rand.Reader, 2048)
 	if err != nil {
 		panic(fmt.Sprintf("Error creating rsa key: %s", err))
@@ -56,8 +56,10 @@ func generateTestCertificate(expiry time.Time) ([]byte, []byte) {
 		KeyUsage:    x509.KeyUsageDigitalSignature | x509.KeyUsageCertSign,
 	}
 	cert.DNSNames = append(cert.DNSNames, "localhost")
-	cert.IPAddresses = append(cert.IPAddresses, net.ParseIP("127.0.0.1"))
-	cert.IPAddresses = append(cert.IPAddresses, net.ParseIP("::1"))
+	if IPAddressSAN {
+		cert.IPAddresses = append(cert.IPAddresses, net.ParseIP("127.0.0.1"))
+		cert.IPAddresses = append(cert.IPAddresses, net.ParseIP("::1"))
+	}
 	derCert, err := x509.CreateCertificate(rand.Reader, &cert, &cert, publickey, privatekey)
 	if err != nil {
 		panic(fmt.Sprintf("Error signing test-certificate: %s", err))


### PR DESCRIPTION
Because dialTCP manually resolves name to IP, the
actual tls.DialWithDialer call cannot deduce the name
from the target. This changes puts the "lost" name
into tlsConfig to fix certficate name verification.
Tests are also added which fail without and succeed
with this change.

This fixes #225 