### PR TITLE
CrLf option for newline

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -57,6 +57,7 @@ var (
 	// DefaultTCPProbe set default value for TCPProbe
 	DefaultTCPProbe = TCPProbe{
 		IPProtocolFallback: true,
+		CrLf:               false,
 	}
 
 	// DefaultICMPProbe set default value for ICMPProbe
@@ -161,6 +162,7 @@ type TCPProbe struct {
 	QueryResponse      []QueryResponse  `yaml:"query_response,omitempty"`
 	TLS                bool             `yaml:"tls,omitempty"`
 	TLSConfig          config.TLSConfig `yaml:"tls_config,omitempty"`
+	CrLf               bool             `yaml:"crlf,omitempty"`
 }
 
 type ICMPProbe struct {

--- a/config/testdata/blackbox-good.yml
+++ b/config/testdata/blackbox-good.yml
@@ -32,6 +32,7 @@ modules:
     prober: tcp
     timeout: 5s
     tcp:
+      crlf: true
       query_response:
       - expect: "^220 "
       - send: "EHLO prober"

--- a/example.yml
+++ b/example.yml
@@ -75,6 +75,7 @@ modules:
     prober: tcp
     timeout: 5s
     tcp:
+      crlf: true
       query_response:
         - expect: "^220 ([^ ]+) ESMTP (.+)$"
         - send: "EHLO prober"

--- a/prober/tcp.go
+++ b/prober/tcp.go
@@ -142,6 +142,10 @@ func ProbeTCP(ctx context.Context, target string, module config.Module, registry
 		probeSSLLastChainExpiryTimestampSeconds.Set(float64(getLastChainExpiry(&state).Unix()))
 		probeSSLLastInformation.WithLabelValues(getFingerprint(&state)).Set(1)
 	}
+	newLine := "\n"
+	if module.TCP.CrLf {
+		newLine = "\r\n"
+	}
 	scanner := bufio.NewScanner(conn)
 	for i, qr := range module.TCP.QueryResponse {
 		level.Info(logger).Log("msg", "Processing query response entry", "entry_number", i)
@@ -176,7 +180,8 @@ func ProbeTCP(ctx context.Context, target string, module config.Module, registry
 		}
 		if send != "" {
 			level.Debug(logger).Log("msg", "Sending line", "line", send)
-			if _, err := fmt.Fprintf(conn, "%s\n", send); err != nil {
+
+			if _, err := fmt.Fprintf(conn, "%s%s", send, newLine); err != nil {
 				level.Error(logger).Log("msg", "Failed to send", "err", err)
 				return false
 			}


### PR DESCRIPTION
Most internet protocols require `CRLF` for a newline. For example, for SMTP see https://tools.ietf.org/html/rfc2821#section-4.1.1

The blackbox exporter is only sending `LF`, which is accepted by some servers (e.g. Postfix) but not by others (e.g. Exchange). This PR adds an option to send `CRLF`. I've set it to false by default for backwards compatibility (although it should probably be enabled in most cases).