### PR TITLE
HTTP response header regex matching

### DIFF
--- a/CONFIGURATION.md
+++ b/CONFIGURATION.md
@@ -70,6 +70,7 @@ The other placeholders are specified separately.
   fail_if_header_matches_regexp:
     [ - header: <header-name>
         pattern: <regex>
+        # Also fail if the header is missing from the response.
         required: <bool>
       ... ]
 
@@ -77,6 +78,7 @@ The other placeholders are specified separately.
   fail_if_header_not_matches_regexp:
     [ - header: <header-name>
         pattern: <regex>
+        # Also fail if the header is missing from the response.
         required: <bool>
       ... ]
 

--- a/CONFIGURATION.md
+++ b/CONFIGURATION.md
@@ -66,6 +66,20 @@ The other placeholders are specified separately.
   fail_if_not_matches_regexp:
     [ - <regex>, ... ]
 
+  # Probe fails if response header matches regex.
+  fail_if_header_matches_regexp:
+    [ - header: <header-name>
+        pattern: <regex>
+        required: <bool>
+      ... ]
+
+  # Probe fails if response does not header matches regex.
+  fail_if_header_not_matches_regexp:
+    [ - header: <header-name>
+        pattern: <regex>
+        required: <bool>
+      ... ]
+
   # Configuration for TLS protocol of HTTP probe.
   tls_config:
     [ <tls_config> ]

--- a/config/config.go
+++ b/config/config.go
@@ -53,7 +53,7 @@ type Module struct {
 type HTTPHeaderMatch struct {
 	Header   string `yaml:"header,omitempty"`
 	Pattern  string `yaml:"pattern,omitempty"`
-	Required bool   `yaml:"pattern,omitempty"`
+	Required bool   `yaml:"required,omitempty"`
 }
 
 type HTTPProbe struct {

--- a/config/config.go
+++ b/config/config.go
@@ -52,18 +52,18 @@ type Module struct {
 
 type HTTPProbe struct {
 	// Defaults to 2xx.
-	ValidStatusCodes       []int                   `yaml:"valid_status_codes,omitempty"`
-	ValidHTTPVersions      []string                `yaml:"valid_http_versions,omitempty"`
-	PreferredIPProtocol    string                  `yaml:"preferred_ip_protocol,omitempty"`
-	NoFollowRedirects      bool                    `yaml:"no_follow_redirects,omitempty"`
-	FailIfSSL              bool                    `yaml:"fail_if_ssl,omitempty"`
-	FailIfNotSSL           bool                    `yaml:"fail_if_not_ssl,omitempty"`
-	Method                 string                  `yaml:"method,omitempty"`
-	Headers                map[string]string       `yaml:"headers,omitempty"`
-	FailIfMatchesRegexp    []string                `yaml:"fail_if_matches_regexp,omitempty"`
-	FailIfNotMatchesRegexp []string                `yaml:"fail_if_not_matches_regexp,omitempty"`
-	Body                   string                  `yaml:"body,omitempty"`
-	HTTPClientConfig       config.HTTPClientConfig `yaml:"http_client_config,inline"`
+	ValidStatusCodes           []int                   `yaml:"valid_status_codes,omitempty"`
+	ValidHTTPVersions          []string                `yaml:"valid_http_versions,omitempty"`
+	PreferredIPProtocol        string                  `yaml:"preferred_ip_protocol,omitempty"`
+	NoFollowRedirects          bool                    `yaml:"no_follow_redirects,omitempty"`
+	FailIfSSL                  bool                    `yaml:"fail_if_ssl,omitempty"`
+	FailIfNotSSL               bool                    `yaml:"fail_if_not_ssl,omitempty"`
+	Method                     string                  `yaml:"method,omitempty"`
+	Headers                    map[string]string       `yaml:"headers,omitempty"`
+	FailIfBodyMatchesRegexp    []string                `yaml:"fail_if_matches_regexp,omitempty"`
+	FailIfBodyNotMatchesRegexp []string                `yaml:"fail_if_not_matches_regexp,omitempty"`
+	Body                       string                  `yaml:"body,omitempty"`
+	HTTPClientConfig           config.HTTPClientConfig `yaml:"http_client_config,inline"`
 }
 
 type QueryResponse struct {

--- a/config/config.go
+++ b/config/config.go
@@ -50,20 +50,28 @@ type Module struct {
 	DNS     DNSProbe      `yaml:"dns,omitempty"`
 }
 
+type HTTPHeaderMatch struct {
+	Header   string `yaml:"header,omitempty"`
+	Pattern  string `yaml:"pattern,omitempty"`
+	Required bool   `yaml:"pattern,omitempty"`
+}
+
 type HTTPProbe struct {
 	// Defaults to 2xx.
-	ValidStatusCodes           []int                   `yaml:"valid_status_codes,omitempty"`
-	ValidHTTPVersions          []string                `yaml:"valid_http_versions,omitempty"`
-	PreferredIPProtocol        string                  `yaml:"preferred_ip_protocol,omitempty"`
-	NoFollowRedirects          bool                    `yaml:"no_follow_redirects,omitempty"`
-	FailIfSSL                  bool                    `yaml:"fail_if_ssl,omitempty"`
-	FailIfNotSSL               bool                    `yaml:"fail_if_not_ssl,omitempty"`
-	Method                     string                  `yaml:"method,omitempty"`
-	Headers                    map[string]string       `yaml:"headers,omitempty"`
-	FailIfBodyMatchesRegexp    []string                `yaml:"fail_if_matches_regexp,omitempty"`
-	FailIfBodyNotMatchesRegexp []string                `yaml:"fail_if_not_matches_regexp,omitempty"`
-	Body                       string                  `yaml:"body,omitempty"`
-	HTTPClientConfig           config.HTTPClientConfig `yaml:"http_client_config,inline"`
+	ValidStatusCodes             []int                   `yaml:"valid_status_codes,omitempty"`
+	ValidHTTPVersions            []string                `yaml:"valid_http_versions,omitempty"`
+	PreferredIPProtocol          string                  `yaml:"preferred_ip_protocol,omitempty"`
+	NoFollowRedirects            bool                    `yaml:"no_follow_redirects,omitempty"`
+	FailIfSSL                    bool                    `yaml:"fail_if_ssl,omitempty"`
+	FailIfNotSSL                 bool                    `yaml:"fail_if_not_ssl,omitempty"`
+	Method                       string                  `yaml:"method,omitempty"`
+	Headers                      map[string]string       `yaml:"headers,omitempty"`
+	FailIfBodyMatchesRegexp      []string                `yaml:"fail_if_matches_regexp,omitempty"`
+	FailIfBodyNotMatchesRegexp   []string                `yaml:"fail_if_not_matches_regexp,omitempty"`
+	FailIfHeaderMatchesRegexp    []HTTPHeaderMatch       `yaml:"fail_if_header_matches_regexp,omitempty"`
+	FailIfHeaderNotMatchesRegexp []HTTPHeaderMatch       `yaml:"fail_if_header_not_matches_regexp,omitempty"`
+	Body                         string                  `yaml:"body,omitempty"`
+	HTTPClientConfig             config.HTTPClientConfig `yaml:"http_client_config,inline"`
 }
 
 type QueryResponse struct {

--- a/example.yml
+++ b/example.yml
@@ -16,8 +16,6 @@ modules:
         - "Could not connect to database"
       fail_if_not_matches_regexp:
         - "Download the latest version here"
-      fail_if_not_matches_regexp:
-        - "Download the latest version here"
       fail_if_header_matches_regexp:
         - header: server
           pattern: "Apache"

--- a/example.yml
+++ b/example.yml
@@ -16,6 +16,15 @@ modules:
         - "Could not connect to database"
       fail_if_not_matches_regexp:
         - "Download the latest version here"
+      fail_if_not_matches_regexp:
+        - "Download the latest version here"
+      fail_if_header_matches_regexp:
+        - header: server
+          pattern: "Apache"
+      fail_if_header_not_matches_regexp:
+        - header: server
+          pattern: "nginx"
+          required: true
       tls_config:
         insecure_skip_verify: false
       preferred_ip_protocol: "ip4" # defaults to "ip6"

--- a/prober/http.go
+++ b/prober/http.go
@@ -54,6 +54,7 @@ func matchHeaderRegularExpressions(headers http.Header, httpConfig config.HTTPPr
 				}
 			}
 		} else if matcher.Required {
+			level.Error(logger).Log("msg", "Header was missing from the response", "regexp", key)
 			return false
 		}
 	}
@@ -72,6 +73,7 @@ func matchHeaderRegularExpressions(headers http.Header, httpConfig config.HTTPPr
 				}
 			}
 		} else if matcher.Required {
+			level.Error(logger).Log("msg", "Header was missing from the response", "regexp", key)
 			return false
 		}
 	}

--- a/prober/http.go
+++ b/prober/http.go
@@ -211,12 +211,7 @@ func ProbeHTTP(ctx context.Context, target string, module config.Module, registr
 			Help: "Returns the version of HTTP of the probe response",
 		})
 
-		probeFailedDueToHeaderRegex = prometheus.NewGauge(prometheus.GaugeOpts{
-			Name: "probe_failed_due_to_header_regex",
-			Help: "Indicates if probe failed due to header regex",
-		})
-
-		probeFailedDueToBodyRegex = prometheus.NewGauge(prometheus.GaugeOpts{
+		probeFailedDueToRegex = prometheus.NewGauge(prometheus.GaugeOpts{
 			Name: "probe_failed_due_to_regex",
 			Help: "Indicates if probe failed due to body regex",
 		})
@@ -232,8 +227,7 @@ func ProbeHTTP(ctx context.Context, target string, module config.Module, registr
 	registry.MustRegister(isSSLGauge)
 	registry.MustRegister(statusCodeGauge)
 	registry.MustRegister(probeHTTPVersionGauge)
-	registry.MustRegister(probeFailedDueToHeaderRegex)
-	registry.MustRegister(probeFailedDueToBodyRegex)
+	registry.MustRegister(probeFailedDueToRegex)
 
 	httpConfig := module.HTTP
 
@@ -366,18 +360,18 @@ func ProbeHTTP(ctx context.Context, target string, module config.Module, registr
 		if success && (len(httpConfig.FailIfHeaderMatchesRegexp) > 0 || len(httpConfig.FailIfHeaderNotMatchesRegexp) > 0) {
 			success = matchHeaderRegularExpressions(resp.Header, httpConfig, logger)
 			if success {
-				probeFailedDueToHeaderRegex.Set(0)
+				probeFailedDueToRegex.Set(0)
 			} else {
-				probeFailedDueToHeaderRegex.Set(1)
+				probeFailedDueToRegex.Set(1)
 			}
 		}
 
 		if success && (len(httpConfig.FailIfBodyMatchesRegexp) > 0 || len(httpConfig.FailIfBodyNotMatchesRegexp) > 0) {
 			success = matchBodyRegularExpressions(resp.Body, httpConfig, logger)
 			if success {
-				probeFailedDueToBodyRegex.Set(0)
+				probeFailedDueToRegex.Set(0)
 			} else {
-				probeFailedDueToBodyRegex.Set(1)
+				probeFailedDueToRegex.Set(1)
 			}
 		}
 

--- a/prober/http_test.go
+++ b/prober/http_test.go
@@ -331,7 +331,7 @@ func TestFailIfHeaderMatchesRegexp(t *testing.T) {
 		t.Fatal(err)
 	}
 	expectedResults := map[string]float64{
-		"probe_failed_due_to_header_regex": 1,
+		"probe_failed_due_to_regex": 1,
 	}
 	checkRegistryResults(expectedResults, mfs, t)
 
@@ -354,7 +354,7 @@ func TestFailIfHeaderMatchesRegexp(t *testing.T) {
 		t.Fatal(err)
 	}
 	expectedResults = map[string]float64{
-		"probe_failed_due_to_header_regex": 0,
+		"probe_failed_due_to_regex": 0,
 	}
 	checkRegistryResults(expectedResults, mfs, t)
 
@@ -541,7 +541,7 @@ func TestFailIfHeaderNotMatchesRegexp(t *testing.T) {
 		t.Fatal(err)
 	}
 	expectedResults := map[string]float64{
-		"probe_failed_due_to_header_regex": 0,
+		"probe_failed_due_to_regex": 0,
 	}
 	checkRegistryResults(expectedResults, mfs, t)
 
@@ -564,7 +564,7 @@ func TestFailIfHeaderNotMatchesRegexp(t *testing.T) {
 		t.Fatal(err)
 	}
 	expectedResults = map[string]float64{
-		"probe_failed_due_to_header_regex": 1,
+		"probe_failed_due_to_regex": 1,
 	}
 	checkRegistryResults(expectedResults, mfs, t)
 

--- a/prober/http_test.go
+++ b/prober/http_test.go
@@ -231,7 +231,7 @@ func TestFailIfNotSSL(t *testing.T) {
 	checkRegistryResults(expectedResults, mfs, t)
 }
 
-func TestFailIfMatchesRegexp(t *testing.T) {
+func TestFailIfBodyMatchesRegexp(t *testing.T) {
 	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		fmt.Fprintf(w, "Bad news: could not connect to database server")
 	}))
@@ -242,7 +242,7 @@ func TestFailIfMatchesRegexp(t *testing.T) {
 	testCTX, cancel := context.WithTimeout(context.Background(), 10*time.Second)
 	defer cancel()
 	result := ProbeHTTP(testCTX, ts.URL,
-		config.Module{Timeout: time.Second, HTTP: config.HTTPProbe{FailIfMatchesRegexp: []string{"could not connect to database"}}}, registry, log.NewNopLogger())
+		config.Module{Timeout: time.Second, HTTP: config.HTTPProbe{FailIfBodyMatchesRegexp: []string{"could not connect to database"}}}, registry, log.NewNopLogger())
 	body := recorder.Body.String()
 	if result {
 		t.Fatalf("Regexp test succeeded unexpectedly, got %s", body)
@@ -264,7 +264,7 @@ func TestFailIfMatchesRegexp(t *testing.T) {
 	recorder = httptest.NewRecorder()
 	registry = prometheus.NewRegistry()
 	result = ProbeHTTP(testCTX, ts.URL,
-		config.Module{Timeout: time.Second, HTTP: config.HTTPProbe{FailIfMatchesRegexp: []string{"could not connect to database"}}}, registry, log.NewNopLogger())
+		config.Module{Timeout: time.Second, HTTP: config.HTTPProbe{FailIfBodyMatchesRegexp: []string{"could not connect to database"}}}, registry, log.NewNopLogger())
 	body = recorder.Body.String()
 	if !result {
 		t.Fatalf("Regexp test failed unexpectedly, got %s", body)
@@ -288,7 +288,7 @@ func TestFailIfMatchesRegexp(t *testing.T) {
 	recorder = httptest.NewRecorder()
 	registry = prometheus.NewRegistry()
 	result = ProbeHTTP(testCTX, ts.URL,
-		config.Module{Timeout: time.Second, HTTP: config.HTTPProbe{FailIfMatchesRegexp: []string{"could not connect to database", "internal error"}}}, registry, log.NewNopLogger())
+		config.Module{Timeout: time.Second, HTTP: config.HTTPProbe{FailIfBodyMatchesRegexp: []string{"could not connect to database", "internal error"}}}, registry, log.NewNopLogger())
 	body = recorder.Body.String()
 	if result {
 		t.Fatalf("Regexp test succeeded unexpectedly, got %s", body)
@@ -302,14 +302,14 @@ func TestFailIfMatchesRegexp(t *testing.T) {
 	recorder = httptest.NewRecorder()
 	registry = prometheus.NewRegistry()
 	result = ProbeHTTP(testCTX, ts.URL,
-		config.Module{Timeout: time.Second, HTTP: config.HTTPProbe{FailIfMatchesRegexp: []string{"could not connect to database", "internal error"}}}, registry, log.NewNopLogger())
+		config.Module{Timeout: time.Second, HTTP: config.HTTPProbe{FailIfBodyMatchesRegexp: []string{"could not connect to database", "internal error"}}}, registry, log.NewNopLogger())
 	body = recorder.Body.String()
 	if !result {
 		t.Fatalf("Regexp test failed unexpectedly, got %s", body)
 	}
 }
 
-func TestFailIfNotMatchesRegexp(t *testing.T) {
+func TestFailIfBodyNotMatchesRegexp(t *testing.T) {
 	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		fmt.Fprintf(w, "Bad news: could not connect to database server")
 	}))
@@ -320,7 +320,7 @@ func TestFailIfNotMatchesRegexp(t *testing.T) {
 	testCTX, cancel := context.WithTimeout(context.Background(), 10*time.Second)
 	defer cancel()
 	result := ProbeHTTP(testCTX, ts.URL,
-		config.Module{Timeout: time.Second, HTTP: config.HTTPProbe{FailIfNotMatchesRegexp: []string{"Download the latest version here"}}}, registry, log.NewNopLogger())
+		config.Module{Timeout: time.Second, HTTP: config.HTTPProbe{FailIfBodyNotMatchesRegexp: []string{"Download the latest version here"}}}, registry, log.NewNopLogger())
 	body := recorder.Body.String()
 	if result {
 		t.Fatalf("Regexp test succeeded unexpectedly, got %s", body)
@@ -334,7 +334,7 @@ func TestFailIfNotMatchesRegexp(t *testing.T) {
 	recorder = httptest.NewRecorder()
 	registry = prometheus.NewRegistry()
 	result = ProbeHTTP(testCTX, ts.URL,
-		config.Module{Timeout: time.Second, HTTP: config.HTTPProbe{FailIfNotMatchesRegexp: []string{"Download the latest version here"}}}, registry, log.NewNopLogger())
+		config.Module{Timeout: time.Second, HTTP: config.HTTPProbe{FailIfBodyNotMatchesRegexp: []string{"Download the latest version here"}}}, registry, log.NewNopLogger())
 	body = recorder.Body.String()
 	if !result {
 		t.Fatalf("Regexp test failed unexpectedly, got %s", body)
@@ -350,7 +350,7 @@ func TestFailIfNotMatchesRegexp(t *testing.T) {
 	recorder = httptest.NewRecorder()
 	registry = prometheus.NewRegistry()
 	result = ProbeHTTP(testCTX, ts.URL,
-		config.Module{Timeout: time.Second, HTTP: config.HTTPProbe{FailIfNotMatchesRegexp: []string{"Download the latest version here", "Copyright 2015"}}}, registry, log.NewNopLogger())
+		config.Module{Timeout: time.Second, HTTP: config.HTTPProbe{FailIfBodyNotMatchesRegexp: []string{"Download the latest version here", "Copyright 2015"}}}, registry, log.NewNopLogger())
 	body = recorder.Body.String()
 	if result {
 		t.Fatalf("Regexp test succeeded unexpectedly, got %s", body)
@@ -364,7 +364,7 @@ func TestFailIfNotMatchesRegexp(t *testing.T) {
 	recorder = httptest.NewRecorder()
 	registry = prometheus.NewRegistry()
 	result = ProbeHTTP(testCTX, ts.URL,
-		config.Module{Timeout: time.Second, HTTP: config.HTTPProbe{FailIfNotMatchesRegexp: []string{"Download the latest version here", "Copyright 2015"}}}, registry, log.NewNopLogger())
+		config.Module{Timeout: time.Second, HTTP: config.HTTPProbe{FailIfBodyNotMatchesRegexp: []string{"Download the latest version here", "Copyright 2015"}}}, registry, log.NewNopLogger())
 	body = recorder.Body.String()
 	if !result {
 		t.Fatalf("Regexp test failed unexpectedly, got %s", body)


### PR DESCRIPTION
Also enables validating if response headers exist or not.

Defaulting to require all headers to match/not match is something I'm not sure about, but seems like the least worst default. Having multiple headers with the same name is a fairly uncommon scenario.