### PR TITLE
Empty in YAML means null.

### DIFF
--- a/blackbox.yml
+++ b/blackbox.yml
@@ -1,7 +1,6 @@
 modules:
   http_2xx:
     prober: http
-    http:
   http_post_2xx:
     prober: http
     http:


### PR DESCRIPTION
The null then overrides the default config. Avoid this
in the example config file.

Signed-off-by: Brian Brazil <brian.brazil@robustperception.io>