### PR TITLE
166 auto document metrics

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -29,10 +29,27 @@ jobs:
           sudo service docker restart
     - run: docker run --rm -t -v "$(pwd):/app" "${DOCKER_TEST_IMAGE_NAME}" -i github.com/prometheus/blackbox_exporter -T
 
+  checkdoc:
+    # Ensure that doc is uptodate in git repo
+    docker:
+      - image: alpine/make:latest
+    steps:
+      - checkout
+      - run: 
+          name: "verify metrics.md is up to date"
+          command: |
+            cp metrics.md  metrics.md.git
+            make metrics.md
+            diff metrics.ms metrics.md.git
+
 workflows:
   version: 2
   blackbox_exporter:
     jobs:
+    - checkdoc:
+        filters:
+          tags:
+            only: /.*/
     - test:
         filters:
           tags:
@@ -45,6 +62,7 @@ workflows:
     - prometheus/publish_master:
         context: org-context
         requires:
+        - checkdoc
         - test
         - build
         filters:
@@ -53,6 +71,7 @@ workflows:
     - prometheus/publish_release:
         context: org-context
         requires:
+        - checkdoc
         - test
         - build
         filters:

--- a/Makefile
+++ b/Makefile
@@ -14,6 +14,15 @@
 # Needs to be defined before including Makefile.common to auto-generate targets
 DOCKER_ARCHS ?= amd64 armv7 arm64 ppc64le
 
+GOFILES = ${shell find . -name "*.go" | grep -v "^\./vendor"}
+
+allanddoc: all metrics.md
+
 include Makefile.common
 
 DOCKER_IMAGE_NAME       ?= blackbox-exporter
+
+
+metrics.md: ${GOFILES} scripts/extract_metric_doc.sh
+	scripts/extract_metric_doc.sh ${GOFILES} > $@
+

--- a/README.md
+++ b/README.md
@@ -43,6 +43,9 @@ will return debug information for that probe.
 After a successful local build:
 
     docker build -t blackbox_exporter .
+## Metrics
+
+The blackbox_exporter metrics are documented in [this file](metrics.md).
 
 ## [Configuration](CONFIGURATION.md)
 

--- a/metrics.md
+++ b/metrics.md
@@ -1,0 +1,58 @@
+# Blackbox Exporter Metric Documentation
+
+*Those tables are automatically extracted from source code. Do not modify
+manually!*
+
+
+## Dns metrics
+
+| metric name              | doc                                                             |
+|--------------------------|-----------------------------------------------------------------|
+| probe_dns_additional_rrs | Returns number of entries in the additional resource record list|
+| probe_dns_answer_rrs     | Returns number of entries in the answer resource record list    |
+| probe_dns_authority_rrs  | Returns number of entries in the authority resource record list |
+| probe_dns_serial         | Returns the serial number of the zone                           |
+
+## General metrics
+
+| metric name                                  | doc                                                                               |
+|----------------------------------------------|-----------------------------------------------------------------------------------|
+| config_last_reload_successful                | Blackbox exporter config loaded successfully.                                     |
+| config_last_reload_success_timestamp_seconds | Timestamp of the last successful configuration reload.                            |
+| probe_dns_lookup_time_seconds                | Returns the time taken for probe dns lookup in seconds                            |
+| probe_duration_seconds                       | Returns how long the probe took to complete in seconds                            |
+| probe_ip_addr_hash                           | Specifies the hash of IP address. It's useful to detect if the IP address changes.|
+| probe_ip_protocol                            | Specifies whether probe ip protocol is IP4 or IP6                                 |
+| probe_success                                | Displays whether or not the probe was a success                                   |
+
+## Http metrics
+
+| metric name                                   | doc                                                         |
+|-----------------------------------------------|-------------------------------------------------------------|
+| probe_failed_due_to_regex                     | Indicates if probe failed due to regex                      |
+| probe_http_content_length                     | Length of http content response                             |
+| probe_http_duration_seconds                   | Duration of http request by phase, summed over all redirects|
+| probe_http_last_modified_timestamp_seconds    | Returns the Last-Modified HTTP response header in unixtime  |
+| probe_http_redirects                          | The number of redirects                                     |
+| probe_http_ssl                                | Indicates if SSL was used for the final redirect            |
+| probe_http_status_code                        | Response HTTP status code                                   |
+| probe_http_uncompressed_body_length           | Length of uncompressed response body                        |
+| probe_http_version                            | Returns the version of HTTP of the probe response           |
+| probe_ssl_earliest_cert_expiry                | Returns earliest SSL cert expiry in unixtime                |
+| probe_ssl_last_chain_expiry_timestamp_seconds | Returns last SSL chain expiry in timestamp seconds          |
+| probe_tls_version_info                        | Contains the TLS version used                               |
+
+## Icmp metrics
+
+| metric name                 | doc                                              |
+|-----------------------------|--------------------------------------------------|
+| probe_icmp_duration_seconds | Duration of icmp request by phase                |
+
+## Tcp metrics
+
+| metric name                                   | doc                                              |
+|-----------------------------------------------|--------------------------------------------------|
+| probe_failed_due_to_regex                     | Indicates if probe failed due to regex           |
+| probe_ssl_earliest_cert_expiry                | Returns earliest SSL cert expiry date            |
+| probe_ssl_last_chain_expiry_timestamp_seconds | Returns last SSL chain expiry in unixtime        |
+| probe_tls_version_info                        | Returns the TLS version used, or NaN when unknown|

--- a/scripts/extract_metric_doc.sh
+++ b/scripts/extract_metric_doc.sh
@@ -1,0 +1,58 @@
+#!/bin/bash
+set -e
+
+cursection=
+
+function header() {
+   section="$1"
+   echo
+   echo "## ${section^} metrics"
+   echo
+}
+
+function table_header() {
+   echo "| metric name | doc                                              |"
+   echo "|-------------|--------------------------------------------------|"
+}
+
+# Align column of markdown table saved in "$tmpfile"
+function beautify_section() {
+   column -t -s'|' -o '|' < "$tmpfile" | sed '/^|----/s/ /-/g'
+}
+
+tmpfile=$(mktemp /tmp/extract-metric.XXXXXX)
+trap 'rm "$tmpfile"' INT ABRT EXIT
+
+cat <<EOF
+# Blackbox Exporter Metric Documentation
+
+*Those tables are automatically extracted from source code. Do not modify
+manually!*
+
+EOF
+
+grep '^\s*\<\(Name\|Help\):\s*"\(.*\)"' $* | \
+   sed -e 's#^./\(vendor\|main\|config\|prober/utils\).*go:#!General!#' \
+   -e 's#^./prober/\([^.]*\)\.go:#!\1!#' \
+   -e 's#^.*Help: *"##' \
+   -e 's#!\s*Name: *"#! #' \
+| sed -e 'N;s/\n/ /' \
+   -e 's#",\s*$##' \
+   -e 's#",\s*# | #' \
+| sort \
+| while read -r line ;
+do
+   section=$(echo "$line" | sed 's/^!\([^!]*\)!.*/\1/')
+   doc=${line:$((${#section}+2))}
+   if [[ $section != "$cursection" ]]
+   then
+      cursection="$section"
+      beautify_section
+      header "$section"  
+      table_header > "$tmpfile"
+   fi
+   echo "|$doc|" >> "$tmpfile"
+done
+beautify_section
+
+


### PR DESCRIPTION
This PR enable to generate a markdown files `metric.md` describing the metrics collected by blackbox_exporter.

The document is auto-generatd when doing `make` and a job is added to the CI to ensure that the commited `metrics.md` is up to date (Note, that I'm not sure about the circle-ci config file and I'm not sure how to test it, so it may not works at first try).

See #166.