### PR TITLE
Keep blackbox exporter's address in instance label

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,7 +84,7 @@ scrape_configs:
       - source_labels: [__address__]
         target_label: __param_target
       - source_labels: [__param_target]
-        target_label: instance
+        target_label: target
       - target_label: __address__
         replacement: 127.0.0.1:9115  # The blackbox exporter's real hostname:port.
 ```


### PR DESCRIPTION
This avoids conflicts when two instances of the blackbox exporter are probing the same target.