### PR TITLE
Add none/all matches to DNS RRset validation

### DIFF
--- a/CONFIGURATION.md
+++ b/CONFIGURATION.md
@@ -165,7 +165,13 @@ validate_answer_rrs:
   fail_if_matches_regexp:
     [ - <regex>, ... ]
 
+  fail_if_all_match_regexp:
+    [ - <regex>, ... ]
+
   fail_if_not_matches_regexp:
+    [ - <regex>, ... ]
+
+  fail_if_none_matches_regexp:
     [ - <regex>, ... ]
 
 validate_authority_rrs:
@@ -173,7 +179,13 @@ validate_authority_rrs:
   fail_if_matches_regexp:
     [ - <regex>, ... ]
 
+  fail_if_all_match_regexp:
+    [ - <regex>, ... ]
+
   fail_if_not_matches_regexp:
+    [ - <regex>, ... ]
+
+  fail_if_none_matches_regexp:
     [ - <regex>, ... ]
 
 validate_additional_rrs:
@@ -181,7 +193,13 @@ validate_additional_rrs:
   fail_if_matches_regexp:
     [ - <regex>, ... ]
 
+  fail_if_all_match_regexp:
+    [ - <regex>, ... ]
+
   fail_if_not_matches_regexp:
+    [ - <regex>, ... ]
+
+  fail_if_none_matches_regexp:
     [ - <regex>, ... ]
 
 ```

--- a/config/config.go
+++ b/config/config.go
@@ -184,8 +184,10 @@ type DNSProbe struct {
 }
 
 type DNSRRValidator struct {
-	FailIfMatchesRegexp    []string `yaml:"fail_if_matches_regexp,omitempty"`
-	FailIfNotMatchesRegexp []string `yaml:"fail_if_not_matches_regexp,omitempty"`
+	FailIfMatchesRegexp     []string `yaml:"fail_if_matches_regexp,omitempty"`
+	FailIfAllMatchRegexp    []string `yaml:"fail_if_all_match_regexp,omitempty"`
+	FailIfNotMatchesRegexp  []string `yaml:"fail_if_not_matches_regexp,omitempty"`
+	FailIfNoneMatchesRegexp []string `yaml:"fail_if_none_matches_regexp,omitempty"`
 }
 
 // UnmarshalYAML implements the yaml.Unmarshaler interface.

--- a/example.yml
+++ b/example.yml
@@ -112,8 +112,12 @@ modules:
       validate_answer_rrs:
         fail_if_matches_regexp:
         - ".*127.0.0.1"
+        fail_if_all_match_regexp:
+        - ".*127.0.0.1"
         fail_if_not_matches_regexp:
         - "www.prometheus.io.\t300\tIN\tA\t127.0.0.1"
+        fail_if_none_matches_regexp:
+        - "127.0.0.1"
       validate_authority_rrs:
         fail_if_matches_regexp:
         - ".*127.0.0.1"

--- a/prober/dns_test.go
+++ b/prober/dns_test.go
@@ -303,6 +303,26 @@ func TestAuthoritativeDNSResponse(t *testing.T) {
 				},
 			}, false,
 		},
+		{
+			config.DNSProbe{
+				IPProtocol:         "ip4",
+				IPProtocolFallback: true,
+				QueryName:          "example.com",
+				ValidateAdditional: config.DNSRRValidator{
+					FailIfAllMatchRegexp: []string{".*127.0.0.*"},
+				},
+			}, false,
+		},
+		{
+			config.DNSProbe{
+				IPProtocol:         "ip4",
+				IPProtocolFallback: true,
+				QueryName:          "example.com",
+				ValidateAdditional: config.DNSRRValidator{
+					FailIfNoneMatchesRegexp: []string{".*127.0.0.3.*"},
+				},
+			}, false,
+		},
 	}
 
 	for _, protocol := range PROTOCOLS {


### PR DESCRIPTION
The current validators for the DNS probers (if_matches/if_not_matches) pass if _any_ record matches/does not match. This patch adds the opposite sense of each, so that a validation will pass if _no_ records match, or _all_ records match. This is much more useful for example with TXT records where you might want to check if a particular record is present or not without failing if any record does not match.