### PR TITLE
Change the front page links to probe logs into relative links

### DIFF
--- a/main.go
+++ b/main.go
@@ -324,7 +324,7 @@ func run() int {
 			if !r.success {
 				success = "<strong>Failure</strong>"
 			}
-			fmt.Fprintf(w, "<tr><td>%s</td><td>%s</td><td>%s</td><td><a href='"+path.Join(*routePrefix, "/logs")+"?id=%d'>Logs</a></td></td>",
+			fmt.Fprintf(w, "<tr><td>%s</td><td>%s</td><td>%s</td><td><a href='logs?id=%d'>Logs</a></td></td>",
 				html.EscapeString(r.moduleName), html.EscapeString(r.target), success, r.id)
 		}
 


### PR DESCRIPTION
The front page contains a table of links to logs from the most recent
probes. These links were accidentally changed to absolute links in
252a878, in a form that doesn't work when using --web.external-url.
Rather than prefixing these with the external URL (if set), we return
them to being relative links, as they are meant to be (per issue #519).

Fixes #519

Signed-off-by: Chris Siebenmann <cks.git01@cs.toronto.edu>