### PR TITLE
Add password file field to document

### DIFF
--- a/CONFIGURATION.md
+++ b/CONFIGURATION.md
@@ -82,6 +82,7 @@ The other placeholders are specified separately.
   basic_auth:
     [ username: <string> ]
     [ password: <secret> ]
+    [ password_file: <filename> ]
 
   # The bearer token for the targets.
   [ bearer_token: <secret> ]


### PR DESCRIPTION
## Summary

- Add `password_file` field to document of http probe.
- Ref. https://github.com/prometheus/blackbox_exporter/blob/v0.16.0/vendor/github.com/prometheus/common/config/http_config.go#L43