### PR TITLE
Add new probe_ssl_latest_verified_chain_expiry metric

### DIFF
--- a/prober/http.go
+++ b/prober/http.go
@@ -551,13 +551,10 @@ func ProbeHTTP(ctx context.Context, target string, module config.Module, registr
 
 	if resp.TLS != nil {
 		isSSLGauge.Set(float64(1))
-		registry.MustRegister(probeSSLEarliestCertExpiryGauge, probeTLSVersion)
+		registry.MustRegister(probeSSLEarliestCertExpiryGauge, probeTLSVersion, probeSSLLastChainExpiryTimestampSeconds)
 		probeSSLEarliestCertExpiryGauge.Set(float64(getEarliestCertExpiry(resp.TLS).Unix()))
 		probeTLSVersion.WithLabelValues(getTLSVersion(resp.TLS)).Set(1)
-		if lastChainExpiry, ok := getLastChainExpiry(resp.TLS); ok {
-			registry.MustRegister(probeSSLLastChainExpiryTimestampSeconds)
-			probeSSLLastChainExpiryTimestampSeconds.Set(float64(lastChainExpiry.Unix()))
-		}
+		probeSSLLastChainExpiryTimestampSeconds.Set(float64(getLastChainExpiry(resp.TLS).Unix()))
 		if httpConfig.FailIfSSL {
 			level.Error(logger).Log("msg", "Final request was over SSL")
 			success = false

--- a/prober/http.go
+++ b/prober/http.go
@@ -261,9 +261,9 @@ func ProbeHTTP(ctx context.Context, target string, module config.Module, registr
 			Help: "Returns earliest SSL cert expiry in unixtime",
 		})
 
-		probeSSLLatestVerifiedChainExpiryGauge = prometheus.NewGauge(prometheus.GaugeOpts{
-			Name: "probe_ssl_latest_verified_chain_expiry",
-			Help: "Returns latest SSL verified chain expiry in unixtime",
+		probeSSLLastChainExpiryTimestampSeconds = prometheus.NewGauge(prometheus.GaugeOpts{
+			Name: "probe_ssl_last_chain_expiry_timestamp_seconds",
+			Help: "Returns last SSL chain expiry in timestamp seconds",
 		})
 
 		probeTLSVersion = prometheus.NewGaugeVec(
@@ -551,9 +551,9 @@ func ProbeHTTP(ctx context.Context, target string, module config.Module, registr
 
 	if resp.TLS != nil {
 		isSSLGauge.Set(float64(1))
-		registry.MustRegister(probeSSLEarliestCertExpiryGauge, probeSSLLatestVerifiedChainExpiryGauge, probeTLSVersion)
+		registry.MustRegister(probeSSLEarliestCertExpiryGauge, probeSSLLastChainExpiryTimestampSeconds, probeTLSVersion)
 		probeSSLEarliestCertExpiryGauge.Set(float64(getEarliestCertExpiry(resp.TLS).Unix()))
-		probeSSLLatestVerifiedChainExpiryGauge.Set(float64(getLatestVerifiedChainExpiry(resp.TLS).Unix()))
+		probeSSLLastChainExpiryTimestampSeconds.Set(float64(getLastChainExpiry(resp.TLS).Unix()))
 		probeTLSVersion.WithLabelValues(getTLSVersion(resp.TLS)).Set(1)
 		if httpConfig.FailIfSSL {
 			level.Error(logger).Log("msg", "Final request was over SSL")

--- a/prober/tcp.go
+++ b/prober/tcp.go
@@ -94,9 +94,9 @@ func ProbeTCP(ctx context.Context, target string, module config.Module, registry
 		Name: "probe_ssl_earliest_cert_expiry",
 		Help: "Returns earliest SSL cert expiry date",
 	})
-	probeSSLLatestVerifiedChainExpiry := prometheus.NewGauge(prometheus.GaugeOpts{
-		Name: "probe_ssl_latest_verified_chain_expiry",
-		Help: "Returns latest SSL verified chain expiry date",
+	probeSSLLastChainExpiryTimestampSeconds := prometheus.NewGauge(prometheus.GaugeOpts{
+		Name: "probe_ssl_last_chain_expiry_timestamp_seconds",
+		Help: "Returns last SSL chain expiry in timestamp seconds",
 	})
 	probeTLSVersion := prometheus.NewGaugeVec(
 		prometheus.GaugeOpts{
@@ -129,9 +129,9 @@ func ProbeTCP(ctx context.Context, target string, module config.Module, registry
 	}
 	if module.TCP.TLS {
 		state := conn.(*tls.Conn).ConnectionState()
-		registry.MustRegister(probeSSLEarliestCertExpiry, probeSSLLatestVerifiedChainExpiry, probeTLSVersion)
+		registry.MustRegister(probeSSLEarliestCertExpiry, probeSSLLastChainExpiryTimestampSeconds, probeTLSVersion)
 		probeSSLEarliestCertExpiry.Set(float64(getEarliestCertExpiry(&state).Unix()))
-		probeSSLLatestVerifiedChainExpiry.Set(float64(getLatestVerifiedChainExpiry(&state).Unix()))
+		probeSSLLastChainExpiryTimestampSeconds.Set(float64(getLastChainExpiry(&state).Unix()))
 		probeTLSVersion.WithLabelValues(getTLSVersion(&state)).Set(1)
 	}
 	scanner := bufio.NewScanner(conn)

--- a/prober/tcp.go
+++ b/prober/tcp.go
@@ -94,6 +94,10 @@ func ProbeTCP(ctx context.Context, target string, module config.Module, registry
 		Name: "probe_ssl_earliest_cert_expiry",
 		Help: "Returns earliest SSL cert expiry date",
 	})
+	probeSSLLatestVerifiedChainExpiry := prometheus.NewGauge(prometheus.GaugeOpts{
+		Name: "probe_ssl_latest_verified_chain_expiry",
+		Help: "Returns latest SSL verified chain expiry date",
+	})
 	probeTLSVersion := prometheus.NewGaugeVec(
 		prometheus.GaugeOpts{
 			Name: "probe_tls_version_info",
@@ -125,8 +129,9 @@ func ProbeTCP(ctx context.Context, target string, module config.Module, registry
 	}
 	if module.TCP.TLS {
 		state := conn.(*tls.Conn).ConnectionState()
-		registry.MustRegister(probeSSLEarliestCertExpiry, probeTLSVersion)
+		registry.MustRegister(probeSSLEarliestCertExpiry, probeSSLLatestVerifiedChainExpiry, probeTLSVersion)
 		probeSSLEarliestCertExpiry.Set(float64(getEarliestCertExpiry(&state).Unix()))
+		probeSSLLatestVerifiedChainExpiry.Set(float64(getLatestVerifiedChainExpiry(&state).Unix()))
 		probeTLSVersion.WithLabelValues(getTLSVersion(&state)).Set(1)
 	}
 	scanner := bufio.NewScanner(conn)

--- a/prober/tcp.go
+++ b/prober/tcp.go
@@ -206,6 +206,12 @@ func ProbeTCP(ctx context.Context, target string, module config.Module, registry
 			registry.MustRegister(probeSSLEarliestCertExpiry)
 			probeSSLEarliestCertExpiry.Set(float64(getEarliestCertExpiry(&state).Unix()))
 			probeTLSVersion.WithLabelValues(getTLSVersion(&state)).Set(1)
+
+			if lastChainExpiry, ok := getLastChainExpiry(&state); ok {
+				registry.MustRegister(probeSSLLastChainExpiryTimestampSeconds)
+				probeSSLLastChainExpiryTimestampSeconds.Set(float64(lastChainExpiry.Unix()))
+			}
+
 		}
 	}
 	return true

--- a/prober/tcp.go
+++ b/prober/tcp.go
@@ -129,14 +129,10 @@ func ProbeTCP(ctx context.Context, target string, module config.Module, registry
 	}
 	if module.TCP.TLS {
 		state := conn.(*tls.Conn).ConnectionState()
-		registry.MustRegister(probeSSLEarliestCertExpiry, probeTLSVersion)
+		registry.MustRegister(probeSSLEarliestCertExpiry, probeTLSVersion, probeSSLLastChainExpiryTimestampSeconds)
 		probeSSLEarliestCertExpiry.Set(float64(getEarliestCertExpiry(&state).Unix()))
 		probeTLSVersion.WithLabelValues(getTLSVersion(&state)).Set(1)
-
-		if lastChainExpiry, ok := getLastChainExpiry(&state); ok {
-			registry.MustRegister(probeSSLLastChainExpiryTimestampSeconds)
-			probeSSLLastChainExpiryTimestampSeconds.Set(float64(lastChainExpiry.Unix()))
-		}
+		probeSSLLastChainExpiryTimestampSeconds.Set(float64(getLastChainExpiry(&state).Unix()))
 	}
 	scanner := bufio.NewScanner(conn)
 	for i, qr := range module.TCP.QueryResponse {
@@ -203,15 +199,10 @@ func ProbeTCP(ctx context.Context, target string, module config.Module, registry
 
 			// Get certificate expiry.
 			state := tlsConn.ConnectionState()
-			registry.MustRegister(probeSSLEarliestCertExpiry)
+			registry.MustRegister(probeSSLEarliestCertExpiry, probeSSLLastChainExpiryTimestampSeconds)
 			probeSSLEarliestCertExpiry.Set(float64(getEarliestCertExpiry(&state).Unix()))
 			probeTLSVersion.WithLabelValues(getTLSVersion(&state)).Set(1)
-
-			if lastChainExpiry, ok := getLastChainExpiry(&state); ok {
-				registry.MustRegister(probeSSLLastChainExpiryTimestampSeconds)
-				probeSSLLastChainExpiryTimestampSeconds.Set(float64(lastChainExpiry.Unix()))
-			}
-
+			probeSSLLastChainExpiryTimestampSeconds.Set(float64(getLastChainExpiry(&state).Unix()))
 		}
 	}
 	return true

--- a/prober/tcp.go
+++ b/prober/tcp.go
@@ -96,7 +96,7 @@ func ProbeTCP(ctx context.Context, target string, module config.Module, registry
 	})
 	probeSSLLastChainExpiryTimestampSeconds := prometheus.NewGauge(prometheus.GaugeOpts{
 		Name: "probe_ssl_last_chain_expiry_timestamp_seconds",
-		Help: "Returns last SSL chain expiry in timestamp seconds",
+		Help: "Returns last SSL chain expiry in unixtime",
 	})
 	probeTLSVersion := prometheus.NewGaugeVec(
 		prometheus.GaugeOpts{

--- a/prober/tcp_test.go
+++ b/prober/tcp_test.go
@@ -331,26 +331,6 @@ func TestTCPConnectionWithTLSAndVerifiedCertificateChain(t *testing.T) {
 		"probe_tls_version_info":                        1,
 	}
 	checkRegistryResults(expectedResults, mfs, t)
-
-	module.TCP.TLSConfig.InsecureSkipVerify = true
-
-	registry = prometheus.NewRegistry()
-	go serverFunc()
-	if !ProbeTCP(testCTX, target, module, registry, log.NewNopLogger()) {
-		t.Fatalf("TCP module failed, expected success.")
-	}
-	<-ch
-
-	mfs, err = registry.Gather()
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	for i := range mfs {
-		if mfs[i].GetName() == "probe_ssl_last_chain_expiry_timestamp_seconds" {
-			t.Fatalf("Unexpected metric probe_ssl_last_chain_expiry_timestamp_seconds found in returned metrics")
-		}
-	}
 }
 
 func TestTCPConnectionQueryResponseStartTLS(t *testing.T) {

--- a/prober/tls.go
+++ b/prober/tls.go
@@ -28,11 +28,8 @@ func getEarliestCertExpiry(state *tls.ConnectionState) time.Time {
 	return earliest
 }
 
-func getLastChainExpiry(state *tls.ConnectionState) (time.Time, bool) {
+func getLastChainExpiry(state *tls.ConnectionState) time.Time {
 	lastChainExpiry := time.Time{}
-	if len(state.VerifiedChains) == 0 {
-		return lastChainExpiry, false
-	}
 	for _, chain := range state.VerifiedChains {
 		earliestCertExpiry := time.Time{}
 		for _, cert := range chain {
@@ -45,7 +42,7 @@ func getLastChainExpiry(state *tls.ConnectionState) (time.Time, bool) {
 		}
 
 	}
-	return lastChainExpiry, true
+	return lastChainExpiry
 }
 
 func getTLSVersion(state *tls.ConnectionState) string {

--- a/prober/tls.go
+++ b/prober/tls.go
@@ -28,8 +28,11 @@ func getEarliestCertExpiry(state *tls.ConnectionState) time.Time {
 	return earliest
 }
 
-func getLastChainExpiry(state *tls.ConnectionState) time.Time {
+func getLastChainExpiry(state *tls.ConnectionState) (time.Time, bool) {
 	lastChainExpiry := time.Time{}
+	if len(state.VerifiedChains) == 0 {
+		return lastChainExpiry, false
+	}
 	for _, chain := range state.VerifiedChains {
 		earliestCertExpiry := time.Time{}
 		for _, cert := range chain {
@@ -42,7 +45,7 @@ func getLastChainExpiry(state *tls.ConnectionState) time.Time {
 		}
 
 	}
-	return lastChainExpiry
+	return lastChainExpiry, true
 }
 
 func getTLSVersion(state *tls.ConnectionState) string {

--- a/prober/tls.go
+++ b/prober/tls.go
@@ -28,6 +28,23 @@ func getEarliestCertExpiry(state *tls.ConnectionState) time.Time {
 	return earliest
 }
 
+func getLatestVerifiedChainExpiry(state *tls.ConnectionState) time.Time {
+	latestVerifiedChainExpiry := time.Time{}
+	for _, chain := range state.VerifiedChains {
+		earliestCertExpiry := time.Time{}
+		for _, cert := range chain {
+			if (earliestCertExpiry.IsZero() || cert.NotAfter.Before(earliestCertExpiry)) && !cert.NotAfter.IsZero() {
+				earliestCertExpiry = cert.NotAfter
+			}
+		}
+		if latestVerifiedChainExpiry.IsZero() || latestVerifiedChainExpiry.After(earliestCertExpiry) {
+			latestVerifiedChainExpiry = earliestCertExpiry
+		}
+
+	}
+	return latestVerifiedChainExpiry
+}
+
 func getTLSVersion(state *tls.ConnectionState) string {
 	switch state.Version {
 	case tls.VersionTLS10:

--- a/prober/tls.go
+++ b/prober/tls.go
@@ -28,8 +28,8 @@ func getEarliestCertExpiry(state *tls.ConnectionState) time.Time {
 	return earliest
 }
 
-func getLatestVerifiedChainExpiry(state *tls.ConnectionState) time.Time {
-	latestVerifiedChainExpiry := time.Time{}
+func getLastChainExpiry(state *tls.ConnectionState) time.Time {
+	lastChainExpiry := time.Time{}
 	for _, chain := range state.VerifiedChains {
 		earliestCertExpiry := time.Time{}
 		for _, cert := range chain {
@@ -37,12 +37,12 @@ func getLatestVerifiedChainExpiry(state *tls.ConnectionState) time.Time {
 				earliestCertExpiry = cert.NotAfter
 			}
 		}
-		if latestVerifiedChainExpiry.IsZero() || latestVerifiedChainExpiry.After(earliestCertExpiry) {
-			latestVerifiedChainExpiry = earliestCertExpiry
+		if lastChainExpiry.IsZero() || lastChainExpiry.After(earliestCertExpiry) {
+			lastChainExpiry = earliestCertExpiry
 		}
 
 	}
-	return latestVerifiedChainExpiry
+	return lastChainExpiry
 }
 
 func getTLSVersion(state *tls.ConnectionState) string {

--- a/prober/utils_test.go
+++ b/prober/utils_test.go
@@ -79,18 +79,8 @@ func checkRegistryLabels(expRes map[string]map[string]string, mfs []*dto.MetricF
 	}
 }
 
-// Create test certificate with specified expiry date
-// Certificate will be self-signed and use localhost/127.0.0.1
-// Generated certificate and key are returned in PEM encoding
-func generateTestCertificate(expiry time.Time, IPAddressSAN bool) ([]byte, []byte) {
-	privatekey, err := rsa.GenerateKey(rand.Reader, 2048)
-	if err != nil {
-		panic(fmt.Sprintf("Error creating rsa key: %s", err))
-	}
-	publickey := &privatekey.PublicKey
-
-	cert := x509.Certificate{
-		IsCA:                  true,
+func generateCertificateTemplate(expiry time.Time, IPAddressSAN bool) *x509.Certificate {
+	template := &x509.Certificate{
 		BasicConstraintsValid: true,
 		SubjectKeyId:          []byte{1},
 		SerialNumber:          big.NewInt(1),
@@ -102,18 +92,54 @@ func generateTestCertificate(expiry time.Time, IPAddressSAN bool) ([]byte, []byt
 		ExtKeyUsage: []x509.ExtKeyUsage{x509.ExtKeyUsageClientAuth, x509.ExtKeyUsageServerAuth},
 		KeyUsage:    x509.KeyUsageDigitalSignature | x509.KeyUsageCertSign,
 	}
-	cert.DNSNames = append(cert.DNSNames, "localhost")
+
+	template.DNSNames = append(template.DNSNames, "localhost")
 	if IPAddressSAN {
-		cert.IPAddresses = append(cert.IPAddresses, net.ParseIP("127.0.0.1"))
-		cert.IPAddresses = append(cert.IPAddresses, net.ParseIP("::1"))
+		template.IPAddresses = append(template.IPAddresses, net.ParseIP("127.0.0.1"))
+		template.IPAddresses = append(template.IPAddresses, net.ParseIP("::1"))
 	}
-	derCert, err := x509.CreateCertificate(rand.Reader, &cert, &cert, publickey, privatekey)
+
+	return template
+}
+
+func generateCertificate(template, parent *x509.Certificate, publickey *rsa.PublicKey, privatekey *rsa.PrivateKey) (*x509.Certificate, []byte) {
+	derCert, err := x509.CreateCertificate(rand.Reader, template, template, publickey, privatekey)
 	if err != nil {
 		panic(fmt.Sprintf("Error signing test-certificate: %s", err))
 	}
+	cert, err := x509.ParseCertificate(derCert)
+	if err != nil {
+		panic(fmt.Sprintf("Error parsing test-certificate: %s", err))
+	}
 	pemCert := pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: derCert})
-	pemKey := pem.EncodeToMemory(&pem.Block{Type: "RSA PRIVATE KEY", Bytes: x509.MarshalPKCS1PrivateKey(privatekey)})
-	return pemCert, pemKey
+	return cert, pemCert
+
+}
+
+func generateSignedCertificate(template, parentCert *x509.Certificate, parentKey *rsa.PrivateKey) (*x509.Certificate, []byte, *rsa.PrivateKey) {
+	privatekey, err := rsa.GenerateKey(rand.Reader, 2048)
+	if err != nil {
+		panic(fmt.Sprintf("Error creating rsa key: %s", err))
+	}
+	cert, pemCert := generateCertificate(template, parentCert, &privatekey.PublicKey, parentKey)
+	return cert, pemCert, privatekey
+}
+
+func generateSelfSignedCertificate(template *x509.Certificate) (*x509.Certificate, []byte, *rsa.PrivateKey) {
+	privatekey, err := rsa.GenerateKey(rand.Reader, 2048)
+	if err != nil {
+		panic(fmt.Sprintf("Error creating rsa key: %s", err))
+	}
+	publickey := &privatekey.PublicKey
+
+	cert, pemCert := generateCertificate(template, template, publickey, privatekey)
+	return cert, pemCert, privatekey
+}
+
+func generateSelfSignedCertificateWithPrivateKey(template *x509.Certificate, privatekey *rsa.PrivateKey) (*x509.Certificate, []byte) {
+	publickey := &privatekey.PublicKey
+	cert, pemCert := generateCertificate(template, template, publickey, privatekey)
+	return cert, pemCert
 }
 
 func TestChooseProtocol(t *testing.T) {


### PR DESCRIPTION
Resolves https://github.com/prometheus/blackbox_exporter/issues/340

Based on the discussion in the issue above, this metric will help determine
when the SSL/TLS certificate expiration error actually happens on clients
like a browser that attempts to verify certificates by building one or
more chains from peer certificates.