### PR TITLE
tcp prober: add support of raw bytes in query_response

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -149,9 +149,11 @@ type HeaderMatch struct {
 }
 
 type QueryResponse struct {
-	Expect   string `yaml:"expect,omitempty"`
-	Send     string `yaml:"send,omitempty"`
-	StartTLS bool   `yaml:"starttls,omitempty"`
+	Expect      string `yaml:"expect,omitempty"`
+	ExpectBytes string `yaml:"expect_bytes,omitempty"`
+	Send        string `yaml:"send,omitempty"`
+	SendBytes   string `yaml:"send_bytes,omitempty"`
+	StartTLS    bool   `yaml:"starttls,omitempty"`
 }
 
 type TCPProbe struct {


### PR DESCRIPTION
This PR aims to make the blackbox-exporter support any protocol by allowing to pass raw bytes in `query_response`.

Our use case was to monitor PostgreSQL certificate expiration. The PostgreSQL SSL handshake is not very standard. First, we must send a bytes sequence to ask the server if it supports SSL. If so, it will respond with one byte which in the letter `S` in ASCII. Then, we can start a STARTTLS handshake.

I haven't be able to do these things with the current `send` and `except` functions. Thus, I added two *functions* `send_bytes` and `expect_bytes`. The idea was to write something simple and quite generic as we don't have to write specific code in the blackbox-exporter project for every custom procotol we want to support.
With this PR, the blackbox-exporter can support any protocol as long as the user describes it into a module.

Based on this PR, we wrote the following module for our PostgreSQL SSL handshake's use case:

```yaml
postgresql_ssl:
  prober: tcp
  timeout: 5s
  tcp:
    preferred_ip_protocol: ip4
    tls_config:
      insecure_skip_verify: true
    query_response:
      - send_bytes: "\u0000\u0000\u0000\u0008\u0004\u00d2\u0016\u002f"
      - expect_bytes: "S"
      - starttls: true
```