### PR TITLE
Use multi-stage builds

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -11,7 +11,7 @@ FROM quay.io/prometheus/busybox:latest
 LABEL Maintainer="prometheus-developers@googlegroups.com"
 
 COPY --from=build /go/src/github.com/prometheus/blackbox_exporter/blackbox_exporter /bin/blackbox_exporter
-COPY blackbox.yml /etc/blackbox_exporter/config.yml
+COPY --from=build /go/src/github.com/prometheus/blackbox_exporter/blackbox.yml /etc/blackbox_exporter/config.yml
 
 EXPOSE 9115
 ENTRYPOINT [ "/bin/blackbox_exporter" ]


### PR DESCRIPTION
Multi-step builds will not change the final image, and the entire build process can be put into Docker, so the Golang environment does not need to be installed locally when building.

This change will not affect the Makefile and make commands.

[Docker Document](https://docs.docker.com/develop/develop-images/multistage-build)
