### PR TITLE
[dns] Allow to specify query Class

### DIFF
--- a/CONFIGURATION.md
+++ b/CONFIGURATION.md
@@ -156,6 +156,7 @@ tls_config:
 query_name: <string>
 
 [ query_type: <string> | default = "ANY" ]
+[ query_class: <string> | default = "IN" ]
 
 # List of valid response codes.
 valid_rcodes:

--- a/config/config.go
+++ b/config/config.go
@@ -175,6 +175,7 @@ type DNSProbe struct {
 	IPProtocolFallback bool           `yaml:"ip_protocol_fallback,omitempty"`
 	SourceIPAddress    string         `yaml:"source_ip_address,omitempty"`
 	TransportProtocol  string         `yaml:"transport_protocol,omitempty"`
+	QueryClass         string         `yaml:"query_class,omitempty"` // Defaults to IN.
 	QueryName          string         `yaml:"query_name,omitempty"`
 	QueryType          string         `yaml:"query_type,omitempty"`   // Defaults to ANY.
 	ValidRcodes        []string       `yaml:"valid_rcodes,omitempty"` // Defaults to NOERROR.

--- a/config/config.go
+++ b/config/config.go
@@ -23,6 +23,7 @@ import (
 
 	yaml "gopkg.in/yaml.v3"
 
+	"github.com/miekg/dns"
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/common/config"
 )
@@ -233,6 +234,17 @@ func (s *DNSProbe) UnmarshalYAML(unmarshal func(interface{}) error) error {
 	if s.QueryName == "" {
 		return errors.New("query name must be set for DNS module")
 	}
+	if s.QueryClass != "" {
+		if _, ok := dns.StringToClass[s.QueryClass]; !ok {
+			return fmt.Errorf("query class '%s' is not valid", s.QueryClass)
+		}
+	}
+	if s.QueryType != "" {
+		if _, ok := dns.StringToType[s.QueryType]; !ok {
+			return fmt.Errorf("query type '%s' is not valid", s.QueryType)
+		}
+	}
+
 	return nil
 }
 

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -52,6 +52,14 @@ func TestLoadBadConfigs(t *testing.T) {
 			ExpectedError: "error parsing config file: query name must be set for DNS module",
 		},
 		{
+			ConfigFile:    "testdata/invalid-dns-class.yml",
+			ExpectedError: "error parsing config file: query class 'X' is not valid",
+		},
+		{
+			ConfigFile:    "testdata/invalid-dns-type.yml",
+			ExpectedError: "error parsing config file: query type 'X' is not valid",
+		},
+		{
 			ConfigFile:    "testdata/invalid-http-header-match.yml",
 			ExpectedError: "error parsing config file: regexp must be set for HTTP header matchers",
 		},

--- a/config/testdata/invalid-dns-class.yml
+++ b/config/testdata/invalid-dns-class.yml
@@ -1,0 +1,8 @@
+modules:
+  dns_test:
+    prober: dns
+    timeout: 5s
+    dns:
+      query_name: example.com
+      query_class: X
+      query_type: A

--- a/config/testdata/invalid-dns-type.yml
+++ b/config/testdata/invalid-dns-type.yml
@@ -1,0 +1,8 @@
+modules:
+  dns_test:
+    prober: dns
+    timeout: 5s
+    dns:
+      query_name: example.com
+      query_class: CH
+      query_type: X


### PR DESCRIPTION
**Context**
In some cases we might want to probe other DNS class than the INET one; for instance we could probe the server version often exposed in a `TXT CH version.bind` record.

This PR offers the ability to do so by setting `query_class` in your prober configuration, the default is `"IN"` as it was before.

**Implementation note**
Most of the code is a copy/paste/replace of the `query_type` setting; except that the `setQuestion` call has been replaced by its "[slightly more verbose, but more flexible](https://godoc.org/github.com/miekg/dns)" alternative.