### PR TITLE
Fix example ssh_banner check: Send identification string

### DIFF
--- a/blackbox.yml
+++ b/blackbox.yml
@@ -20,6 +20,7 @@ modules:
     tcp:
       query_response:
       - expect: "^SSH-2.0-"
+      - send: "SSH-2.0-blackbox-ssh-check"
   irc_banner:
     prober: tcp
     tcp:


### PR DESCRIPTION
This is to reduce log spam:

"sshd[3750]: Did not receive identification string from ..:"

There will still be a "Connection closed by" message.