### PR TITLE
Setting httpConfig.Body at NewRequest to get Content-Length set impli…

### DIFF
--- a/prober/http.go
+++ b/prober/http.go
@@ -256,8 +256,9 @@ func ProbeHTTP(ctx context.Context, target string, module config.Module, registr
 		targetURL.Host = net.JoinHostPort(ip.String(), targetPort)
 	}
 
-	var body io.Reader = nil
-	//If a body is configured, add it to the request.
+	var body io.Reader
+
+	// If a body is configured, add it to the request.
 	if httpConfig.Body != "" {
 		body = strings.NewReader(httpConfig.Body)
 	}

--- a/prober/http.go
+++ b/prober/http.go
@@ -255,7 +255,14 @@ func ProbeHTTP(ctx context.Context, target string, module config.Module, registr
 	} else {
 		targetURL.Host = net.JoinHostPort(ip.String(), targetPort)
 	}
-	request, err := http.NewRequest(httpConfig.Method, targetURL.String(), nil)
+
+	var body io.Reader = nil
+	//If a body is configured, add it to the request.
+	if httpConfig.Body != "" {
+		body = strings.NewReader(httpConfig.Body)
+	}
+
+	request, err := http.NewRequest(httpConfig.Method, targetURL.String(), body)
 	request.Host = origHost
 	request = request.WithContext(ctx)
 	if err != nil {
@@ -271,10 +278,6 @@ func ProbeHTTP(ctx context.Context, target string, module config.Module, registr
 		request.Header.Set(key, value)
 	}
 
-	// If a body is configured, add it to the request.
-	if httpConfig.Body != "" {
-		request.Body = ioutil.NopCloser(strings.NewReader(httpConfig.Body))
-	}
 	level.Info(logger).Log("msg", "Making HTTP request", "url", request.URL.String(), "host", request.Host)
 
 	trace := &httptrace.ClientTrace{


### PR DESCRIPTION
Setting the post body in the NewRequest so the Content-Length will be available during the request. Alternative approach to solving: https://github.com/prometheus/blackbox_exporter/pull/263