### PR TITLE
prober/tls: fix probe_ssl_last_chain_expiry_timestamp_seconds

### DIFF
--- a/prober/tcp_test.go
+++ b/prober/tcp_test.go
@@ -224,26 +224,26 @@ func TestTCPConnectionWithTLSAndVerifiedCertificateChain(t *testing.T) {
 		panic(fmt.Sprintf("Error creating rsa key: %s", err))
 	}
 
-	rootCertExpiry := time.Now().AddDate(0, 0, 2)
+	rootCertExpiry := time.Now().AddDate(0, 0, 3)
 	rootCertTmpl := generateCertificateTemplate(rootCertExpiry, false)
 	rootCertTmpl.IsCA = true
 	_, rootCertPem := generateSelfSignedCertificateWithPrivateKey(rootCertTmpl, rootPrivatekey)
 
-	oldRootCertExpiry := time.Now().AddDate(0, 0, -1)
-	expiredRootCertTmpl := generateCertificateTemplate(oldRootCertExpiry, false)
-	expiredRootCertTmpl.IsCA = true
-	expiredRootCert, expiredRootCertPem := generateSelfSignedCertificateWithPrivateKey(expiredRootCertTmpl, rootPrivatekey)
+	oldRootCertExpiry := time.Now().AddDate(0, 0, 1)
+	olderRootCertTmpl := generateCertificateTemplate(oldRootCertExpiry, false)
+	olderRootCertTmpl.IsCA = true
+	olderRootCert, olderRootCertPem := generateSelfSignedCertificateWithPrivateKey(olderRootCertTmpl, rootPrivatekey)
 
-	serverCertExpiry := time.Now().AddDate(0, 0, 1)
+	serverCertExpiry := time.Now().AddDate(0, 0, 2)
 	serverCertTmpl := generateCertificateTemplate(serverCertExpiry, false)
-	_, serverCertPem, serverKey := generateSignedCertificate(serverCertTmpl, expiredRootCert, rootPrivatekey)
+	_, serverCertPem, serverKey := generateSignedCertificate(serverCertTmpl, olderRootCert, rootPrivatekey)
 
 	// CAFile must be passed via filesystem, use a tempfile.
 	tmpCaFile, err := ioutil.TempFile("", "cafile.pem")
 	if err != nil {
 		t.Fatalf(fmt.Sprintf("Error creating CA tempfile: %s", err))
 	}
-	if _, err := tmpCaFile.Write(bytes.Join([][]byte{rootCertPem, expiredRootCertPem}, []byte("\n"))); err != nil {
+	if _, err := tmpCaFile.Write(bytes.Join([][]byte{rootCertPem, olderRootCertPem}, []byte("\n"))); err != nil {
 		t.Fatalf(fmt.Sprintf("Error writing CA tempfile: %s", err))
 	}
 	if err := tmpCaFile.Close(); err != nil {

--- a/prober/tls.go
+++ b/prober/tls.go
@@ -45,7 +45,7 @@ func getLastChainExpiry(state *tls.ConnectionState) time.Time {
 				earliestCertExpiry = cert.NotAfter
 			}
 		}
-		if lastChainExpiry.IsZero() || lastChainExpiry.After(earliestCertExpiry) {
+		if lastChainExpiry.IsZero() || lastChainExpiry.Before(earliestCertExpiry) {
 			lastChainExpiry = earliestCertExpiry
 		}
 


### PR DESCRIPTION
Apologies if I've misunderstood the purpose of this metric but I believe that it should be reporting the earliest expiry date of the chain that expires last out of all the verified chains. Presently it's reporting the earliest expiry of the chain that expires first.

This wasn't identified by the test for this metric because the test is using an expired root certificate which is not included in the `VerifiedChains`, so there was only one chain for the method to iterate over and therefore `getLastChainExpiry` returned the same regardless of the logic.