### PR TITLE
Addresses a bug where the Content-Length header is empty

### DIFF
--- a/prober/http.go
+++ b/prober/http.go
@@ -273,7 +273,9 @@ func ProbeHTTP(ctx context.Context, target string, module config.Module, registr
 
 	// If a body is configured, add it to the request.
 	if httpConfig.Body != "" {
-		request.Body = ioutil.NopCloser(strings.NewReader(httpConfig.Body))
+		body := strings.NewReader(httpConfig.Body)
+		request.Body = ioutil.NopCloser(body)
+		request.ContentLength = int64(body.Len())
 	}
 	level.Info(logger).Log("msg", "Making HTTP request", "url", request.URL.String(), "host", request.Host)
 


### PR DESCRIPTION
We noticed that when testing some of our applications that are sensitive to the content-length header the test was failing. This duplicates some of the logic from http.NewRequest with the exception of the GetBody() func, which didn't appear to be necessary.

https://golang.org/src/net/http/request.go?s=25171:25240#L755