### PR TITLE
Skip network dependent test in short mode

### DIFF
--- a/prober/http_test.go
+++ b/prober/http_test.go
@@ -651,7 +651,7 @@ func TestHTTPUsesTargetAsTLSServerName(t *testing.T) {
 
 func TestRedirectToTLSHostWorks(t *testing.T) {
 	if testing.Short() {
-		t.Skip("skipping network dependant test")
+		t.Skip("skipping network dependent test")
 	}
 	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		http.Redirect(w, r, "https://prometheus.io", http.StatusFound)

--- a/prober/utils_test.go
+++ b/prober/utils_test.go
@@ -117,6 +117,9 @@ func generateTestCertificate(expiry time.Time, IPAddressSAN bool) ([]byte, []byt
 }
 
 func TestChooseProtocol(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping network dependent test")
+	}
 	ctx := context.Background()
 	registry := prometheus.NewPedanticRegistry()
 	w := log.NewSyncWriter(os.Stderr)


### PR DESCRIPTION
Skip the network-dependent `TestChooseProtocol` test when testing in short mode. Also fix spelling of "dependent" elsewhere in tests.