### PR TITLE
Add source_ip_address support to http probes

### DIFF
--- a/CONFIGURATION.md
+++ b/CONFIGURATION.md
@@ -97,6 +97,9 @@ The other placeholders are specified separately.
   [ preferred_ip_protocol: <string> | default = "ip6" ]
   [ ip_protocol_fallback: <boolean> | default = true ]
 
+  # The source IP address.
+  [ source_ip_address: <string> ]
+
   # The body of the HTTP request used in probe.
   body: [ <string> ]
 

--- a/config/config.go
+++ b/config/config.go
@@ -177,6 +177,7 @@ type HTTPProbe struct {
 	ValidHTTPVersions            []string                `yaml:"valid_http_versions,omitempty"`
 	IPProtocol                   string                  `yaml:"preferred_ip_protocol,omitempty"`
 	IPProtocolFallback           bool                    `yaml:"ip_protocol_fallback,omitempty"`
+	SourceIPAddress              string                  `yaml:"source_ip_address,omitempty"`
 	NoFollowRedirects            bool                    `yaml:"no_follow_redirects,omitempty"`
 	FailIfSSL                    bool                    `yaml:"fail_if_ssl,omitempty"`
 	FailIfNotSSL                 bool                    `yaml:"fail_if_not_ssl,omitempty"`

--- a/go.mod
+++ b/go.mod
@@ -3,6 +3,7 @@ module github.com/prometheus/blackbox_exporter
 require (
 	github.com/go-kit/kit v0.10.0
 	github.com/miekg/dns v1.1.40
+	github.com/mwitkow/go-conntrack v0.0.0-20190716064945-2f068394615f
 	github.com/pkg/errors v0.9.1
 	github.com/prometheus/client_golang v1.9.0
 	github.com/prometheus/client_model v0.2.0


### PR DESCRIPTION
This is a logical continuation of #262.

It's the same as #765 but without changing `prometheus/common` as @roidelapluie suggested.

Signed-off-by: Ivan Babrou <github@ivan.computer>