### PR TITLE
Make the history limit a configurable flag

### DIFF
--- a/history.go
+++ b/history.go
@@ -26,9 +26,10 @@ type result struct {
 }
 
 type resultHistory struct {
-	mu      sync.Mutex
-	nextId  int64
-	results []*result
+	mu         sync.Mutex
+	nextId     int64
+	results    []*result
+	maxResults uint
 }
 
 // Add a result to the history.
@@ -46,7 +47,7 @@ func (rh *resultHistory) Add(moduleName, target, debugOutput string, success boo
 	rh.nextId++
 
 	rh.results = append(rh.results, r)
-	if len(rh.results) > 100 {
+	if uint(len(rh.results)) > rh.maxResults {
 		results := make([]*result, len(rh.results)-1)
 		copy(results, rh.results[1:])
 		rh.results = results

--- a/main.go
+++ b/main.go
@@ -50,6 +50,7 @@ var (
 	listenAddress = kingpin.Flag("web.listen-address", "The address to listen on for HTTP requests.").Default(":9115").String()
 	timeoutOffset = kingpin.Flag("timeout-offset", "Offset to subtract from timeout in seconds.").Default("0.5").Float64()
 	configCheck   = kingpin.Flag("config.check", "If true validate the config file and then exit.").Default().Bool()
+	historyLimit  = kingpin.Flag("history.limit", "The maximum amount of items to keep in the history.").Default("100").Uint()
 
 	Probers = map[string]prober.ProbeFn{
 		"http": prober.ProbeHTTP,
@@ -209,7 +210,7 @@ func main() {
 	kingpin.HelpFlag.Short('h')
 	kingpin.Parse()
 	logger := promlog.New(allowedLevel)
-	rh := &resultHistory{}
+	rh := &resultHistory{maxResults: *historyLimit}
 
 	level.Info(logger).Log("msg", "Starting blackbox_exporter", "version", version.Info())
 	level.Info(logger).Log("msg", "Build context", version.BuildContext())


### PR DESCRIPTION
This change replaces the hardcoded limit on the number of elements stored in the log history with a configurable value that can be set as a runtime argument. The the old value of 100 elements will be use by default either when the argument is left off or the argument is out of range (less than 1).

The driving use case for this is when there are over 100 endpoints queried, some of them will be removed almost immediately from the logs.