### PR TITLE
Ignore DNAME records while validating RRs.

### DIFF
--- a/prober/dns.go
+++ b/prober/dns.go
@@ -43,6 +43,11 @@ func validRRs(rrs *[]dns.RR, v *config.DNSRRValidator, logger log.Logger) bool {
 	}
 	for _, rr := range *rrs {
 		level.Info(logger).Log("msg", "Validating RR", "rr", rr)
+		// Ignore DNAMEs as they likely won't match with regexp
+		if rr.Header().Rrtype == dns.TypeDNAME {
+			level.Debug(logger).Log("msg", "Ignoging DNAME record", "rr", rr.String())
+			continue
+		}
 		for _, re := range v.FailIfMatchesRegexp {
 			match, err := regexp.MatchString(re, rr.String())
 			if err != nil {


### PR DESCRIPTION
We ran into a little answer RR validation when DNAME records are involved when doing some dns checking. Configuration was:

```
modules:
  testaroo:
    prober: dns
    timeout: 5s
    dns:
        ip_protocol_fallback: true
        query_name: druid-broker-central.query.consul
        query_type: A
        valid_rcodes:
          - NOERROR
        validate_answer_rrs:
            fail_if_not_matches_regexp:
              - .*broker.*
```


At the time of testing, the record is valid and should not fail:

```
$ host druid-broker-central.query.consul
consul has DNAME record consul.preprod.bigcorp.in.
druid-broker-central.query.consul is an alias for druid-broker-central.query.consul.preprod.bigcorp.in.
druid-broker-central.query.consul.preprod.bigcorp.in has address 10.224.44.73
```

However, the blackbox check fails, and the failure is related to the DNAME record which doesn't match the configured **.*broker.*** regexp:

```
$ ./blackbox_exporter --config.file=test.yml --log.level=debug
|...]
ts=2020-05-10T09:45:16.460Z caller=main.go:169 module=testaroo target=ns06-par.central.bigcorp.prod level=debug msg="Validating Answer RRs"
ts=2020-05-10T09:45:16.460Z caller=main.go:169 module=testaroo target=ns06-par.central.bigcorp.prod level=debug msg="Validating RR" rr="druid-broker-central.query.consul.\t490\tIN\tCNAME\tdruid-broker-central.query.consul.prod.bigcorp.in."
ts=2020-05-10T09:45:16.460Z caller=main.go:169 module=testaroo target=ns06-par.central.bigcorp.prod level=debug msg="Validating RR" rr="consul.\t490\tIN\tDNAME\tconsul.prod.bigcorp.in."
ts=2020-05-10T09:45:16.460Z caller=main.go:169 module=testaroo target=ns06-par.central.bigcorp.prod level=debug msg="At least one RR did not match regexp" regexp=.*broker.* rr="consul.\t490\tIN\tDNAME\tconsul.prod.bigcorp.in."
ts=2020-05-10T09:45:16.460Z caller=main.go:169 module=testaroo target=ns06-par.central.bigcorp.prod level=debug msg="Answer RRs validation failed"
ts=2020-05-10T09:45:16.460Z caller=main.go:169 module=testaroo target=ns06-par.central.bigcorp.prod level=debug msg="Probe failed" duration_seconds=0.023089678
```

The patch I propose in this PR is about ignoring with a debug message the DNAME record when checking. With the fix, the result is somewhat better:

```
ts=2020-05-10T09:50:55.155Z caller=main.go:169 module=testaroo target=ns06-par.central.bigcorp.prod level=debug msg="Validating Answer RRs"
ts=2020-05-10T09:50:55.155Z caller=main.go:169 module=testaroo target=ns06-par.central.bigcorp.prod level=debug msg="Validating RR" rr="druid-broker-central.query.consul.\t151\tIN\tCNAME\tdruid-broker-central.query.consul.prod.bigcorp.in."
ts=2020-05-10T09:50:55.155Z caller=main.go:169 module=testaroo target=ns06-par.central.bigcorp.prod level=debug msg="Validating RR" rr="druid-broker-central.query.consul.prod.bigcorp.in.\t3\tIN\tA\t10.224.122.28"
ts=2020-05-10T09:50:55.155Z caller=main.go:169 module=testaroo target=ns06-par.central.bigcorp.prod level=debug msg="Validating RR" rr="consul.\t151\tIN\tDNAME\tconsul.prod.bigcorp.in."
ts=2020-05-10T09:50:55.155Z caller=main.go:169 module=testaroo target=ns06-par.central.bigcorp.prod level=debug msg="Ignoging DNAME record" rr="consul.\t151\tIN\tDNAME\tconsul.prod.bigcorp.in."
ts=2020-05-10T09:50:55.155Z caller=main.go:169 module=testaroo target=ns06-par.central.bigcorp.prod level=debug msg="Validating Authority RRs"
ts=2020-05-10T09:50:55.155Z caller=main.go:169 module=testaroo target=ns06-par.central.bigcorp.prod level=debug msg="Validating Additional RRs"
ts=2020-05-10T09:50:55.156Z caller=main.go:169 module=testaroo target=ns06-par.central.bigcorp.prod level=debug msg="Probe succeeded" duration_seconds=0.016174402
```

Regards.


