### PR TITLE
prober/tls: adding metric to expose certificate fingerprint info

### DIFF
--- a/prober/tcp.go
+++ b/prober/tcp.go
@@ -98,6 +98,13 @@ func ProbeTCP(ctx context.Context, target string, module config.Module, registry
 		Name: "probe_ssl_last_chain_expiry_timestamp_seconds",
 		Help: "Returns last SSL chain expiry in unixtime",
 	})
+	probeSSLLastInformation := prometheus.NewGaugeVec(
+		prometheus.GaugeOpts{
+			Name: "probe_ssl_last_chain_info",
+			Help: "Contains SSL leaf certificate information",
+		},
+		[]string{"fingerprint_sha256"},
+	)
 	probeTLSVersion := prometheus.NewGaugeVec(
 		prometheus.GaugeOpts{
 			Name: "probe_tls_version_info",
@@ -129,10 +136,11 @@ func ProbeTCP(ctx context.Context, target string, module config.Module, registry
 	}
 	if module.TCP.TLS {
 		state := conn.(*tls.Conn).ConnectionState()
-		registry.MustRegister(probeSSLEarliestCertExpiry, probeTLSVersion, probeSSLLastChainExpiryTimestampSeconds)
+		registry.MustRegister(probeSSLEarliestCertExpiry, probeTLSVersion, probeSSLLastChainExpiryTimestampSeconds, probeSSLLastInformation)
 		probeSSLEarliestCertExpiry.Set(float64(getEarliestCertExpiry(&state).Unix()))
 		probeTLSVersion.WithLabelValues(getTLSVersion(&state)).Set(1)
 		probeSSLLastChainExpiryTimestampSeconds.Set(float64(getLastChainExpiry(&state).Unix()))
+		probeSSLLastInformation.WithLabelValues(getFingerprint(&state)).Set(1)
 	}
 	scanner := bufio.NewScanner(conn)
 	for i, qr := range module.TCP.QueryResponse {
@@ -203,6 +211,7 @@ func ProbeTCP(ctx context.Context, target string, module config.Module, registry
 			probeSSLEarliestCertExpiry.Set(float64(getEarliestCertExpiry(&state).Unix()))
 			probeTLSVersion.WithLabelValues(getTLSVersion(&state)).Set(1)
 			probeSSLLastChainExpiryTimestampSeconds.Set(float64(getLastChainExpiry(&state).Unix()))
+			probeSSLLastInformation.WithLabelValues(getFingerprint(&state)).Set(1)
 		}
 	}
 	return true

--- a/prober/tcp_test.go
+++ b/prober/tcp_test.go
@@ -196,6 +196,7 @@ func TestTCPConnectionWithTLS(t *testing.T) {
 	// Check values
 	expectedResults := map[string]float64{
 		"probe_ssl_earliest_cert_expiry": float64(certExpiry.Unix()),
+		"probe_ssl_last_chain_info":      1,
 		"probe_tls_version_info":         1,
 	}
 	checkRegistryResults(expectedResults, mfs, t)
@@ -317,6 +318,7 @@ func TestTCPConnectionWithTLSAndVerifiedCertificateChain(t *testing.T) {
 	expectedResults := map[string]float64{
 		"probe_ssl_earliest_cert_expiry":                float64(serverCertExpiry.Unix()),
 		"probe_ssl_last_chain_expiry_timestamp_seconds": float64(serverCertExpiry.Unix()),
+		"probe_ssl_last_chain_info":                     1,
 		"probe_tls_version_info":                        1,
 	}
 	checkRegistryResults(expectedResults, mfs, t)

--- a/prober/tls.go
+++ b/prober/tls.go
@@ -14,7 +14,9 @@
 package prober
 
 import (
+	"crypto/sha256"
 	"crypto/tls"
+	"encoding/hex"
 	"time"
 )
 
@@ -26,6 +28,12 @@ func getEarliestCertExpiry(state *tls.ConnectionState) time.Time {
 		}
 	}
 	return earliest
+}
+
+func getFingerprint(state *tls.ConnectionState) string {
+	cert := state.PeerCertificates[0]
+	fingerprint := sha256.Sum256(cert.Raw)
+	return hex.EncodeToString(fingerprint[:])
 }
 
 func getLastChainExpiry(state *tls.ConnectionState) time.Time {


### PR DESCRIPTION
this change adds a new metric `probe_ssl_fingerprint_info` to both tcp
and http probes. the metric always returns 1 similar to the tls version
metric and contains the leaf certificates sha256 fingerprint (hex) as a
label value.

this change allows users to validate in prometheus if a particular
certificate is being served.