### PR TITLE
Fix function comments based on best practices from Effective Go

### DIFF
--- a/history.go
+++ b/history.go
@@ -54,7 +54,7 @@ func (rh *resultHistory) Add(moduleName, target, debugOutput string, success boo
 	}
 }
 
-// Return a list of all results.
+// List returns a list of all results.
 func (rh *resultHistory) List() []*result {
 	rh.mu.Lock()
 	defer rh.mu.Unlock()
@@ -62,7 +62,7 @@ func (rh *resultHistory) List() []*result {
 	return rh.results[:]
 }
 
-// Return a given result.
+// Get returns a given result.
 func (rh *resultHistory) Get(id int64) *result {
 	rh.mu.Lock()
 	defer rh.mu.Unlock()

--- a/main.go
+++ b/main.go
@@ -174,7 +174,7 @@ func (sl scrapeLogger) Log(keyvals ...interface{}) error {
 	return sl.next.Log(kvs...)
 }
 
-// Returns plaintext debug output for a probe.
+// DebugOutput returns plaintext debug output for a probe.
 func DebugOutput(module *config.Module, logBuffer *bytes.Buffer, registry *prometheus.Registry) string {
 	buf := &bytes.Buffer{}
 	fmt.Fprintf(buf, "Logs for the probe:\n")


### PR DESCRIPTION
Hi, we updated some exported function comments based on best practices from [Effective Go](https://golang.org/doc/effective_go.html#commentary). It’s admittedly a relatively minor fix up. Does this help you?