### PR TITLE
Conditionally register and set probe_ssl_last_chain_expiry_timestamp_seconds

### DIFF
--- a/prober/http.go
+++ b/prober/http.go
@@ -552,9 +552,10 @@ func ProbeHTTP(ctx context.Context, target string, module config.Module, registr
 		registry.MustRegister(probeSSLEarliestCertExpiryGauge, probeTLSVersion)
 		probeSSLEarliestCertExpiryGauge.Set(float64(getEarliestCertExpiry(resp.TLS).Unix()))
 		probeTLSVersion.WithLabelValues(getTLSVersion(resp.TLS)).Set(1)
-		if !module.HTTP.HTTPClientConfig.TLSConfig.InsecureSkipVerify {
+		lastChainExpiry := getLastChainExpiry(resp.TLS)
+		if !lastChainExpiry.IsZero() {
 			registry.MustRegister(probeSSLLastChainExpiryTimestampSeconds)
-			probeSSLLastChainExpiryTimestampSeconds.Set(float64(getLastChainExpiry(resp.TLS).Unix()))
+			probeSSLLastChainExpiryTimestampSeconds.Set(float64(lastChainExpiry.Unix()))
 		}
 		if httpConfig.FailIfSSL {
 			level.Error(logger).Log("msg", "Final request was over SSL")

--- a/prober/tcp.go
+++ b/prober/tcp.go
@@ -132,9 +132,10 @@ func ProbeTCP(ctx context.Context, target string, module config.Module, registry
 		registry.MustRegister(probeSSLEarliestCertExpiry, probeTLSVersion)
 		probeSSLEarliestCertExpiry.Set(float64(getEarliestCertExpiry(&state).Unix()))
 		probeTLSVersion.WithLabelValues(getTLSVersion(&state)).Set(1)
-		if !module.TCP.TLSConfig.InsecureSkipVerify {
+		lastChainExpiry := getLastChainExpiry(&state)
+		if !lastChainExpiry.IsZero() {
 			registry.MustRegister(probeSSLLastChainExpiryTimestampSeconds)
-			probeSSLLastChainExpiryTimestampSeconds.Set(float64(getLastChainExpiry(&state).Unix()))
+			probeSSLLastChainExpiryTimestampSeconds.Set(float64(lastChainExpiry.Unix()))
 		}
 	}
 	scanner := bufio.NewScanner(conn)
@@ -205,9 +206,10 @@ func ProbeTCP(ctx context.Context, target string, module config.Module, registry
 			registry.MustRegister(probeSSLEarliestCertExpiry)
 			probeSSLEarliestCertExpiry.Set(float64(getEarliestCertExpiry(&state).Unix()))
 			probeTLSVersion.WithLabelValues(getTLSVersion(&state)).Set(1)
-			if !module.TCP.TLSConfig.InsecureSkipVerify {
+			lastChainExpiry := getLastChainExpiry(&state)
+			if !lastChainExpiry.IsZero() {
 				registry.MustRegister(probeSSLLastChainExpiryTimestampSeconds)
-				probeSSLLastChainExpiryTimestampSeconds.Set(float64(getLastChainExpiry(&state).Unix()))
+				probeSSLLastChainExpiryTimestampSeconds.Set(float64(lastChainExpiry.Unix()))
 			}
 		}
 	}


### PR DESCRIPTION
If verification is disabled, there won't get any chains to verify, and a
timestamp value cannot be produced. Skip the metric altogether.

Fixes #653 