### PR TITLE
Use preferred protocol first when resolving hostname

### DIFF
--- a/prober/utils.go
+++ b/prober/utils.go
@@ -15,7 +15,6 @@ package prober
 
 import (
 	"context"
-	"errors"
 	"fmt"
 	"hash/fnv"
 	"net"
@@ -30,23 +29,6 @@ import (
 var protocolToGauge = map[string]float64{
 	"ip4": 4,
 	"ip6": 6,
-}
-
-type resolver struct {
-	net.Resolver
-}
-
-// A simple wrapper around resolver.LookupIP.
-func (r *resolver) resolve(ctx context.Context, target string, protocol string) (*net.IPAddr, error) {
-	ips, err := r.LookupIP(ctx, protocol, target)
-	if err != nil {
-		return nil, err
-	}
-	for _, ip := range ips {
-		return &net.IPAddr{IP: ip}, nil
-	}
-	// Go doc did not specify when this could happen, better be defensive.
-	return nil, errors.New("calling LookupIP returned empty list of addresses")
 }
 
 // Returns the IP for the IPProtocol and lookup time.

--- a/prober/utils_test.go
+++ b/prober/utils_test.go
@@ -24,6 +24,7 @@ import (
 	"math/big"
 	"net"
 	"os"
+	"strings"
 	"testing"
 	"time"
 
@@ -162,13 +163,24 @@ func TestChooseProtocol(t *testing.T) {
 	registry = prometheus.NewPedanticRegistry()
 
 	ip, _, err = chooseProtocol(ctx, "ip4", false, "ipv6.google.com", registry, logger)
-	if err != nil && err.Error() != "unable to find ip; no fallback" {
+	if err != nil && !strings.HasPrefix(err.Error(), "unable to find ip; no fallback") {
 		t.Error(err)
 	} else if err == nil {
 		t.Error("should set error")
 	}
 	if ip != nil {
 		t.Error("without fallback it should not answer")
+	}
+
+	registry = prometheus.NewPedanticRegistry()
+	ip, _, err = chooseProtocol(ctx, "ip4", true, "does-not-exist.google.com", registry, logger)
+	if err != nil && !strings.HasPrefix(err.Error(), "unable to find ip; exhausted fallback") {
+		t.Error(err)
+	} else if err == nil {
+		t.Error("should set error")
+	}
+	if ip != nil {
+		t.Error("with exhausted fallback it should not answer")
 	}
 }
 

--- a/prober/utils_test.go
+++ b/prober/utils_test.go
@@ -173,7 +173,7 @@ func TestChooseProtocol(t *testing.T) {
 	}
 
 	registry = prometheus.NewPedanticRegistry()
-	ip, _, err = chooseProtocol(ctx, "ip4", true, "does-not-exist.google.com", registry, logger)
+	ip, _, err = chooseProtocol(ctx, "ip4", true, "does-not-exist.example.com", registry, logger)
 	if err != nil && !strings.HasPrefix(err.Error(), "unable to find ip; exhausted fallback") {
 		t.Error(err)
 	} else if err == nil {


### PR DESCRIPTION
Prior to this change, LookupIPAddr() is used to do the DNS query,
which sends two DNS queries for A/AAAA records, even if the config has
preferred protocol set to ip4 and does not allow fallback protocol.

This change will change to use LookupIP() with the preferred protocol,
and only try fallback protocol if it's set to true. In most cases doing
this will save one RTT of DNS query.

Fixes #724 