### PR TITLE
Add support for DoT to DNS probes

### DIFF
--- a/CONFIGURATION.md
+++ b/CONFIGURATION.md
@@ -153,6 +153,9 @@ tls_config:
 
 [ transport_protocol: <string> | default = "udp" ] # udp, tcp
 
+# Whether to use DNS over TLS. This only works with TCP.
+[ dns_over_tls: <boolean | default = false> ]
+
 query_name: <string>
 
 [ query_type: <string> | default = "ANY" ]

--- a/config/config.go
+++ b/config/config.go
@@ -174,6 +174,7 @@ type ICMPProbe struct {
 type DNSProbe struct {
 	IPProtocol         string         `yaml:"preferred_ip_protocol,omitempty"`
 	IPProtocolFallback bool           `yaml:"ip_protocol_fallback,omitempty"`
+	DNSOverTLS         bool           `yaml:"dns_over_tls,omitempty"`
 	SourceIPAddress    string         `yaml:"source_ip_address,omitempty"`
 	TransportProtocol  string         `yaml:"transport_protocol,omitempty"`
 	QueryClass         string         `yaml:"query_class,omitempty"` // Defaults to IN.

--- a/prober/dns.go
+++ b/prober/dns.go
@@ -190,6 +190,15 @@ func ProbeDNS(ctx context.Context, target string, module config.Module, registry
 		dialProtocol = module.DNS.TransportProtocol + "4"
 	}
 
+	if module.DNS.DNSOverTLS {
+		if module.DNS.TransportProtocol == "tcp" {
+			dialProtocol += "-tls"
+		} else {
+			level.Error(logger).Log("msg", "Configuration error: Expected transport protocol tcp for DoT", "protocol", module.DNS.TransportProtocol)
+			return false
+		}
+	}
+
 	client := new(dns.Client)
 	client.Net = dialProtocol
 


### PR DESCRIPTION
This adds a new DNS probe option `dns_over_tls` to enable DoT on DNS probes.