### PR TITLE
Add cmd probe

### DIFF
--- a/config/config_test.go
+++ b/config/config_test.go
@@ -55,6 +55,18 @@ func TestLoadBadConfigs(t *testing.T) {
 			ConfigFile:    "testdata/invalid-http-header-match.yml",
 			ExpectedError: "error parsing config file: regexp must be set for HTTP header matchers",
 		},
+		{
+			ConfigFile:    "testdata/blackbox-bad3.yml",
+			ExpectedError: "error parsing config file: cmdline must be configured",
+		},
+		{
+			ConfigFile:    "testdata/blackbox-bad4.yml",
+			ExpectedError: "error parsing config file: shell mode can only be used on bash or sh executable",
+		},
+		{
+			ConfigFile:    "testdata/blackbox-bad5.yml",
+			ExpectedError: "error parsing config file: scriptPath must be set for script mode",
+		},
 	}
 	for i, test := range tests {
 		err := sc.ReloadConfig(test.ConfigFile)

--- a/config/testdata/blackbox-bad3.yml
+++ b/config/testdata/blackbox-bad3.yml
@@ -1,0 +1,6 @@
+modules:
+  cmd_test:
+    prober: cmd
+    timeout: 2s
+    cmd:
+      executable: "/bin/bash"

--- a/config/testdata/blackbox-bad4.yml
+++ b/config/testdata/blackbox-bad4.yml
@@ -1,0 +1,10 @@
+modules:
+  cmd_test_2:
+    prober: cmd
+    timeout: 2s
+    cmd:
+      scriptMode: false
+      executable: "/usr/local/bin/ruby"
+      scriptPath: "/tmp/ruby_script.rb"
+      cmdline:
+        - "abc"

--- a/config/testdata/blackbox-bad5.yml
+++ b/config/testdata/blackbox-bad5.yml
@@ -1,0 +1,9 @@
+modules:
+  cmd_test_2:
+    prober: cmd
+    timeout: 2s
+    cmd:
+      scriptMode: true
+      executable: "/usr/local/bin/ruby"
+      cmdline:
+        - "abc"

--- a/config/testdata/blackbox-good.yml
+++ b/config/testdata/blackbox-good.yml
@@ -77,3 +77,10 @@ modules:
         - header: Access-Control-Allow-Origin
           regexp: '(\*|example\.com)'
           allow_missing: false
+  cmd_test:
+    prober: cmd
+    timeout: 2s
+    cmd:
+      cmdline:
+        - "echo 1"
+      executable: "/bin/bash"

--- a/main.go
+++ b/main.go
@@ -64,6 +64,7 @@ var (
 		"tcp":  prober.ProbeTCP,
 		"icmp": prober.ProbeICMP,
 		"dns":  prober.ProbeDNS,
+		"cmd":  prober.ProbeCMD,
 	}
 )
 

--- a/prober/cmd.go
+++ b/prober/cmd.go
@@ -1,0 +1,49 @@
+// Copyright 2016 The Prometheus Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package prober
+
+import (
+	"context"
+	"github.com/go-kit/kit/log"
+	"github.com/go-kit/kit/log/level"
+	"github.com/prometheus/blackbox_exporter/config"
+	"github.com/prometheus/client_golang/prometheus"
+)
+
+func executeCMD(module config.Module, logger log.Logger) (executeResult float64, err error) {
+	executeResult, err = executeCmd(module.CMD, module.Timeout)
+	if err != nil {
+		level.Error(logger).Log("msg", "Error execute cmdline", "err", err)
+		return executeResult, err
+	}
+	return executeResult, nil
+}
+
+func ProbeCMD(_ context.Context, _ string, module config.Module, registry *prometheus.Registry, logger log.Logger) bool {
+	probeCMDExecuteResult := prometheus.NewGauge(prometheus.GaugeOpts{
+		Name: "probe_cmd_execute_result",
+		Help: "Returns cmdline executed result",
+	})
+	registry.MustRegister(probeCMDExecuteResult)
+
+	executeResult, err := executeCMD(module, logger)
+	if err != nil {
+		level.Error(logger).Log("msg", "Error execute CMD", "err", err)
+		probeCMDExecuteResult.Set(executeResult)
+		return false
+	}
+	level.Info(logger).Log("msg", "Successfully executed")
+	probeCMDExecuteResult.Set(executeResult)
+	return true
+}


### PR DESCRIPTION
Add cmd probe. Allows users scrape metrics by execute their specified commands. Now you only need to modify part of the configuration file.