### PR TITLE
Docker image generation not requiring building the project outside docker

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,14 @@
-FROM        quay.io/prometheus/busybox:latest
+FROM golang:1.12 as builder
+
+WORKDIR /go/src/github.com/prometheus/blackbox_exporter
+ADD . .
+RUN make
+
+FROM quay.io/prometheus/busybox:latest
 LABEL maintainer="The Prometheus Authors <prometheus-developers@googlegroups.com>"
 
-COPY blackbox_exporter  /bin/blackbox_exporter
-COPY blackbox.yml       /etc/blackbox_exporter/config.yml
+COPY --from=builder /go/src/github.com/prometheus/blackbox_exporter/blackbox_exporter /bin/blackbox_exporter
+COPY blackbox.yml /etc/blackbox_exporter/config.yml
 
 EXPOSE      9115
 ENTRYPOINT  [ "/bin/blackbox_exporter" ]

--- a/README.md
+++ b/README.md
@@ -21,6 +21,9 @@ will return debug information for that probe.
 
 ### Building with Docker
 
+*Note: Given the default config in the tests, your docker setup requires ipv6 enabled.
+You can follow [these instructions](https://docs.docker.com/v17.09/engine/userguide/networking/default_network/ipv6/)*
+
     docker build -t blackbox_exporter .
     docker run -d -p 9115:9115 --name blackbox_exporter -v `pwd`:/config blackbox_exporter --config.file=/config/blackbox.yml
 


### PR DESCRIPTION
Introducing multistage build in the main dockerfile so we don't depend on an external build to generate a dockered version of the software