### PR TITLE
prober/http: Handle HTTP/2 as HTTP/2.0 for backwards compatibly

### DIFF
--- a/example.yml
+++ b/example.yml
@@ -3,7 +3,7 @@ modules:
     prober: http
     timeout: 5s
     http:
-      valid_http_versions: ["HTTP/1.1", "HTTP/2.0"]
+      valid_http_versions: ["HTTP/1.1", "HTTP/2", "HTTP/2.0"]
       valid_status_codes: []  # Defaults to 2xx
       method: GET
       headers:

--- a/prober/http.go
+++ b/prober/http.go
@@ -521,6 +521,11 @@ func ProbeHTTP(ctx context.Context, target string, module config.Module, registr
 					found = true
 					break
 				}
+				// Fixes https://github.com/prometheus/blackbox_exporter/issues/691
+				if version == "HTTP/2" && resp.Proto == "HTTP/2.0" {
+					found = true
+					break
+				}
 			}
 			if !found {
 				level.Error(logger).Log("msg", "Invalid HTTP version number", "version", resp.Proto)

--- a/prober/http_test.go
+++ b/prober/http_test.go
@@ -77,6 +77,7 @@ func TestValidHTTPVersion(t *testing.T) {
 	}{
 		{[]string{}, true},
 		{[]string{"HTTP/1.1"}, true},
+		{[]string{"HTTP/1.1", "HTTP/2"}, true},
 		{[]string{"HTTP/1.1", "HTTP/2.0"}, true},
 		{[]string{"HTTP/2.0"}, false},
 	}


### PR DESCRIPTION
Fixes https://github.com/prometheus/blackbox_exporter/issues/691