### PR TITLE
Fix broken build because of go fmt issue

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,7 @@ language: go
 # Whenever the Go version is updated here, .circleci/config.yml should also be
 # updated.
 go:
-- 1.10.x
+- 1.11.x
 
 go_import_path: github.com/prometheus/blackbox_exporter
 

--- a/prober/utils_test.go
+++ b/prober/utils_test.go
@@ -43,7 +43,7 @@ func generateTestCertificate(expiry time.Time, IPAddressSAN bool) ([]byte, []byt
 	publickey := &privatekey.PublicKey
 
 	cert := x509.Certificate{
-		IsCA: true,
+		IsCA:                  true,
 		BasicConstraintsValid: true,
 		SubjectKeyId:          []byte{1},
 		SerialNumber:          big.NewInt(1),


### PR DESCRIPTION
```
$ make
>> checking code style
! gofmt -d $(find . -path ./vendor -prune -o -name '*.go' -print) | grep '^'
diff -u ./prober/utils_test.go.orig ./prober/utils_test.go
--- ./prober/utils_test.go.orig	2018-09-25 11:52:34.000000000 -0700
+++ ./prober/utils_test.go	2018-09-25 11:52:34.000000000 -0700
@@ -43,7 +43,7 @@
    publickey := &privatekey.PublicKey

    cert := x509.Certificate{
-		IsCA: true,
+		IsCA:                  true,
	BasicConstraintsValid: true,
	SubjectKeyId:          []byte{1},
	SerialNumber:          big.NewInt(1),
make: *** [style] Error 1
```