### PR TITLE
circleci: switch to 2.1 config

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,5 +1,5 @@
 ---
-version: 2
+version: 2.1
 
 jobs:
   # IPv6 tests require the machine executor.
@@ -15,7 +15,7 @@ jobs:
     - run:
         name: enable ipv6
         command: |
-          cat <<'EOF' | sudo tee /etc/docker/daemon.json
+          cat \<<'EOF' | sudo tee /etc/docker/daemon.json
           {
             "ipv6": true,
             "fixed-cidr-v6": "2001:db8:1::/64"


### PR DESCRIPTION
Similar to https://github.com/prometheus/prometheus/pull/4713 and https://github.com/prometheus/alertmanager/pull/1579. Once the 2.1 config is enabled, we can reduce duplication in `.circleci/config.yml` a bit.