### PR TITLE
Bump default timeout to 2m

### DIFF
--- a/main.go
+++ b/main.go
@@ -354,7 +354,7 @@ func getTimeout(r *http.Request, module config.Module, offset float64) (timeoutS
 		}
 	}
 	if timeoutSeconds == 0 {
-		timeoutSeconds = 10
+		timeoutSeconds = 120
 	}
 
 	var maxTimeoutSeconds = timeoutSeconds - offset

--- a/main_test.go
+++ b/main_test.go
@@ -116,12 +116,12 @@ func TestTimeoutIsSetCorrectly(t *testing.T) {
 		{20 * time.Second, "15", 0, 15},
 		{5 * time.Second, "15", 0, 5},
 		{5 * time.Second, "15", 0.5, 5},
-		{10 * time.Second, "", 0.5, 9.5},
+		{10 * time.Second, "", 0.5, 10},
 		{10 * time.Second, "10", 0.5, 9.5},
 		{9500 * time.Millisecond, "", 0.5, 9.5},
-		{9500 * time.Millisecond, "", 1, 9},
-		{0 * time.Second, "", 0.5, 9.5},
-		{0 * time.Second, "", 0, 10},
+		{9500 * time.Millisecond, "", 1, 9.5},
+		{0 * time.Second, "", 0.5, 119.5},
+		{0 * time.Second, "", 0, 120},
 	}
 
 	for _, v := range tests {


### PR DESCRIPTION
The current default of 10s is problematic when testing slower probes
from a browser. Cancellation will still work as a fallback,
including for older Prometheus servers that don't send the timeout
header, so there shouldn't be a big buildup of ongoing probes.

Fixes #259

Signed-off-by: Brian Brazil <brian.brazil@robustperception.io>