### PR TITLE
Add support for "rootless" ping

### DIFF
--- a/CONFIGURATION.md
+++ b/CONFIGURATION.md
@@ -217,7 +217,8 @@ validate_additional_rrs:
 # The source IP address.
 [ source_ip_address: <string> ]
 
-# Set the DF-bit in the IP-header. Only works with ip4 and on *nix systems.
+# Set the DF-bit in the IP-header. Only works with ip4, on *nix systems and
+# requires raw sockets (i.e. root or CAP_NET_RAW on Linux).
 [ dont_fragment: <boolean> | default = false ]
 
 # The size of the payload.

--- a/README.md
+++ b/README.md
@@ -94,9 +94,15 @@ scrape_configs:
 The ICMP probe requires elevated privileges to function:
 
 * *Windows*: Administrator privileges are required.
-* *Linux*: root user _or_ `CAP_NET_RAW` capability is required.
-  * Can be set by executing `setcap cap_net_raw+ep blackbox_exporter`
-* *BSD / OS X*: root user is required.
+* *Linux*: either the root user, the `CAP_NET_RAW` capability or a user with a
+  group within net.ipv4.ping_group_range is required.
+  * The capability can be set by executing `setcap cap_net_raw+ep blackbox_exporter`
+  * Your distribution may configure `net.ipv4.ping_group_range` by default in
+    `/etc/sysctl.conf` or similar. If not you can set
+    `net.ipv4.ping_group_range = 0  2147483647` to allow any user the ability
+    to use ping.
+* *BSD*: root user is required.
+* *OS X*: No additional privileges are needed.
 
 [circleci]: https://circleci.com/gh/prometheus/blackbox_exporter
 [hub]: https://hub.docker.com/r/prom/blackbox-exporter/

--- a/README.md
+++ b/README.md
@@ -94,13 +94,14 @@ scrape_configs:
 The ICMP probe requires elevated privileges to function:
 
 * *Windows*: Administrator privileges are required.
-* *Linux*: either the root user, the `CAP_NET_RAW` capability or a user with a
-  group within net.ipv4.ping_group_range is required.
-  * The capability can be set by executing `setcap cap_net_raw+ep blackbox_exporter`
+* *Linux*: either a user with a group within `net.ipv4.ping_group_range`, the
+  `CAP_NET_RAW` capability or the root user is required.
   * Your distribution may configure `net.ipv4.ping_group_range` by default in
     `/etc/sysctl.conf` or similar. If not you can set
     `net.ipv4.ping_group_range = 0  2147483647` to allow any user the ability
     to use ping.
+  * Alternatively the capability can be set by executing `setcap cap_net_raw+ep
+    blackbox_exporter`
 * *BSD*: root user is required.
 * *OS X*: No additional privileges are needed.
 


### PR DESCRIPTION
This works for Linux and Darwin.

On Linux the user running the exporter needs to be a member of a group
with an ID in the range specified in the sysctl
net.ipv4.ping_group_range.

Fixes #147.

I've tested this on:

## Darwin, macOS 10.15.4

Works, able to set ID and confirmed with tcpdump the ID is the same on outgoing
packets.

## Linux 5.4.43 (NixOS)

Kernel always overwrites ID, e.g.:

```
ts=2020-06-16T11:53:06.722Z caller=main.go:169 module=icmp target=127.0.0.1 level=debug msg="Creating ICMP packet" seq=46268 id=17449
```

tcpdump:
```
12:53:06.722861 IP 127.0.0.1 > 127.0.0.1: ICMP echo request, id 62, seq 46268, length 36
```

The code takes this into account.

Works when:
```
sysctl -w net.ipv4.ping_group_range='0	2147483647'
```

Example log:
```
ts=2020-06-16T11:53:06.722Z caller=main.go:169 module=icmp target=127.0.0.1 level=debug msg="Creating socket"
ts=2020-06-16T11:53:06.722Z caller=main.go:169 module=icmp target=127.0.0.1 level=debug msg="Creating ICMP packet" seq=46268 id=17449
ts=2020-06-16T11:53:06.722Z caller=main.go:169 module=icmp target=127.0.0.1 level=debug msg="Writing out packet"
ts=2020-06-16T11:53:06.722Z caller=main.go:169 module=icmp target=127.0.0.1 level=debug msg="Waiting for reply packets"
ts=2020-06-16T11:53:06.722Z caller=main.go:169 module=icmp target=127.0.0.1 level=debug msg="Found matching reply packet"
```

Fails when running as user with:

```
sysctl -w net.ipv4.ping_group_range='0 0'
```

Example log:
```
ts=2020-06-16T11:42:16.671Z caller=main.go:169 module=icmp target=127.0.0.1 level=debug msg="Unable to do unprivileged listen on socket, will attempt privileged" err="socket: permission denied"
ts=2020-06-16T11:42:16.671Z caller=main.go:169 module=icmp target=127.0.0.1 level=debug msg="Error listening to socket" err="listen ip4:icmp 0.0.0.0: socket: operation not permitted"
```

Succeeds using raw sockets when run as user with CAP_NET_RAW but not in ping_group_range:

```
sudo setcap cap_net_raw=eip ./blackbox_exporter
```

Example log:
```
ts=2020-06-16T11:43:49.143Z caller=main.go:169 module=icmp target=127.0.0.1 level=debug msg="Unable to do unprivileged listen on socket, will attempt privileged" err="socket: permission denied"
ts=2020-06-16T11:43:49.143Z caller=main.go:169 module=icmp target=127.0.0.1 level=debug msg="Creating ICMP packet" seq=41274 id=16135
```

Succeeds when run as root with (non default):
```
sysctl -w net.ipv4.ping_group_range='0 0'
```

Example log:
```
ts=2020-06-16T11:45:19.848Z caller=main.go:169 module=icmp target=127.0.0.1 level=debug msg="Creating socket"
ts=2020-06-16T11:45:19.848Z caller=main.go:169 module=icmp target=127.0.0.1 level=debug msg="Creating ICMP packet" seq=6944 id=16229
ts=2020-06-16T11:45:19.848Z caller=main.go:169 module=icmp target=127.0.0.1 level=debug msg="Writing out packet"
ts=2020-06-16T11:45:19.848Z caller=main.go:169 module=icmp target=127.0.0.1 level=debug msg="Waiting for reply packets"
ts=2020-06-16T11:45:19.848Z caller=main.go:169 module=icmp target=127.0.0.1 level=debug msg="Found matching reply packet"
```

Note this uses "udp" sockets when run as root, if they work (no fallback
output). The thinking being root in a Docker container may not have CAP_NET_RAW
but may be able to use ping sockets.

Succeeds using raw sockets when run as root with ping_group_range disabled
(this is the default Linux kernel setting, but overridden via sysctl.conf on
many recent distributions default configuration):

```
sudo sysctl -w net.ipv4.ping_group_range='1 0'
```

Example log:
```
ts=2020-06-16T11:49:28.473Z caller=main.go:169 module=icmp target=127.0.0.1 level=debug msg="Creating socket"
ts=2020-06-16T11:49:28.473Z caller=main.go:169 module=icmp target=127.0.0.1 level=debug msg="Unable to do unprivileged listen on socket, will attempt privileged" err="socket: permission denied"
ts=2020-06-16T11:49:28.473Z caller=main.go:169 module=icmp target=127.0.0.1 level=debug msg="Creating ICMP packet" seq=39844 id=16445
ts=2020-06-16T11:49:28.473Z caller=main.go:169 module=icmp target=127.0.0.1 level=debug msg="Writing out packet"
ts=2020-06-16T11:49:28.473Z caller=main.go:169 module=icmp target=127.0.0.1 level=debug msg="Waiting for reply packets"
ts=2020-06-16T11:49:28.473Z caller=main.go:169 module=icmp target=127.0.0.1 level=debug msg="Found matching reply packet"
```

Prober configured with `dont_fragment: true`, fails running as normal user as
it must use raw sockets:

```
ts=2020-06-16T12:00:21.924Z caller=main.go:169 module=icmp target=127.0.0.1 level=debug msg="Creating socket"
ts=2020-06-16T12:00:21.924Z caller=main.go:169 module=icmp target=127.0.0.1 level=debug msg="Error listening to socket" err="listen ip4:icmp 0.0.0.0: socket: operation not permitted"
```
