### PR TITLE
[ PoC - IDEA ] calculate download time instead of simple reachability

### DIFF
--- a/prober/http.go
+++ b/prober/http.go
@@ -296,10 +296,8 @@ func ProbeHTTP(ctx context.Context, target string, module config.Module, registr
 	if err != nil && resp == nil {
 		level.Error(logger).Log("msg", "Error for HTTP request", "err", err)
 	} else {
-		
-			io.Copy(ioutil.Discard, resp.Body)
-			resp.Body.Close()
-		
+		io.Copy(ioutil.Discard, resp.Body)
+		resp.Body.Close()
 		level.Info(logger).Log("msg", "Received HTTP response", "status_code", resp.StatusCode)
 		if len(httpConfig.ValidStatusCodes) != 0 {
 			for _, code := range httpConfig.ValidStatusCodes {

--- a/prober/http.go
+++ b/prober/http.go
@@ -296,10 +296,10 @@ func ProbeHTTP(ctx context.Context, target string, module config.Module, registr
 	if err != nil && resp == nil {
 		level.Error(logger).Log("msg", "Error for HTTP request", "err", err)
 	} else {
-		defer func() {
+		
 			io.Copy(ioutil.Discard, resp.Body)
 			resp.Body.Close()
-		}()
+		
 		level.Info(logger).Log("msg", "Received HTTP response", "status_code", resp.StatusCode)
 		if len(httpConfig.ValidStatusCodes) != 0 {
 			for _, code := range httpConfig.ValidStatusCodes {


### PR DESCRIPTION
I wanted to monitor the download time from our internal repositories (Artifactory) using blackbox instead of creating a new tool/script.
I checked the code and I saw the URL after being contacted gets silently discarded by a goroutine, by simply removing it, I was able to monitor the time needed to download a binary from the internal repo.
I used an url like http://artifactory.local/files/Debian7.iso and I can monitor variation of its download time.
I think this could be useful to everybody and it could be refined / transformed in a configuration at a target level. 
I am aware the removed goroutine was used to reduce the load of the task, but it could be easily parametrized to provide this new functionality.

Let me know your thoughts.
