### PR TITLE
Don't init http phase values

### DIFF
--- a/prober/http.go
+++ b/prober/http.go
@@ -288,10 +288,6 @@ func ProbeHTTP(ctx context.Context, target string, module config.Module, registr
 		})
 	)
 
-	for _, lv := range []string{"resolve", "connect", "tls", "processing", "transfer"} {
-		durationGaugeVec.WithLabelValues(lv)
-	}
-
 	registry.MustRegister(durationGaugeVec)
 	registry.MustRegister(contentLengthGauge)
 	registry.MustRegister(bodyUncompressedLengthGauge)


### PR DESCRIPTION
Don't init http probe phase labels for phases we haven't observed.
Avoids exposing 0 value samples for things we haven't measured.

Fixes: https://github.com/prometheus/blackbox_exporter/issues/579

Signed-off-by: Ben Kochie <superq@gmail.com>