### PR TITLE
Switch from quay.io busybox to docker hub

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM        quay.io/prometheus/busybox:latest
+FROM  busybox:latest
 LABEL maintainer="The Prometheus Authors <prometheus-developers@googlegroups.com>"
 
 COPY blackbox_exporter  /bin/blackbox_exporter


### PR DESCRIPTION
There are several DNS issues related to busybox versions 1.28.4 and above. It seems like quay.io has not updated its latest image in 2 months. In order to get bugfixes sooner, it's better to use the up to date versions on docker hub.
More info: https://github.com/docker-library/busybox/issues/48