### PR TITLE
Log http version string we compare with, rather than float we put in metric.

### DIFF
--- a/prober/http.go
+++ b/prober/http.go
@@ -494,7 +494,7 @@ func ProbeHTTP(ctx context.Context, target string, module config.Module, registr
 				}
 			}
 			if !found {
-				level.Error(logger).Log("msg", "Invalid HTTP version number", "version", httpVersionNumber)
+				level.Error(logger).Log("msg", "Invalid HTTP version number", "version", resp.Proto)
 				success = false
 			}
 		}


### PR DESCRIPTION
See #658

Signed-off-by: Brian Brazil <brian.brazil@robustperception.io>