### PR TITLE
Update golangci-lint to 1.36.0

### DIFF
--- a/Makefile.common
+++ b/Makefile.common
@@ -83,7 +83,7 @@ PROMU_URL     := https://github.com/prometheus/promu/releases/download/v$(PROMU_
 
 GOLANGCI_LINT :=
 GOLANGCI_LINT_OPTS ?=
-GOLANGCI_LINT_VERSION ?= v1.18.0
+GOLANGCI_LINT_VERSION ?= v1.36.0
 # golangci-lint only supports linux, darwin and windows platforms on i386/amd64.
 # windows isn't included here because of the path separator being different.
 ifeq ($(GOHOSTOS),$(filter $(GOHOSTOS),linux darwin))

--- a/prober/utils_test.go
+++ b/prober/utils_test.go
@@ -209,7 +209,7 @@ func checkMetrics(expected map[string]map[string]map[string]struct{}, mfs []*dto
 				var lv labelValidation
 				if values != nil {
 					lv.values = map[string]valueValidation{}
-					for vname, _ := range values {
+					for vname := range values {
 						lv.values[vname] = valueValidation{}
 					}
 				}


### PR DESCRIPTION
Newer versions of golangci-lint flag a possible nil pointer dereference,
so rework some of the logic to make sure that's not the case.

Closes #738

Signed-off-by: Marcelo E. Magallon <marcelo.magallon@grafana.com>