### PR TITLE
add probe_ip_addr_hash to detect if the IP changes

### DIFF
--- a/prober/utils.go
+++ b/prober/utils.go
@@ -39,18 +39,12 @@ func chooseProtocol(ctx context.Context, IPProtocol string, fallbackIPProtocol b
 		Help: "Specifies whether probe ip protocol is IP4 or IP6",
 	})
 
-	probeIPAddr := prometheus.NewGaugeVec(prometheus.GaugeOpts{
-		Name: "probe_ip_addr",
-		Help: "Specifies the IP address",
-	}, []string{"ip"})
-
 	probeIPAddrHash := prometheus.NewGauge(prometheus.GaugeOpts{
 		Name: "probe_ip_addr_hash",
 		Help: "Specifies the hash of IP address. It's useful to detect if the IP address changes.",
 	})
 	registry.MustRegister(probeIPProtocolGauge)
 	registry.MustRegister(probeDNSLookupTimeSeconds)
-	registry.MustRegister(probeIPAddr)
 	registry.MustRegister(probeIPAddrHash)
 
 	if IPProtocol == "ip6" || IPProtocol == "" {
@@ -84,7 +78,6 @@ func chooseProtocol(ctx context.Context, IPProtocol string, fallbackIPProtocol b
 			if ip.IP.To4() != nil {
 				level.Info(logger).Log("msg", "Resolved target address", "ip", ip.String())
 				probeIPProtocolGauge.Set(4)
-				probeIPAddr.WithLabelValues(ip.String()).Set(0)
 				probeIPAddrHash.Set(ipHash(ip.IP))
 				return &ip, lookupTime, nil
 			}
@@ -96,7 +89,6 @@ func chooseProtocol(ctx context.Context, IPProtocol string, fallbackIPProtocol b
 			if ip.IP.To4() == nil {
 				level.Info(logger).Log("msg", "Resolved target address", "ip", ip.String())
 				probeIPProtocolGauge.Set(6)
-				probeIPAddr.WithLabelValues(ip.String()).Set(0)
 				probeIPAddrHash.Set(ipHash(ip.IP))
 				return &ip, lookupTime, nil
 			}
@@ -117,7 +109,6 @@ func chooseProtocol(ctx context.Context, IPProtocol string, fallbackIPProtocol b
 	} else {
 		probeIPProtocolGauge.Set(6)
 	}
-	probeIPAddr.WithLabelValues(fallback.String()).Set(0)
 	probeIPAddrHash.Set(ipHash(fallback.IP))
 	level.Info(logger).Log("msg", "Resolved target address", "ip", fallback.String())
 	return fallback, lookupTime, nil

--- a/prober/utils.go
+++ b/prober/utils.go
@@ -37,8 +37,14 @@ func chooseProtocol(ctx context.Context, IPProtocol string, fallbackIPProtocol b
 		Name: "probe_ip_protocol",
 		Help: "Specifies whether probe ip protocol is IP4 or IP6",
 	})
+
+	probeIPAddrHash := prometheus.NewGauge(prometheus.GaugeOpts{
+		Name: "probe_ip_addr_hash",
+		Help: "Specifies the hash of IP address. It's useful to detect if the IP address changes.",
+	})
 	registry.MustRegister(probeIPProtocolGauge)
 	registry.MustRegister(probeDNSLookupTimeSeconds)
+	registry.MustRegister(probeIPAddrHash)
 
 	if IPProtocol == "ip6" || IPProtocol == "" {
 		IPProtocol = "ip6"
@@ -71,6 +77,7 @@ func chooseProtocol(ctx context.Context, IPProtocol string, fallbackIPProtocol b
 			if ip.IP.To4() != nil {
 				level.Info(logger).Log("msg", "Resolved target address", "ip", ip.String())
 				probeIPProtocolGauge.Set(4)
+				probeIPAddrHash.Set(ipHash(ip.IP))
 				return &ip, lookupTime, nil
 			}
 
@@ -81,6 +88,7 @@ func chooseProtocol(ctx context.Context, IPProtocol string, fallbackIPProtocol b
 			if ip.IP.To4() == nil {
 				level.Info(logger).Log("msg", "Resolved target address", "ip", ip.String())
 				probeIPProtocolGauge.Set(6)
+				probeIPAddrHash.Set(ipHash(ip.IP))
 				return &ip, lookupTime, nil
 			}
 
@@ -100,6 +108,15 @@ func chooseProtocol(ctx context.Context, IPProtocol string, fallbackIPProtocol b
 	} else {
 		probeIPProtocolGauge.Set(6)
 	}
+	probeIPAddrHash.Set(ipHash(fallback.IP))
 	level.Info(logger).Log("msg", "Resolved target address", "ip", fallback.String())
 	return fallback, lookupTime, nil
+}
+
+func ipHash(ip net.IP) float64 {
+	var hash uint32
+	for _, b := range ip {
+		hash = 31*hash + uint32(b)
+	}
+	return float64(hash)
 }


### PR DESCRIPTION
## WHAT

add `probe_ip_addr_hash` metrics to specify the hash of IP address

## WHY

We want to detect if the IP is changed by `change(probe_ip_addr_hash[10h])`

### Use Case

Assume you use CDN and you want to monitoring your web server.

```
blackbox_exporter --> CDN edge server --> origin server
```

if the edge server failover, blackbox exporter returns error and the IP address will be changed.
With `probe_ip_addr_hash`, we can tell the error happen due to edge failover.
