### PR TITLE
Add separate history for expired failed probe results

### DIFF
--- a/history.go
+++ b/history.go
@@ -32,7 +32,7 @@ type resultHistory struct {
 	mu                     sync.Mutex
 	nextId                 int64
 	results                []*result
-	preservedFailedResults []*result 
+	preservedFailedResults []*result
 	maxResults             uint
 }
 

--- a/history.go
+++ b/history.go
@@ -26,12 +26,11 @@ type result struct {
 }
 
 type resultHistory struct {
-	mu                        sync.Mutex
-	nextId                    int64
-	results                   []*result
-	maxResults                uint
-	preservedFailedResults    []*result
-	maxPreservedFailedResults uint
+	mu                     sync.Mutex
+	nextId                 int64
+	results                []*result
+	preservedFailedResults []*result
+	maxResults             uint
 }
 
 // Add a result to the history.
@@ -52,7 +51,7 @@ func (rh *resultHistory) Add(moduleName, target, debugOutput string, success boo
 	if uint(len(rh.results)) > rh.maxResults {
 		if !rh.results[0].success {
 			rh.preservedFailedResults = append(rh.preservedFailedResults, rh.results[0])
-			if uint(len(rh.preservedFailedResults)) > rh.maxPreservedFailedResults {
+			if uint(len(rh.preservedFailedResults)) > rh.maxResults {
 				preservedFailedResults := make([]*result, len(rh.preservedFailedResults)-1)
 				copy(preservedFailedResults, rh.preservedFailedResults[1:])
 				rh.preservedFailedResults = preservedFailedResults
@@ -69,15 +68,7 @@ func (rh *resultHistory) List() []*result {
 	rh.mu.Lock()
 	defer rh.mu.Unlock()
 
-	return rh.results[:]
-}
-
-// ListPreservedFailures returns a list of all preserved failed results.
-func (rh *resultHistory) ListPreservedFailures() []*result {
-	rh.mu.Lock()
-	defer rh.mu.Unlock()
-
-	return rh.preservedFailedResults[:]
+	return append(rh.preservedFailedResults[:], rh.results...)
 }
 
 // Get returns a given result.

--- a/history.go
+++ b/history.go
@@ -25,11 +25,14 @@ type result struct {
 	success     bool
 }
 
+// resultHistory contains two history slices: `results` contains most recent `maxResults` results.
+// After they expire out of `results`, failures will be saved in `preservedFailedResults`. This
+// ensures that we are always able to see debug information about recent failures.
 type resultHistory struct {
 	mu                     sync.Mutex
 	nextId                 int64
 	results                []*result
-	preservedFailedResults []*result
+	preservedFailedResults []*result 
 	maxResults             uint
 }
 
@@ -49,6 +52,8 @@ func (rh *resultHistory) Add(moduleName, target, debugOutput string, success boo
 
 	rh.results = append(rh.results, r)
 	if uint(len(rh.results)) > rh.maxResults {
+		// If we are about to remove a failure, add it to the failed result history, then
+		// remove the oldest failed result, if needed.
 		if !rh.results[0].success {
 			rh.preservedFailedResults = append(rh.preservedFailedResults, rh.results[0])
 			if uint(len(rh.preservedFailedResults)) > rh.maxResults {
@@ -68,6 +73,7 @@ func (rh *resultHistory) List() []*result {
 	rh.mu.Lock()
 	defer rh.mu.Unlock()
 
+	// Results in each slice are disjoint. We can simply concatenate the results.
 	return append(rh.preservedFailedResults[:], rh.results...)
 }
 

--- a/history_test.go
+++ b/history_test.go
@@ -19,7 +19,7 @@ import (
 )
 
 func TestHistoryKeepsLatestResults(t *testing.T) {
-	history := &resultHistory{maxResults: 3, maxPreservedFailedResults: 3}
+	history := &resultHistory{maxResults: 3}
 	for i := 0; i < 4; i++ {
 		history.Add("module", "target", fmt.Sprintf("result %d", i), true)
 	}
@@ -39,22 +39,18 @@ func FillHistoryWithMaxSuccesses(h *resultHistory) {
 }
 
 func FillHistoryWithMaxPreservedFailures(h *resultHistory) {
-	for i := uint(0); i < h.maxPreservedFailedResults; i++ {
+	for i := uint(0); i < h.maxResults; i++ {
 		h.Add("module", "target", fmt.Sprintf("result %d", h.nextId), false)
 	}
 }
 
 func TestHistoryPreservesExpiredFailedResults(t *testing.T) {
-	history := &resultHistory{maxResults: 3, maxPreservedFailedResults: 3}
+	history := &resultHistory{maxResults: 3}
 
 	// Success are expired, no failues are expired
 	FillHistoryWithMaxSuccesses(history)
 	FillHistoryWithMaxPreservedFailures(history)
 	savedResults := history.List()
-	savedFailedResults := history.ListPreservedFailures()
-	if len(savedFailedResults) > 0 {
-		t.Errorf("Preserved failures contains failures unnecessarily.")
-	}
 	for i := uint(0); i < uint(len(savedResults)); i++ {
 		expectedDebugOutput := fmt.Sprintf("result %d", i+history.maxResults)
 		if savedResults[i].debugOutput != expectedDebugOutput {
@@ -65,15 +61,8 @@ func TestHistoryPreservesExpiredFailedResults(t *testing.T) {
 	// Failures are expired, should all be preserved
 	FillHistoryWithMaxPreservedFailures(history)
 	savedResults = history.List()
-	savedFailedResults = history.ListPreservedFailures()
-	for i := uint(0); i < uint(len(savedFailedResults)); i++ {
-		expectedDebugOutput := fmt.Sprintf("result %d", i+history.maxResults)
-		if savedFailedResults[i].debugOutput != expectedDebugOutput {
-			t.Errorf("History contained the wrong result at index %d. Expected: %s, Actual: %s", i, expectedDebugOutput, savedResults[i].debugOutput)
-		}
-	}
 	for i := uint(0); i < uint(len(savedResults)); i++ {
-		expectedDebugOutput := fmt.Sprintf("result %d", i+history.maxResults+history.maxPreservedFailedResults)
+		expectedDebugOutput := fmt.Sprintf("result %d", i+history.maxResults)
 		if savedResults[i].debugOutput != expectedDebugOutput {
 			t.Errorf("History contained the wrong result at index %d. Expected: %s, Actual: %s", i, expectedDebugOutput, savedResults[i].debugOutput)
 		}
@@ -83,15 +72,8 @@ func TestHistoryPreservesExpiredFailedResults(t *testing.T) {
 	FillHistoryWithMaxPreservedFailures(history)
 	FillHistoryWithMaxSuccesses(history)
 	savedResults = history.List()
-	savedFailedResults = history.ListPreservedFailures()
-	for i := uint(0); i < uint(len(savedFailedResults)); i++ {
-		expectedDebugOutput := fmt.Sprintf("result %d", i+history.maxResults+history.maxPreservedFailedResults*2)
-		if savedFailedResults[i].debugOutput != expectedDebugOutput {
-			t.Errorf("History contained the wrong result at index %d. Expected: %s, Actual: %s", i, expectedDebugOutput, savedResults[i].debugOutput)
-		}
-	}
 	for i := uint(0); i < uint(len(savedResults)); i++ {
-		expectedDebugOutput := fmt.Sprintf("result %d", i+history.maxResults+history.maxPreservedFailedResults*3)
+		expectedDebugOutput := fmt.Sprintf("result %d", i+history.maxResults*3)
 		if savedResults[i].debugOutput != expectedDebugOutput {
 			t.Errorf("History contained the wrong result at index %d. Expected: %s, Actual: %s", i, expectedDebugOutput, savedResults[i].debugOutput)
 		}

--- a/history_test.go
+++ b/history_test.go
@@ -1,0 +1,99 @@
+// Copyright 2017 The Prometheus Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+import (
+	"fmt"
+	"testing"
+)
+
+func TestHistoryKeepsLatestResults(t *testing.T) {
+	history := &resultHistory{maxResults: 3, maxPreservedFailedResults: 3}
+	for i := 0; i < 4; i++ {
+		history.Add("module", "target", fmt.Sprintf("result %d", i), true)
+	}
+
+	savedResults := history.List()
+	for i := 0; i < len(savedResults); i++ {
+		if savedResults[i].debugOutput != fmt.Sprintf("result %d", i+1) {
+			t.Errorf("History contained the wrong result at index %d", i)
+		}
+	}
+}
+
+func FillHistoryWithMaxSuccesses(h *resultHistory) {
+	for i := uint(0); i < h.maxResults; i++ {
+		h.Add("module", "target", fmt.Sprintf("result %d", h.nextId), true)
+	}
+}
+
+func FillHistoryWithMaxPreservedFailures(h *resultHistory) {
+	for i := uint(0); i < h.maxPreservedFailedResults; i++ {
+		h.Add("module", "target", fmt.Sprintf("result %d", h.nextId), false)
+	}
+}
+
+func TestHistoryPreservesExpiredFailedResults(t *testing.T) {
+	history := &resultHistory{maxResults: 3, maxPreservedFailedResults: 3}
+
+	// Success are expired, no failues are expired
+	FillHistoryWithMaxSuccesses(history)
+	FillHistoryWithMaxPreservedFailures(history)
+	savedResults := history.List()
+	savedFailedResults := history.ListPreservedFailures()
+	if len(savedFailedResults) > 0 {
+		t.Errorf("Preserved failures contains failures unnecessarily.")
+	}
+	for i := uint(0); i < uint(len(savedResults)); i++ {
+		expectedDebugOutput := fmt.Sprintf("result %d", i+history.maxResults)
+		if savedResults[i].debugOutput != expectedDebugOutput {
+			t.Errorf("History contained the wrong result at index %d. Expected: %s, Actual: %s", i, expectedDebugOutput, savedResults[i].debugOutput)
+		}
+	}
+
+	// Failures are expired, should all be preserved
+	FillHistoryWithMaxPreservedFailures(history)
+	savedResults = history.List()
+	savedFailedResults = history.ListPreservedFailures()
+	for i := uint(0); i < uint(len(savedFailedResults)); i++ {
+		expectedDebugOutput := fmt.Sprintf("result %d", i+history.maxResults)
+		if savedFailedResults[i].debugOutput != expectedDebugOutput {
+			t.Errorf("History contained the wrong result at index %d. Expected: %s, Actual: %s", i, expectedDebugOutput, savedResults[i].debugOutput)
+		}
+	}
+	for i := uint(0); i < uint(len(savedResults)); i++ {
+		expectedDebugOutput := fmt.Sprintf("result %d", i+history.maxResults+history.maxPreservedFailedResults)
+		if savedResults[i].debugOutput != expectedDebugOutput {
+			t.Errorf("History contained the wrong result at index %d. Expected: %s, Actual: %s", i, expectedDebugOutput, savedResults[i].debugOutput)
+		}
+	}
+
+	// New expired failures are preserved, new success are not expired
+	FillHistoryWithMaxPreservedFailures(history)
+	FillHistoryWithMaxSuccesses(history)
+	savedResults = history.List()
+	savedFailedResults = history.ListPreservedFailures()
+	for i := uint(0); i < uint(len(savedFailedResults)); i++ {
+		expectedDebugOutput := fmt.Sprintf("result %d", i+history.maxResults+history.maxPreservedFailedResults*2)
+		if savedFailedResults[i].debugOutput != expectedDebugOutput {
+			t.Errorf("History contained the wrong result at index %d. Expected: %s, Actual: %s", i, expectedDebugOutput, savedResults[i].debugOutput)
+		}
+	}
+	for i := uint(0); i < uint(len(savedResults)); i++ {
+		expectedDebugOutput := fmt.Sprintf("result %d", i+history.maxResults+history.maxPreservedFailedResults*3)
+		if savedResults[i].debugOutput != expectedDebugOutput {
+			t.Errorf("History contained the wrong result at index %d. Expected: %s, Actual: %s", i, expectedDebugOutput, savedResults[i].debugOutput)
+		}
+	}
+}

--- a/main.go
+++ b/main.go
@@ -295,7 +295,7 @@ func run() int {
 		preservedFailedResults := rh.ListPreservedFailures()
 
 		for i := len(preservedFailedResults) - 1; i >= 0; i-- {
-			r := results[i]
+			r := preservedFailedResults[i]
 			success := "Success"
 			if !r.success {
 				success = "<strong>Failure</strong>"

--- a/main.go
+++ b/main.go
@@ -46,12 +46,11 @@ var (
 		C: &config.Config{},
 	}
 
-	configFile                  = kingpin.Flag("config.file", "Blackbox exporter configuration file.").Default("blackbox.yml").String()
-	listenAddress               = kingpin.Flag("web.listen-address", "The address to listen on for HTTP requests.").Default(":9115").String()
-	timeoutOffset               = kingpin.Flag("timeout-offset", "Offset to subtract from timeout in seconds.").Default("0.5").Float64()
-	configCheck                 = kingpin.Flag("config.check", "If true validate the config file and then exit.").Default().Bool()
-	historyLimit                = kingpin.Flag("history.limit", "The maximum amount of items to keep in the history.").Default("100").Uint()
-	historyPreservedFailedLimit = kingpin.Flag("history.preserved-failed-limit", "The maximum amount of failed items to preserve after expiration.").Default("5").Uint()
+	configFile    = kingpin.Flag("config.file", "Blackbox exporter configuration file.").Default("blackbox.yml").String()
+	listenAddress = kingpin.Flag("web.listen-address", "The address to listen on for HTTP requests.").Default(":9115").String()
+	timeoutOffset = kingpin.Flag("timeout-offset", "Offset to subtract from timeout in seconds.").Default("0.5").Float64()
+	configCheck   = kingpin.Flag("config.check", "If true validate the config file and then exit.").Default().Bool()
+	historyLimit  = kingpin.Flag("history.limit", "The maximum amount of items to keep in the history.").Default("100").Uint()
 
 	Probers = map[string]prober.ProbeFn{
 		"http": prober.ProbeHTTP,
@@ -201,7 +200,7 @@ func run() int {
 	kingpin.HelpFlag.Short('h')
 	kingpin.Parse()
 	logger := promlog.New(promlogConfig)
-	rh := &resultHistory{maxResults: *historyLimit, maxPreservedFailedResults: *historyPreservedFailedLimit}
+	rh := &resultHistory{maxResults: *historyLimit}
 
 	level.Info(logger).Log("msg", "Starting blackbox_exporter", "version", version.Info())
 	level.Info(logger).Log("msg", "Build context", version.BuildContext())
@@ -280,22 +279,6 @@ func run() int {
 
 		for i := len(results) - 1; i >= 0; i-- {
 			r := results[i]
-			success := "Success"
-			if !r.success {
-				success = "<strong>Failure</strong>"
-			}
-			fmt.Fprintf(w, "<tr><td>%s</td><td>%s</td><td>%s</td><td><a href='logs?id=%d'>Logs</a></td></td>",
-				html.EscapeString(r.moduleName), html.EscapeString(r.target), success, r.id)
-		}
-
-		w.Write([]byte(`</table>
-		<h2>Preserved Failed Probes</h2>
-    <table border='1'><tr><th>Module</th><th>Target</th><th>Result</th><th>Debug</th>`))
-
-		preservedFailedResults := rh.ListPreservedFailures()
-
-		for i := len(preservedFailedResults) - 1; i >= 0; i-- {
-			r := preservedFailedResults[i]
 			success := "Success"
 			if !r.success {
 				success = "<strong>Failure</strong>"

--- a/main.go
+++ b/main.go
@@ -287,8 +287,7 @@ func run() int {
 				html.EscapeString(r.moduleName), html.EscapeString(r.target), success, r.id)
 		}
 
-		w.Write([]byte(`</table>
-		</body>
+		w.Write([]byte(`</table></body>
     </html>`))
 	})
 


### PR DESCRIPTION
This PR adds a new section to the history to hold onto failed probes after they expire from the main history. This allows us to check what debug logs for failed probes in environments with a high rate of successful probes.

I implemented this to be strictly additive for the sake of backwards compatibility. The Web UI has a separate section for these preserved failures.

Resolves #350