### PR TITLE
Proposal: a multi-stage dockerfile with all in one build

### DIFF
--- a/Dockerfile.multi
+++ b/Dockerfile.multi
@@ -1,0 +1,20 @@
+FROM golang:1.11
+
+COPY . /go/src/github.com/prometheus/blackbox_exporter
+WORKDIR /go/src/github.com/prometheus/blackbox_exporter
+RUN apt-get update -qq \
+    && apt-get install -y --no-install-recommends --no-install-suggests git curl build-essential\
+    && last_tag=$(git tag -l --sort version:refname|tail -n 1) \
+    && git checkout $last_tag \
+    && make 
+
+
+FROM        quay.io/prometheus/busybox:latest
+MAINTAINER  The Prometheus Authors <prometheus-developers@googlegroups.com>
+
+COPY --from=0  /go/src/github.com/prometheus/blackbox_exporter/blackbox_exporter  /bin/blackbox_exporter
+COPY blackbox.yml       /etc/blackbox_exporter/config.yml
+
+EXPOSE      9115
+ENTRYPOINT  [ "/bin/blackbox_exporter" ]
+CMD         [ "--config.file=/etc/blackbox_exporter/config.yml" ]


### PR DESCRIPTION
Hello everyone,

I was using the project on a new instance that did not have a golang environment and I found the multi-stage build useful, so I am proposing it to you.

Notes:
- It is not possible to use the golang:1.11-alpine image for the initial build. The cause is that the "go race" tests are not compatible with Alpine yet. 
- I had to set the make at the latest tag available in the repo, hence the "last_tag" line
- The unitests that are for DNS and TCP using IPv6 would not work for the normal docker user. The gotcha is that your containers by default have only IPv4 enabled. I used this link to configure my daemon to give IPv6 addresses for my containers: https://docs.docker.com/v17.09/engine/userguide/networking/default_network/ipv6/. In short, put this into `/etc/docker/daemon.json`
```json
{
  "ipv6": true,
  "fixed-cidr-v6": "2001:db8:d0e1::/64"
}
```
and then `systemctl reload docker.service`. The unitests should go smoothly after that.
- You should delete the intermediate image once you are done, to save space. The Docker community suggests "docker prune" command. To use with caution: prefer the version where you manually delete the image using the SHA256 ID yourself or make use of the "--filter" switch to be more explicit.

Hope you find all this useful.

Best regards,
Sofiane