### PR TITLE
Wrap DNS lookup metric time defer

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,8 +3,8 @@ sudo: false
 language: go
 
 go:
-- 1.8.x
-- master
+- 1.9.x
+- 1.x
 
 go_import_path: github.com/prometheus/blackbox_exporter
 

--- a/circle.yml
+++ b/circle.yml
@@ -2,7 +2,7 @@ machine:
   environment:
     DOCKER_IMAGE_NAME: prom/blackbox-exporter
     QUAY_IMAGE_NAME: quay.io/prometheus/blackbox-exporter
-    DOCKER_TEST_IMAGE_NAME: quay.io/prometheus/golang-builder:1.8-base
+    DOCKER_TEST_IMAGE_NAME: quay.io/prometheus/golang-builder:1.9-base
     REPO_PATH: github.com/prometheus/blackbox_exporter
   pre:
     - sudo curl -L -o /usr/bin/docker 'https://s3-external-1.amazonaws.com/circle-downloads/docker-1.9.1-circleci'

--- a/prober/utils.go
+++ b/prober/utils.go
@@ -43,7 +43,9 @@ func chooseProtocol(preferredIPProtocol string, target string, registry *prometh
 	level.Info(logger).Log("msg", "Resolving target address", "preferred_ip_protocol", preferredIPProtocol)
 	resolveStart := time.Now()
 
-	defer probeDNSLookupTimeSeconds.Add(time.Since(resolveStart).Seconds())
+	defer func() {
+		probeDNSLookupTimeSeconds.Add(time.Since(resolveStart).Seconds())
+	}()
 
 	ip, err := net.ResolveIPAddr(preferredIPProtocol, target)
 	if err != nil {


### PR DESCRIPTION
Wrap the DNS lookup time `defer` in an anonymous function to avoid arguments being evaluated early.

Closes: https://github.com/prometheus/blackbox_exporter/issues/253