### PR TITLE
Allow TLS renegotiation

### DIFF
--- a/vendor/github.com/prometheus/common/config/http_config.go
+++ b/vendor/github.com/prometheus/common/config/http_config.go
@@ -210,7 +210,7 @@ func cloneRequest(r *http.Request) *http.Request {
 
 // NewTLSConfig creates a new tls.Config from the given config.TLSConfig.
 func NewTLSConfig(cfg *TLSConfig) (*tls.Config, error) {
-	tlsConfig := &tls.Config{InsecureSkipVerify: cfg.InsecureSkipVerify}
+	tlsConfig := &tls.Config{InsecureSkipVerify: cfg.InsecureSkipVerify, Renegotiation: tls.RenegotiateFreelyAsClient}
 
 	// If a CA cert is provided then let's read it in so we can validate the
 	// scrape target's certificate properly.


### PR DESCRIPTION
This patch is to address an interop issue with Microsoft IIS when using client certificates. Without this, there will always be an error because TLS renegotiation is disabled by default. This has been addressed in Go a while ago, by implementing the 'Renegotiation' parameter.