### PR TITLE
Add support for `body_path` in HTTP probe config.

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -142,10 +142,11 @@ func (s *HTTPProbe) UnmarshalYAML(unmarshal func(interface{}) error) error {
 		return errors.New("at most one of body & body_file may be configured")
 	}
 	if s.BodyFile != "" {
-		_, err := os.Open(s.BodyFile)
+		file, err := os.Open(s.BodyFile)
 		if err != nil {
 			return err
 		}
+		defer file.Close()
 	}
 	return nil
 }

--- a/config/config.go
+++ b/config/config.go
@@ -138,8 +138,8 @@ func (s *HTTPProbe) UnmarshalYAML(unmarshal func(interface{}) error) error {
 	if err := s.HTTPClientConfig.Validate(); err != nil {
 		return err
 	}
-	if s.Body != "" && s.BodyFile != "" {
-		return errors.New("Only one of `body` and `body_file` may be set")
+	if len(s.Body) > 0 && len(s.BodyFile) > 0 {
+		return errors.New("at most one of body & body_file may be configured")
 	}
 	if s.BodyFile != "" {
 		_, err := os.Open(s.BodyFile)

--- a/config/config.go
+++ b/config/config.go
@@ -3,7 +3,9 @@ package config
 import (
 	"errors"
 	"fmt"
+	"io"
 	"io/ioutil"
+	"os"
 	"runtime"
 	"sync"
 	"time"
@@ -52,18 +54,20 @@ type Module struct {
 
 type HTTPProbe struct {
 	// Defaults to 2xx.
-	ValidStatusCodes       []int                   `yaml:"valid_status_codes,omitempty"`
-	ValidHTTPVersions      []string                `yaml:"valid_http_versions,omitempty"`
-	IPProtocol             string                  `yaml:"preferred_ip_protocol,omitempty"`
-	IPProtocolFallback     bool                    `yaml:"ip_protocol_fallback,omitempty"`
-	NoFollowRedirects      bool                    `yaml:"no_follow_redirects,omitempty"`
-	FailIfSSL              bool                    `yaml:"fail_if_ssl,omitempty"`
-	FailIfNotSSL           bool                    `yaml:"fail_if_not_ssl,omitempty"`
-	Method                 string                  `yaml:"method,omitempty"`
-	Headers                map[string]string       `yaml:"headers,omitempty"`
-	FailIfMatchesRegexp    []string                `yaml:"fail_if_matches_regexp,omitempty"`
-	FailIfNotMatchesRegexp []string                `yaml:"fail_if_not_matches_regexp,omitempty"`
-	Body                   string                  `yaml:"body,omitempty"`
+	ValidStatusCodes       []int             `yaml:"valid_status_codes,omitempty"`
+	ValidHTTPVersions      []string          `yaml:"valid_http_versions,omitempty"`
+	IPProtocol             string            `yaml:"preferred_ip_protocol,omitempty"`
+	IPProtocolFallback     bool              `yaml:"ip_protocol_fallback,omitempty"`
+	NoFollowRedirects      bool              `yaml:"no_follow_redirects,omitempty"`
+	FailIfSSL              bool              `yaml:"fail_if_ssl,omitempty"`
+	FailIfNotSSL           bool              `yaml:"fail_if_not_ssl,omitempty"`
+	Method                 string            `yaml:"method,omitempty"`
+	Headers                map[string]string `yaml:"headers,omitempty"`
+	FailIfMatchesRegexp    []string          `yaml:"fail_if_matches_regexp,omitempty"`
+	FailIfNotMatchesRegexp []string          `yaml:"fail_if_not_matches_regexp,omitempty"`
+	Body                   string            `yaml:"body,omitempty"`
+	BodyPath               string            `yaml:"body_path,omitempty"`
+	BodyFile               io.Reader
 	HTTPClientConfig       config.HTTPClientConfig `yaml:"http_client_config,inline"`
 }
 
@@ -134,6 +138,13 @@ func (s *HTTPProbe) UnmarshalYAML(unmarshal func(interface{}) error) error {
 	}
 	if err := s.HTTPClientConfig.Validate(); err != nil {
 		return err
+	}
+	if s.BodyPath != "" {
+		file, err := os.Open(s.BodyPath)
+		if err != nil {
+			return err
+		}
+		s.BodyFile = file
 	}
 	return nil
 }

--- a/config/config.go
+++ b/config/config.go
@@ -3,7 +3,6 @@ package config
 import (
 	"errors"
 	"fmt"
-	"io"
 	"io/ioutil"
 	"os"
 	"runtime"
@@ -66,9 +65,9 @@ type HTTPProbe struct {
 	FailIfMatchesRegexp    []string          `yaml:"fail_if_matches_regexp,omitempty"`
 	FailIfNotMatchesRegexp []string          `yaml:"fail_if_not_matches_regexp,omitempty"`
 	Body                   string            `yaml:"body,omitempty"`
-	BodyPath               string            `yaml:"body_path,omitempty"`
-	BodyFile               io.Reader
-	HTTPClientConfig       config.HTTPClientConfig `yaml:"http_client_config,inline"`
+	BodyFile               string            `yaml:"body_file,omitempty"`
+
+	HTTPClientConfig config.HTTPClientConfig `yaml:"http_client_config,inline"`
 }
 
 type QueryResponse struct {
@@ -139,12 +138,14 @@ func (s *HTTPProbe) UnmarshalYAML(unmarshal func(interface{}) error) error {
 	if err := s.HTTPClientConfig.Validate(); err != nil {
 		return err
 	}
-	if s.BodyPath != "" {
-		file, err := os.Open(s.BodyPath)
+	if s.Body != "" && s.BodyFile != "" {
+		return errors.New("Only one of `body` and `body_file` may be set")
+	}
+	if s.BodyFile != "" {
+		_, err := os.Open(s.BodyFile)
 		if err != nil {
 			return err
 		}
-		s.BodyFile = file
 	}
 	return nil
 }

--- a/prober/http.go
+++ b/prober/http.go
@@ -269,6 +269,7 @@ func ProbeHTTP(ctx context.Context, target string, module config.Module, registr
 			level.Error(logger).Log("msg", "Error opening body file", "err", err)
 			return
 		}
+		defer file.Close()
 		body = file
 	}
 

--- a/prober/http.go
+++ b/prober/http.go
@@ -257,9 +257,13 @@ func ProbeHTTP(ctx context.Context, target string, module config.Module, registr
 
 	var body io.Reader
 
-	// If a body is configured, add it to the request.
+	// If a body string is configured, add it to the request.
 	if httpConfig.Body != "" {
 		body = strings.NewReader(httpConfig.Body)
+	}
+	// If a body path is configured, add it to the request.
+	if httpConfig.BodyFile != nil {
+		body = httpConfig.BodyFile
 	}
 
 	request, err := http.NewRequest(httpConfig.Method, targetURL.String(), body)

--- a/prober/http.go
+++ b/prober/http.go
@@ -24,6 +24,7 @@ import (
 	"net/http/cookiejar"
 	"net/http/httptrace"
 	"net/url"
+	"os"
 	"regexp"
 	"strconv"
 	"strings"
@@ -262,8 +263,13 @@ func ProbeHTTP(ctx context.Context, target string, module config.Module, registr
 		body = strings.NewReader(httpConfig.Body)
 	}
 	// If a body path is configured, add it to the request.
-	if httpConfig.BodyFile != nil {
-		body = httpConfig.BodyFile
+	if httpConfig.BodyFile != "" {
+		file, err := os.Open(httpConfig.BodyFile)
+		if err != nil {
+			level.Error(logger).Log("msg", "Error opening body file", "err", err)
+			return
+		}
+		body = file
 	}
 
 	request, err := http.NewRequest(httpConfig.Method, targetURL.String(), body)

--- a/prober/http_test.go
+++ b/prober/http_test.go
@@ -182,7 +182,7 @@ func TestPostBody(t *testing.T) {
 			HTTP: config.HTTPProbe{
 				IPProtocolFallback: true,
 				Method:             "POST",
-				BodyPath:           "./http.go",
+				BodyFile:           "./http.go",
 			},
 		}, registry, log.NewNopLogger())
 	body := recorder.Body.String()

--- a/prober/http_test.go
+++ b/prober/http_test.go
@@ -182,7 +182,7 @@ func TestPostBody(t *testing.T) {
 			HTTP: config.HTTPProbe{
 				IPProtocolFallback: true,
 				Method:             "POST",
-				BodyFile:           "./http.go",
+				BodyFile:           "./testdata/http_body.txt",
 			},
 		}, registry, log.NewNopLogger())
 	body := recorder.Body.String()

--- a/prober/testdata/http_body.txt
+++ b/prober/testdata/http_body.txt
@@ -1,0 +1,1 @@
+TEST HTTP BODY


### PR DESCRIPTION
Fixes prometheus/blackbox_exporter#391.