### PR TITLE
Expose probe_dns_duration_seconds metric

### DIFF
--- a/prober/dns.go
+++ b/prober/dns.go
@@ -126,6 +126,10 @@ func validRcode(rcode int, valid []string, logger log.Logger) bool {
 
 func ProbeDNS(ctx context.Context, target string, module config.Module, registry *prometheus.Registry, logger log.Logger) bool {
 	var dialProtocol string
+	probeDNSDurationGauge := prometheus.NewGauge(prometheus.GaugeOpts{
+		Name: "probe_dns_duration_seconds",
+		Help: "Duration of DNS request",
+	})
 	probeDNSAnswerRRSGauge := prometheus.NewGauge(prometheus.GaugeOpts{
 		Name: "probe_dns_answer_rrs",
 		Help: "Returns number of entries in the answer resource record list",
@@ -138,6 +142,7 @@ func ProbeDNS(ctx context.Context, target string, module config.Module, registry
 		Name: "probe_dns_additional_rrs",
 		Help: "Returns number of entries in the additional resource record list",
 	})
+	registry.MustRegister(probeDNSDurationGauge)
 	registry.MustRegister(probeDNSAnswerRRSGauge)
 	registry.MustRegister(probeDNSAuthorityRRSGauge)
 	registry.MustRegister(probeDNSAdditionalRRSGauge)
@@ -246,7 +251,14 @@ func ProbeDNS(ctx context.Context, target string, module config.Module, registry
 	level.Info(logger).Log("msg", "Making DNS query", "target", targetIP, "dial_protocol", dialProtocol, "query", module.DNS.QueryName, "type", qt, "class", qc)
 	timeoutDeadline, _ := ctx.Deadline()
 	client.Timeout = time.Until(timeoutDeadline)
+	// we don't use the rtt value returned fom client.Exchange because that
+	// includes only the time to exchange messages with the server _after_
+	// the connection is created. We would in principle have three phases:
+	// resolve (probe_dns_lookup_time_seconds), connect (request - rtt),
+	// request (rtt).
+	requestStart := time.Now()
 	response, _, err := client.Exchange(msg, targetIP)
+	probeDNSDurationGauge.Set(time.Since(requestStart).Seconds())
 	if err != nil {
 		level.Error(logger).Log("msg", "Error while sending a DNS query", "err", err)
 		return false

--- a/prober/dns_test.go
+++ b/prober/dns_test.go
@@ -602,10 +602,16 @@ func TestDNSMetrics(t *testing.T) {
 
 	expectedMetrics := map[string]map[string]map[string]struct{}{
 		"probe_dns_lookup_time_seconds": nil,
-		"probe_dns_duration_seconds":    nil,
-		"probe_dns_answer_rrs":          nil,
-		"probe_dns_authority_rrs":       nil,
-		"probe_dns_additional_rrs":      nil,
+		"probe_dns_duration_seconds": {
+			"phase": {
+				"resolve": {},
+				"connect": {},
+				"request": {},
+			},
+		},
+		"probe_dns_answer_rrs":     nil,
+		"probe_dns_authority_rrs":  nil,
+		"probe_dns_additional_rrs": nil,
 	}
 
 	checkMetrics(expectedMetrics, mfs, t)

--- a/prober/http_test.go
+++ b/prober/http_test.go
@@ -702,42 +702,19 @@ func TestHTTPPhases(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	found := false
-	foundLabel := map[string]bool{
-		"connect":    false,
-		"processing": false,
-		"resolve":    false,
-		"transfer":   false,
-		"tls":        false,
+	expectedMetrics := map[string]map[string]map[string]struct{}{
+		"probe_http_duration_seconds": {
+			"phase": {
+				"connect":    {},
+				"processing": {},
+				"resolve":    {},
+				"transfer":   {},
+				"tls":        {},
+			},
+		},
 	}
-	for _, mf := range mfs {
-		if mf.GetName() == "probe_http_duration_seconds" {
-			found = true
-			for _, metric := range mf.GetMetric() {
-				for _, lp := range metric.Label {
-					if lp.GetName() == "phase" {
-						f, ok := foundLabel[lp.GetValue()]
-						if !ok {
-							t.Fatalf("Unexpected label phase=%s", lp.GetValue())
-						}
-						if f {
-							t.Fatalf("Label phase=%s duplicated", lp.GetValue())
-						}
-						foundLabel[lp.GetValue()] = true
-					}
-				}
-			}
 
-		}
-	}
-	if !found {
-		t.Fatal("probe_http_duration_seconds not found")
-	}
-	for lv, found := range foundLabel {
-		if !found {
-			t.Fatalf("Label phase=%s not found", lv)
-		}
-	}
+	checkMetrics(expectedMetrics, mfs, t)
 }
 
 func TestCookieJar(t *testing.T) {


### PR DESCRIPTION
This follows the same pattern as probe_http_duration_seconds and
probe_icmp_duration_seconds: it captures the time it takes to perform
the actual request, excluding the time it takes to set up things.
probe_duration_seconds includes the time to perform the request as well
as all the time it takes to set it up. probe_dns_lookup_time_seconds
refers to the time it takes to resolve the target's address, so it
doesn't capture the time it takes to make one request for that target.

Signed-off-by: Marcelo E. Magallon <marcelo.magallon@grafana.com>