### PR TITLE
Mention the Go version in the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,10 @@ HTTP, HTTPS, DNS, TCP and ICMP.
 ## Building and running
 
 ### Local Build
-First of all, you need at least Go version `1.7`
+Building from source
+
+To build Prometheus from the source code yourself you need to have a working
+Go environment with [version 1.9 or greater installed](http://golang.org/doc/install).
 
     make
     ./blackbox_exporter <flags>

--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@ HTTP, HTTPS, DNS, TCP and ICMP.
 ## Building and running
 
 ### Local Build
+First of all, you need at least Go version `1.7`
 
     make
     ./blackbox_exporter <flags>


### PR DESCRIPTION
Ubuntu 16.04 ships with go `1.6.2` which does not have the `"context"` package