### PR TITLE
adding probe error log support 

### DIFF
--- a/main_test.go
+++ b/main_test.go
@@ -43,7 +43,7 @@ func TestPrometheusTimeoutHTTP(t *testing.T) {
 
 	rr := httptest.NewRecorder()
 	handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		probeHandler(w, r, c, log.NewNopLogger(), &resultHistory{})
+		probeHandler(w, r, c, log.NewNopLogger(), &resultHistory{}, &resultHistory{})
 	})
 
 	handler.ServeHTTP(rr, req)
@@ -65,7 +65,7 @@ func TestPrometheusConfigSecretsHidden(t *testing.T) {
 	}
 	rr := httptest.NewRecorder()
 	handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		probeHandler(w, r, c, log.NewNopLogger(), &resultHistory{})
+		probeHandler(w, r, c, log.NewNopLogger(), &resultHistory{}, &resultHistory{})
 	})
 	handler.ServeHTTP(rr, req)
 


### PR DESCRIPTION
this PR address issue #350 due to we need to keep failed probe history longer for people to investigate issues. debug logging can not address this issue due to people should not need to look at log to troubleshot probe issue. when probing large number of sites, the failed log entry will be override quickly by succeed logs, so we create a separate entry for this.

I have no tested the change yet due to don't know how to setup build and test on local env