### PR TITLE
Log debug ouput when probe failed

### DIFF
--- a/main.go
+++ b/main.go
@@ -134,6 +134,11 @@ func probeHandler(w http.ResponseWriter, r *http.Request, c *config.Config, logg
 	debugOutput := DebugOutput(&module, &sl.buffer, registry)
 	rh.Add(moduleName, target, debugOutput, success)
 
+	// log out debug ouput if probe failed
+	if !success {
+		level.Error(logger).Log("msg", debugOutput)
+	}
+
 	if r.URL.Query().Get("debug") == "true" {
 		w.Header().Set("Content-Type", "text/plain")
 		w.Write([]byte(debugOutput))

--- a/prober/http.go
+++ b/prober/http.go
@@ -404,6 +404,23 @@ func ProbeHTTP(ctx context.Context, target string, module config.Module, registr
 		durationGaugeVec.WithLabelValues("transfer").Add(trace.end.Sub(trace.responseStart).Seconds())
 	}
 
+	// log headers
+	hs := []string{}
+	for name, headers := range resp.Header {
+		name = strings.ToLower(name)
+		for _, h := range headers {
+			hs = append(hs, fmt.Sprintf("%v: %v", name, h))
+		}
+	}
+	level.Error(logger).Log("responseHeader", fmt.Sprintf("%v", hs))
+	// log body
+	if resp.Body != nil {
+		respBody, err := ioutil.ReadAll(resp.Body)
+		if err == nil {
+			level.Error(logger).Log("responseBody", respBody)
+		}
+	}
+
 	if resp.TLS != nil {
 		isSSLGauge.Set(float64(1))
 		registry.MustRegister(probeSSLEarliestCertExpiryGauge)


### PR DESCRIPTION
As in #350, when the probe failed we want to see the content of the response and we can only do it may be hours after the incident. By that time, the history is lost and we have no record to understand what happened. With writing to log stream, the exporter allows users read application log file for investigation purpose.