### PR TITLE
exclude CA

### DIFF
--- a/prober/tls.go
+++ b/prober/tls.go
@@ -21,7 +21,7 @@ import (
 func getEarliestCertExpiry(state *tls.ConnectionState) time.Time {
 	earliest := time.Time{}
 	for _, cert := range state.PeerCertificates {
-		if (earliest.IsZero() || cert.NotAfter.Before(earliest)) && !cert.NotAfter.IsZero() {
+		if (earliest.IsZero() || cert.NotAfter.Before(earliest)) && !cert.NotAfter.IsZero() && !cert.IsCA {
 			earliest = cert.NotAfter
 		}
 	}


### PR DESCRIPTION
Check the certificate expiration date, exclude the CA authority, and get the last TLS expiration date by default. Sometimes it is the CA authority, and the expiration date of the certificate is not accurate