### PR TITLE
Use net/http, time package constants

### DIFF
--- a/main.go
+++ b/main.go
@@ -65,7 +65,7 @@ func probeHandler(w http.ResponseWriter, r *http.Request, c *config.Config, logg
 	}
 	module, ok := c.Modules[moduleName]
 	if !ok {
-		http.Error(w, fmt.Sprintf("Unknown module %q", moduleName), 400)
+		http.Error(w, fmt.Sprintf("Unknown module %q", moduleName), http.StatusBadRequest)
 		return
 	}
 
@@ -87,7 +87,7 @@ func probeHandler(w http.ResponseWriter, r *http.Request, c *config.Config, logg
 		timeoutSeconds = module.Timeout.Seconds()
 	}
 	timeoutSeconds -= *timeoutOffset
-	ctx, cancel := context.WithTimeout(context.Background(), time.Duration(timeoutSeconds*1e9))
+	ctx, cancel := context.WithTimeout(context.Background(), time.Duration(timeoutSeconds*float64(time.Second)))
 	defer cancel()
 	r = r.WithContext(ctx)
 
@@ -102,13 +102,13 @@ func probeHandler(w http.ResponseWriter, r *http.Request, c *config.Config, logg
 	params := r.URL.Query()
 	target := params.Get("target")
 	if target == "" {
-		http.Error(w, "Target parameter is missing", 400)
+		http.Error(w, "Target parameter is missing", http.StatusBadRequest)
 		return
 	}
 
 	prober, ok := Probers[module.Prober]
 	if !ok {
-		http.Error(w, fmt.Sprintf("Unknown prober %q", module.Prober), 400)
+		http.Error(w, fmt.Sprintf("Unknown prober %q", module.Prober), http.StatusBadRequest)
 		return
 	}
 

--- a/prober/http.go
+++ b/prober/http.go
@@ -384,7 +384,7 @@ func ProbeHTTP(ctx context.Context, target string, module config.Module, registr
 	if resp.TLS != nil {
 		isSSLGauge.Set(float64(1))
 		registry.MustRegister(probeSSLEarliestCertExpiryGauge)
-		probeSSLEarliestCertExpiryGauge.Set(float64(getEarliestCertExpiry(resp.TLS).UnixNano() / 1e9))
+		probeSSLEarliestCertExpiryGauge.Set(float64(getEarliestCertExpiry(resp.TLS).Unix()))
 		if httpConfig.FailIfSSL {
 			level.Error(logger).Log("msg", "Final request was over SSL")
 			success = false

--- a/prober/tcp.go
+++ b/prober/tcp.go
@@ -108,7 +108,7 @@ func ProbeTCP(ctx context.Context, target string, module config.Module, registry
 	if module.TCP.TLS {
 		state := conn.(*tls.Conn).ConnectionState()
 		registry.MustRegister(probeSSLEarliestCertExpiry)
-		probeSSLEarliestCertExpiry.Set(float64(getEarliestCertExpiry(&state).UnixNano()) / 1e9)
+		probeSSLEarliestCertExpiry.Set(float64(getEarliestCertExpiry(&state).Unix()))
 	}
 	scanner := bufio.NewScanner(conn)
 	for i, qr := range module.TCP.QueryResponse {
@@ -176,7 +176,7 @@ func ProbeTCP(ctx context.Context, target string, module config.Module, registry
 			// Get certificate expiry.
 			state := tlsConn.ConnectionState()
 			registry.MustRegister(probeSSLEarliestCertExpiry)
-			probeSSLEarliestCertExpiry.Set(float64(getEarliestCertExpiry(&state).UnixNano()) / 1e9)
+			probeSSLEarliestCertExpiry.Set(float64(getEarliestCertExpiry(&state).Unix()))
 		}
 	}
 	return true


### PR DESCRIPTION
Note that one out of the three modified getEarliestCertExpiry() lines was doing integer division anyway, and was thus futile. The other two were at least converting the UnixNano() to float64 before dividing it by 1e9, but I'm not sure if anyone _really_ cares about nanoseconds on a TLS cert expiry. However, if they do, I'd then still recommend using a `float64(time.Second)` constant for pedantry's sake.