### PR TITLE
Add nsswitch.conf to Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,6 +4,12 @@ MAINTAINER  The Prometheus Authors <prometheus-developers@googlegroups.com>
 COPY blackbox_exporter  /bin/blackbox_exporter
 COPY blackbox.yml       /etc/blackbox_exporter/config.yml
 
+# set up nsswitch.conf for Go's "netgo" implementation (which Docker explicitly uses)
+# - https://github.com/docker/docker-ce/blob/v17.09.0-ce/components/engine/hack/make.sh#L149
+# - https://github.com/golang/go/blob/go1.9.1/src/net/conf.go#L194-L275
+# - docker run --rm debian:stretch grep '^hosts:' /etc/nsswitch.conf
+RUN [ ! -e /etc/nsswitch.conf ] && echo 'hosts: files dns' > /etc/nsswitch.conf
+
 EXPOSE      9115
 ENTRYPOINT  [ "/bin/blackbox_exporter" ]
 CMD         [ "--config.file=/etc/blackbox_exporter/config.yml" ]


### PR DESCRIPTION
Add a minimal `/etc/nsswitch.conf` to allow resolving names from
`/etc/hosts` in Docker.

Signed-off-by: Ben Kochie <superq@gmail.com>

Closes: https://github.com/prometheus/busybox/issues/13