### PR TITLE
Update default timeout in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ HTTP, HTTPS (via the `http` prober), DNS, TCP socket and ICMP (see permissions s
 Additional modules can be defined to meet your needs.
 
 The timeout of each probe is automatically determined from the `scrape_timeout` in the [Prometheus config](https://prometheus.io/docs/operating/configuration/#configuration-file), slightly reduced to allow for network delays. 
-This can be further limited by the `timeout` in the Blackbox exporter config file. If neither is specified, it defaults to 10 seconds.
+This can be further limited by the `timeout` in the Blackbox exporter config file. If neither is specified, it defaults to 120 seconds.
 
 ## Prometheus Configuration
 


### PR DESCRIPTION
Since #509 (4bf18924d4645453ec3e240d01842b7f15db537c) the default timeout was changed to 2m. This change updates the README to reflect it.
