### PR TITLE
Do not connect via IP when behind proxy

### DIFF
--- a/prober/http.go
+++ b/prober/http.go
@@ -393,14 +393,16 @@ func ProbeHTTP(ctx context.Context, target string, module config.Module, registr
 
 	// Replace the host field in the URL with the IP we resolved.
 	origHost := targetURL.Host
-	if targetPort == "" {
-		if strings.Contains(ip.String(), ":") {
-			targetURL.Host = "[" + ip.String() + "]"
+	if httpClientConfig.ProxyURL.URL == nil {
+		if targetPort == "" {
+			if strings.Contains(ip.String(), ":") {
+				targetURL.Host = "[" + ip.String() + "]"
+			} else {
+				targetURL.Host = ip.String()
+			}
 		} else {
-			targetURL.Host = ip.String()
+			targetURL.Host = net.JoinHostPort(ip.String(), targetPort)
 		}
-	} else {
-		targetURL.Host = net.JoinHostPort(ip.String(), targetPort)
 	}
 
 	var body io.Reader


### PR DESCRIPTION
# Problem

My proxy only allows connections to some domains. It therefore needs to see the domain name of the connection in order to let it through. This is specially true for SSL connections, since the `Host` header gets sent inside the encrypted tunnel.

# Proposal

This PR avoids connecting via IP when using proxies. It modifies the HTTP prober to send the domain name in the clear in case any proxy URL is set.

This is an initial approach, of course. I will be happy to iterate this out with the prometheus/blackbox team until we get to an usable version.