### PR TITLE
Fix the HTTP/2 example

### DIFF
--- a/example.yml
+++ b/example.yml
@@ -3,7 +3,7 @@ modules:
     prober: http
     timeout: 5s
     http:
-      valid_http_versions: ["HTTP/1.1", "HTTP/2"]
+      valid_http_versions: ["HTTP/1.1", "HTTP/2.0"]
       valid_status_codes: []  # Defaults to 2xx
       method: GET
       headers:

--- a/prober/http_test.go
+++ b/prober/http_test.go
@@ -74,8 +74,8 @@ func TestValidHTTPVersion(t *testing.T) {
 	}{
 		{[]string{}, true},
 		{[]string{"HTTP/1.1"}, true},
-		{[]string{"HTTP/1.1", "HTTP/2"}, true},
-		{[]string{"HTTP/2"}, false},
+		{[]string{"HTTP/1.1", "HTTP/2.0"}, true},
+		{[]string{"HTTP/2.0"}, false},
 	}
 	for i, test := range tests {
 		ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {


### PR DESCRIPTION
I spent some time trying to understand why I was getting errors like `msg="Invalid HTTP version number" version=2` while my config looked fine: `valid_http_versions: ["HTTP/1.1", "HTTP/2"]`.

Turns out that HTTP/2 is not called HTTP/2 but HTTP/2.0 in the golang HTTP client, so this fixes the example to showcase that.