### PR TITLE
Use HTTP request's context, so cancellation works.

### DIFF
--- a/main.go
+++ b/main.go
@@ -77,7 +77,7 @@ func probeHandler(w http.ResponseWriter, r *http.Request, c *config.Config, logg
 		return
 	}
 
-	ctx, cancel := context.WithTimeout(context.Background(), time.Duration(timeoutSeconds*float64(time.Second)))
+	ctx, cancel := context.WithTimeout(r.Context(), time.Duration(timeoutSeconds*float64(time.Second)))
 	defer cancel()
 	r = r.WithContext(ctx)
 


### PR DESCRIPTION
Signed-off-by: Brian Brazil <brian.brazil@robustperception.io>