### PR TITLE
Make TCP port configurable

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -154,6 +154,7 @@ type QueryResponse struct {
 }
 
 type TCPProbe struct {
+	Port               string           `yaml:"port,omitempty"`
 	IPProtocol         string           `yaml:"preferred_ip_protocol,omitempty"`
 	IPProtocolFallback bool             `yaml:"ip_protocol_fallback,omitempty"`
 	SourceIPAddress    string           `yaml:"source_ip_address,omitempty"`

--- a/prober/tcp.go
+++ b/prober/tcp.go
@@ -90,6 +90,9 @@ func dialTCP(ctx context.Context, target string, module config.Module, registry 
 }
 
 func ProbeTCP(ctx context.Context, target string, module config.Module, registry *prometheus.Registry, logger log.Logger) bool {
+	if _, _, err := net.SplitHostPort(target); err != nil && module.TCP.Port != "" {
+		target = net.JoinHostPort(target, module.TCP.Port)
+	}
 	probeSSLEarliestCertExpiry := prometheus.NewGauge(prometheus.GaugeOpts{
 		Name: "probe_ssl_earliest_cert_expiry",
 		Help: "Returns earliest SSL cert expiry date",


### PR DESCRIPTION
This PR adds a setting for the TCP port. This makes it easier to create probes for generic TCP protocols that have a standard port.

The additional test case is identical to `TestTCPConnection`, but with the port split and added via the configuration.