### PR TITLE
Change default user agent

### DIFF
--- a/prober/http.go
+++ b/prober/http.go
@@ -227,7 +227,7 @@ func (t *transport) GotFirstResponseByte() {
 	t.current.responseStart = time.Now()
 }
 
-var userAgentDefaultHeader = fmt.Sprintf("BlackBox Exporter/%s", version.Version)
+var userAgentDefaultHeader = fmt.Sprintf("Blackbox Exporter/%s", version.Version)
 
 func ProbeHTTP(ctx context.Context, target string, module config.Module, registry *prometheus.Registry, logger log.Logger) (success bool) {
 	var redirects int
@@ -406,7 +406,8 @@ func ProbeHTTP(ctx context.Context, target string, module config.Module, registr
 		request.Header.Set(key, value)
 	}
 
-	if request.Header.Get("User-Agent") == "" {
+	_, hasUserAgent := request.Header["User-Agent"]
+	if !hasUserAgent {
 		request.Header.Set("User-Agent", userAgentDefaultHeader)
 	}
 

--- a/prober/http.go
+++ b/prober/http.go
@@ -35,6 +35,7 @@ import (
 	"github.com/go-kit/kit/log/level"
 	"github.com/prometheus/client_golang/prometheus"
 	pconfig "github.com/prometheus/common/config"
+	"github.com/prometheus/common/version"
 	"golang.org/x/net/publicsuffix"
 
 	"github.com/prometheus/blackbox_exporter/config"
@@ -226,6 +227,8 @@ func (t *transport) GotFirstResponseByte() {
 	t.current.responseStart = time.Now()
 }
 
+var userAgentDefaultHeader = fmt.Sprintf("BlackBox Exporter/%s", version.Version)
+
 func ProbeHTTP(ctx context.Context, target string, module config.Module, registry *prometheus.Registry, logger log.Logger) (success bool) {
 	var redirects int
 	var (
@@ -401,6 +404,10 @@ func ProbeHTTP(ctx context.Context, target string, module config.Module, registr
 			continue
 		}
 		request.Header.Set(key, value)
+	}
+
+	if request.Header.Get("User-Agent") == "" {
+		request.Header.Set("User-Agent", userAgentDefaultHeader)
 	}
 
 	trace := &httptrace.ClientTrace{


### PR DESCRIPTION
Hello.

According to prometheus scrape behavior [here](https://github.com/prometheus/prometheus/blob/48d25e6fe7d960c76c01763303c38f11168b1bba/scrape/scrape.go#L520) Change default go http client user-agent
from "Go-http-client/1.1" to "BlackBox Exporter/{{ version }}"

Issue : https://github.com/prometheus/blackbox_exporter/issues/555
Maintainers : @brian-brazil
