### PR TITLE
Add test to verify published metrics do not change

### DIFF
--- a/prober/dns_test.go
+++ b/prober/dns_test.go
@@ -604,19 +604,18 @@ func TestDNSMetrics(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	expectedMetrics := map[string]map[string]map[string]struct{}{
-		"probe_dns_lookup_time_seconds": nil,
-		"probe_dns_duration_seconds": {
-			"phase": {
-				"resolve": {},
-				"connect": {},
-				"request": {},
+	checkRegistryMetrics(t, mfs,
+		map[string][]map[string]string{
+			"probe_dns_lookup_time_seconds": nil,
+			"probe_dns_duration_seconds": {
+				{"phase": "connect"},
+				{"phase": "request"},
+				{"phase": "resolve"},
 			},
-		},
-		"probe_dns_answer_rrs":     nil,
-		"probe_dns_authority_rrs":  nil,
-		"probe_dns_additional_rrs": nil,
-	}
-
-	checkMetrics(expectedMetrics, mfs, t)
+			"probe_dns_answer_rrs":     nil,
+			"probe_dns_authority_rrs":  nil,
+			"probe_dns_additional_rrs": nil,
+			"probe_ip_addr_hash":       nil,
+			"probe_ip_protocol":        nil,
+		})
 }

--- a/prober/http_test.go
+++ b/prober/http_test.go
@@ -863,6 +863,35 @@ func TestHTTPPhases(t *testing.T) {
 	}
 
 	checkMetrics(expectedMetrics, mfs, t)
+
+	checkRegistryMetrics(t, mfs,
+		map[string][]map[string]string{
+			"probe_dns_lookup_time_seconds": nil,
+			"probe_failed_due_to_regex":     nil,
+			"probe_http_content_length":     nil,
+			"probe_http_duration_seconds": {
+				{"phase": "connect"},
+				{"phase": "processing"},
+				{"phase": "resolve"},
+				{"phase": "transfer"},
+				{"phase": "tls"},
+			},
+			"probe_http_redirects":                          nil,
+			"probe_http_ssl":                                nil,
+			"probe_http_status_code":                        nil,
+			"probe_http_uncompressed_body_length":           nil,
+			"probe_http_version":                            nil,
+			"probe_ip_addr_hash":                            nil,
+			"probe_ip_protocol":                             nil,
+			"probe_ssl_earliest_cert_expiry":                nil,
+			"probe_ssl_last_chain_expiry_timestamp_seconds": nil,
+			"probe_ssl_last_chain_info": {
+				{"fingerprint_sha256": "448f628a8a65aa18560e53a80c53acb38c51b427df0334082349141147dc9bf6"},
+			},
+			"probe_tls_version_info": {
+				{"version": "TLS 1.3"},
+			}})
+
 }
 
 func TestCookieJar(t *testing.T) {

--- a/prober/icmp_test.go
+++ b/prober/icmp_test.go
@@ -1,0 +1,77 @@
+// Copyright 2016 The Prometheus Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package prober
+
+import (
+	"bytes"
+	"context"
+	"os"
+	"testing"
+	"time"
+
+	"github.com/go-kit/kit/log"
+	"github.com/prometheus/blackbox_exporter/config"
+	"github.com/prometheus/client_golang/prometheus"
+)
+
+func TestProbeICMP(t *testing.T) {
+	if os.Getenv("CI") == "true" {
+		t.Skip("skipping; not enough privileges to set up ICMP test")
+	}
+
+	timeout := 2000 * time.Millisecond
+	ctx, cancel := context.WithDeadline(context.Background(), time.Now().Add(timeout))
+	defer cancel()
+
+	registry := prometheus.NewRegistry()
+	logbuf := &bytes.Buffer{}
+
+	success := ProbeICMP(
+		ctx,
+		"127.0.0.1",
+		config.Module{
+			Prober:  "icmp",
+			Timeout: timeout,
+			ICMP: config.ICMPProbe{
+				IPProtocol:         "ip4",
+				IPProtocolFallback: false,
+				PayloadSize:        64,
+			},
+		},
+		registry,
+		log.NewLogfmtLogger(logbuf),
+	)
+
+	if success != true {
+		t.Fatalf("ProbeICMP failed unexpectedly:\n\n%s", logbuf.String())
+	}
+
+	mfs, err := registry.Gather()
+	if err != nil {
+		t.Fatalf("unexpected error gathering metrics: %s", err.Error())
+	}
+
+	checkRegistryMetrics(t, mfs,
+		map[string][]map[string]string{
+			"probe_dns_lookup_time_seconds": nil,
+			"probe_icmp_duration_seconds": {
+				{"phase": "resolve"},
+				{"phase": "rtt"},
+				{"phase": "setup"},
+			},
+			"probe_icmp_reply_hop_limit": nil,
+			"probe_ip_addr_hash":         nil,
+			"probe_ip_protocol":          nil,
+		})
+}

--- a/prober/internal/testcert.go
+++ b/prober/internal/testcert.go
@@ -1,0 +1,45 @@
+// Copyright 2015 The Go Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package internal
+
+import "strings"
+
+// LocalhostCert is a PEM-encoded TLS cert with SAN IPs
+// "127.0.0.1" and "[::1]", expiring at Jan 29 16:00:00 2084 GMT.
+// generated from src/crypto/tls:
+// go run generate_cert.go  --rsa-bits 1024 --host 127.0.0.1,::1,example.com --ca --start-date "Jan 1 00:00:00 1970" --duration=1000000h
+var LocalhostCert = []byte(`-----BEGIN CERTIFICATE-----
+MIICEzCCAXygAwIBAgIQMIMChMLGrR+QvmQvpwAU6zANBgkqhkiG9w0BAQsFADAS
+MRAwDgYDVQQKEwdBY21lIENvMCAXDTcwMDEwMTAwMDAwMFoYDzIwODQwMTI5MTYw
+MDAwWjASMRAwDgYDVQQKEwdBY21lIENvMIGfMA0GCSqGSIb3DQEBAQUAA4GNADCB
+iQKBgQDuLnQAI3mDgey3VBzWnB2L39JUU4txjeVE6myuDqkM/uGlfjb9SjY1bIw4
+iA5sBBZzHi3z0h1YV8QPuxEbi4nW91IJm2gsvvZhIrCHS3l6afab4pZBl2+XsDul
+rKBxKKtD1rGxlG4LjncdabFn9gvLZad2bSysqz/qTAUStTvqJQIDAQABo2gwZjAO
+BgNVHQ8BAf8EBAMCAqQwEwYDVR0lBAwwCgYIKwYBBQUHAwEwDwYDVR0TAQH/BAUw
+AwEB/zAuBgNVHREEJzAlggtleGFtcGxlLmNvbYcEfwAAAYcQAAAAAAAAAAAAAAAA
+AAAAATANBgkqhkiG9w0BAQsFAAOBgQCEcetwO59EWk7WiJsG4x8SY+UIAA+flUI9
+tyC4lNhbcF2Idq9greZwbYCqTTTr2XiRNSMLCOjKyI7ukPoPjo16ocHj+P3vZGfs
+h1fIw3cSS2OolhloGw/XM6RWPWtPAlGykKLciQrBru5NAPvCMsb/I1DAceTiotQM
+fblo6RBxUQ==
+-----END CERTIFICATE-----`)
+
+// LocalhostKey is the private key for localhostCert.
+var LocalhostKey = []byte(testingKey(`-----BEGIN RSA TESTING KEY-----
+MIICXgIBAAKBgQDuLnQAI3mDgey3VBzWnB2L39JUU4txjeVE6myuDqkM/uGlfjb9
+SjY1bIw4iA5sBBZzHi3z0h1YV8QPuxEbi4nW91IJm2gsvvZhIrCHS3l6afab4pZB
+l2+XsDulrKBxKKtD1rGxlG4LjncdabFn9gvLZad2bSysqz/qTAUStTvqJQIDAQAB
+AoGAGRzwwir7XvBOAy5tM/uV6e+Zf6anZzus1s1Y1ClbjbE6HXbnWWF/wbZGOpet
+3Zm4vD6MXc7jpTLryzTQIvVdfQbRc6+MUVeLKwZatTXtdZrhu+Jk7hx0nTPy8Jcb
+uJqFk541aEw+mMogY/xEcfbWd6IOkp+4xqjlFLBEDytgbIECQQDvH/E6nk+hgN4H
+qzzVtxxr397vWrjrIgPbJpQvBsafG7b0dA4AFjwVbFLmQcj2PprIMmPcQrooz8vp
+jy4SHEg1AkEA/v13/5M47K9vCxmb8QeD/asydfsgS5TeuNi8DoUBEmiSJwma7FXY
+fFUtxuvL7XvjwjN5B30pNEbc6Iuyt7y4MQJBAIt21su4b3sjXNueLKH85Q+phy2U
+fQtuUE9txblTu14q3N7gHRZB4ZMhFYyDy8CKrN2cPg/Fvyt0Xlp/DoCzjA0CQQDU
+y2ptGsuSmgUtWj3NM9xuwYPm+Z/F84K6+ARYiZ6PYj013sovGKUFfYAqVXVlxtIX
+qyUBnu3X9ps8ZfjLZO7BAkEAlT4R5Yl6cGhaJQYZHOde3JEMhNRcVFMO8dJDaFeo
+f9Oeos0UUothgiDktdQHxdNEwLjQf7lJJBzV+5OtwswCWA==
+-----END RSA TESTING KEY-----`))
+
+func testingKey(s string) string { return strings.ReplaceAll(s, "TESTING KEY", "PRIVATE KEY") }


### PR DESCRIPTION
The new checkRegistryMetrics verifies that the metrics produced by a particular probe match the expected metrics. Use this function in tests so that if a change adds or deletes metrics, the test has to be modified accordingly and it doesn't slip thru.

The probes involving TLS are tricky because they contain the fingerprint of the certificate. For the HTTP prober, since we are using the httptest package, the localhost certificate is actually known and fixed, so it's OK to embed the fingerprint in the test. For TCP, we are generating the certificate using random data, so the fingerprint changes each time. Change this to follow a similar strategy as the httptest package. The `prober/internal/testcert.go` file is actually copied from the Go source and it's the same key and certificate used in the httptest.

Signed-off-by: Marcelo E. Magallon <marcelo.magallon@grafana.com>