### PR TITLE
Export TLS version

### DIFF
--- a/prober/tls.go
+++ b/prober/tls.go
@@ -27,3 +27,18 @@ func getEarliestCertExpiry(state *tls.ConnectionState) time.Time {
 	}
 	return earliest
 }
+
+func getTLSVersion(state *tls.ConnectionState) string {
+	switch state.Version {
+	case tls.VersionTLS10:
+		return "TLS 1.0"
+	case tls.VersionTLS11:
+		return "TLS 1.1"
+	case tls.VersionTLS12:
+		return "TLS 1.2"
+	case tls.VersionTLS13:
+		return "TLS 1.3"
+	default:
+		return "unknown"
+	}
+}


### PR DESCRIPTION
This PR adds the TLS version to the exported variables, or NaN when it is unknown (maybe that should be 0 instead?). All currently available TLS versions are covered. SSL3 is not, as it is not TLS and will be removed in Go 1.14 (See https://github.com/golang/go/issues/32716).