### PR TITLE
update main.go to allow for docker stop, exit 0 (resolves #447)

### DIFF
--- a/main.go
+++ b/main.go
@@ -342,11 +342,6 @@ func run() int {
 			level.Error(logger).Log("msg", "Error starting HTTP server", "err", err)
 			close(srvc)
 		}
-		defer func() {
-			if err := srv.Close(); err != nil {
-				level.Error(logger).Log("msg", "Error on closing the server", "err", err)
-			}
-		}()
 	}()
 
 	for {


### PR DESCRIPTION
Use Alertmanager main.go as an example to exit 0 when blackbox_exporter service receives SIGTERM.

Signed-off-by: silentpete <peter.gallerani@gmail.com>