### PR TITLE
Add health endpoint

### DIFF
--- a/main.go
+++ b/main.go
@@ -309,6 +309,10 @@ func run() int {
 			}
 		})
 	http.Handle(path.Join(*routePrefix, "/metrics"), promhttp.Handler())
+	http.HandleFunc(path.Join(*routePrefix, "/-/healthy"), func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		w.Write([]byte("Healthy"))
+	})
 	http.HandleFunc(path.Join(*routePrefix, "/probe"), func(w http.ResponseWriter, r *http.Request) {
 		sc.Lock()
 		conf := sc.C


### PR DESCRIPTION
The existing endpoints expose potentially sensitive data. So they cannot be used without authentication to check from the internet if the services is running.