### PR TITLE
Deal with URLs with literal IPv6 addresses

### DIFF
--- a/prober/http.go
+++ b/prober/http.go
@@ -314,11 +314,9 @@ func ProbeHTTP(ctx context.Context, target string, module config.Module, registr
 		level.Error(logger).Log("msg", "Could not parse target URL", "err", err)
 		return false
 	}
-	targetHost, targetPort, err := net.SplitHostPort(targetURL.Host)
-	// If split fails, assuming it's a hostname without port part.
-	if err != nil {
-		targetHost = targetURL.Host
-	}
+
+	targetHost := targetURL.Hostname()
+	targetPort := targetURL.Port()
 
 	ip, lookupTime, err := chooseProtocol(ctx, module.HTTP.IPProtocol, module.HTTP.IPProtocolFallback, targetHost, registry, logger)
 	if err != nil {


### PR DESCRIPTION
Recent versions of Go have started enforcing the usage of
brackets in URLs with literal IPv6 addresses. This change
prevents the attempt to resolve an address in the form
[address]. URL.Hostname() takes care of striping the brackets.

Signed-off-by: André Cruz <acruz@cloudflare.com>