### PR TITLE
Fix HTTP content length metric name

### DIFF
--- a/prober/http.go
+++ b/prober/http.go
@@ -140,7 +140,7 @@ func ProbeHTTP(ctx context.Context, target string, module config.Module, registr
 			Help: "Duration of http request by phase, summed over all redirects",
 		}, []string{"phase"})
 		contentLengthGauge = prometheus.NewGauge(prometheus.GaugeOpts{
-			Name: "content_length",
+			Name: "probe_http_content_length",
 			Help: "Length of http content response",
 		})
 


### PR DESCRIPTION
This got broken as part of introducing the Prometheus client library for
metrics exposure in 7abdf0570d44cc8dbd258987e9d3353af1d6126e.