### PR TITLE
Add support for tcp probes which you expect to fail

### DIFF
--- a/CONFIGURATION.md
+++ b/CONFIGURATION.md
@@ -121,6 +121,9 @@ query_response:
 tls_config:
   [ <tls_config> ]
 
+# Fail if connection to port can be made.
+[ expect_connection_fail: <boolean> | default = false ]
+
 ```
 
 ### <dns_probe>

--- a/config/config.go
+++ b/config/config.go
@@ -102,12 +102,13 @@ type QueryResponse struct {
 }
 
 type TCPProbe struct {
-	IPProtocol         string           `yaml:"preferred_ip_protocol,omitempty"`
-	IPProtocolFallback bool             `yaml:"ip_protocol_fallback,omitempty"`
-	SourceIPAddress    string           `yaml:"source_ip_address,omitempty"`
-	QueryResponse      []QueryResponse  `yaml:"query_response,omitempty"`
-	TLS                bool             `yaml:"tls,omitempty"`
-	TLSConfig          config.TLSConfig `yaml:"tls_config,omitempty"`
+	IPProtocol           string           `yaml:"preferred_ip_protocol,omitempty"`
+	IPProtocolFallback   bool             `yaml:"ip_protocol_fallback,omitempty"`
+	SourceIPAddress      string           `yaml:"source_ip_address,omitempty"`
+	QueryResponse        []QueryResponse  `yaml:"query_response,omitempty"`
+	TLS                  bool             `yaml:"tls,omitempty"`
+	TLSConfig            config.TLSConfig `yaml:"tls_config,omitempty"`
+	ExpectConnectionFail bool             `yaml:"expect_connection_fail,omitempty"`
 }
 
 type ICMPProbe struct {

--- a/prober/http.go
+++ b/prober/http.go
@@ -254,10 +254,12 @@ func ProbeHTTP(ctx context.Context, target string, module config.Module, registr
 
 	// Replace the host field in the URL with the IP we resolved.
 	origHost := targetURL.Host
-	if targetPort == "" {
-		targetURL.Host = "[" + ip.String() + "]"
-	} else {
-		targetURL.Host = net.JoinHostPort(ip.String(), targetPort)
+	if httpClientConfig.ProxyURL.URL == nil {
+		if targetPort == "" {
+			targetURL.Host = "[" + ip.String() + "]"
+		} else {
+			targetURL.Host = net.JoinHostPort(ip.String(), targetPort)
+		}
 	}
 
 	var body io.Reader

--- a/prober/tcp.go
+++ b/prober/tcp.go
@@ -104,18 +104,17 @@ func ProbeTCP(ctx context.Context, target string, module config.Module, registry
 	conn, err := dialTCP(ctx, target, module, registry, logger)
 	if err != nil {
 		if module.TCP.ExpectConnectionFail {
-			level.Info(logger).Log("msg", "Error dialing TCP", "err", err)
+			level.Info(logger).Log("msg", "TCP connection unsuccessfull", "err", err)
 			return true
-		} else {
-			level.Error(logger).Log("msg", "Error dialing TCP", "err", err)
-			return false
 		}
+		level.Error(logger).Log("msg", "Error dialing TCP", "err", err)
+		return false
 	}
+	defer conn.Close()
 	if module.TCP.ExpectConnectionFail {
 		level.Error(logger).Log("msg", "connected to port")
 		return false
 	}
-	defer conn.Close()
 	level.Info(logger).Log("msg", "Successfully dialed")
 
 	// Set a deadline to prevent the following code from blocking forever.

--- a/prober/tcp.go
+++ b/prober/tcp.go
@@ -103,7 +103,16 @@ func ProbeTCP(ctx context.Context, target string, module config.Module, registry
 
 	conn, err := dialTCP(ctx, target, module, registry, logger)
 	if err != nil {
-		level.Error(logger).Log("msg", "Error dialing TCP", "err", err)
+		if module.TCP.ExpectConnectionFail {
+			level.Info(logger).Log("msg", "Error dialing TCP", "err", err)
+			return true
+		} else {
+			level.Error(logger).Log("msg", "Error dialing TCP", "err", err)
+			return false
+		}
+	}
+	if module.TCP.ExpectConnectionFail {
+		level.Error(logger).Log("msg", "connected to port")
 		return false
 	}
 	defer conn.Close()


### PR DESCRIPTION
This PR adds the option expect_connection_fail to the tcp probe. So you can you use the tcp prober to check if ports are closed / unavailable.