### PR TITLE
Add http endpoint support

### DIFF
--- a/CONFIGURATION.md
+++ b/CONFIGURATION.md
@@ -45,6 +45,9 @@ The other placeholders are specified separately.
   # The HTTP method the probe will use.
   [ method: <string> | default = "GET" ]
 
+  # Endpint IP (IP or IP:Portand port) to send HTTP requests, skip DNS lookup.
+  [ endpoint: <string> ]
+
   # The HTTP headers set for the probe.
   headers:
     [ <string>: <string> ... ]

--- a/config/config.go
+++ b/config/config.go
@@ -131,6 +131,7 @@ type HTTPProbe struct {
 	NoFollowRedirects            bool                    `yaml:"no_follow_redirects,omitempty"`
 	FailIfSSL                    bool                    `yaml:"fail_if_ssl,omitempty"`
 	FailIfNotSSL                 bool                    `yaml:"fail_if_not_ssl,omitempty"`
+	Endpoint                     string                  `yaml:"endpoint,omitempty"`
 	Method                       string                  `yaml:"method,omitempty"`
 	Headers                      map[string]string       `yaml:"headers,omitempty"`
 	FailIfBodyMatchesRegexp      []string                `yaml:"fail_if_body_matches_regexp,omitempty"`

--- a/example.yml
+++ b/example.yml
@@ -52,6 +52,18 @@ modules:
       method: GET
       tls_config:
         ca_file: "/certs/my_cert.crt"
+  http_2xx_endpoint_example:
+    prober: http
+    timeout: 5s
+    http:
+      endpoint: "1.1.1.1:443"
+      valid_http_versions: ["HTTP/1.1", "HTTP/2"]
+      valid_status_codes: []  # Defaults to 2xx
+      method: GET
+      fail_if_ssl: false
+      fail_if_not_ssl: false
+      preferred_ip_protocol: "ip4" # defaults to "ip6"
+      ip_protocol_fallback: false  # no fallback to "ip6"
   tls_connect:
     prober: tcp
     timeout: 5s


### PR DESCRIPTION
Add support for custom endpoint (IP/Port; skips DNS resolve) to make probes possible in specific and complex environments:

- possiblity to check a service internally even if a public PaaS cloud gateway is in front of it to check outages in the PaaS/network chain -> outage detection using Prometheus service discovery
- checking services behind eg. Cloudflare and send the probes to the server instead to the CDN
- cloud environments where no DNS split horizon is available or not stable (eg. Azure)
- checking if hosts are NOT available on a loadbalancer
- corporate environments where external DNS requests are not allowed

example module configuration:
```
  http_2xx_endpoint_example:
    prober: http
    timeout: 5s
    http:
      endpoint: "1.1.1.1:443"
      valid_http_versions: ["HTTP/1.1", "HTTP/2"]
      valid_status_codes: []  # Defaults to 2xx
      method: GET
      fail_if_ssl: false
      fail_if_not_ssl: false
      preferred_ip_protocol: "ip4" # defaults to "ip6"
      ip_protocol_fallback: false  # no fallback to "ip6"
```