### PR TITLE
Add http endpoint support

### DIFF
--- a/CONFIGURATION.md
+++ b/CONFIGURATION.md
@@ -45,6 +45,9 @@ The other placeholders are specified separately.
   # The HTTP method the probe will use.
   [ method: <string> | default = "GET" ]
 
+  # Endpint IP (IP or IP:Portand port) to send HTTP requests, skip DNS lookup.
+  [ endpoint: <string> ]
+
   # The HTTP headers set for the probe.
   headers:
     [ <string>: <string> ... ]

--- a/config/config.go
+++ b/config/config.go
@@ -198,6 +198,7 @@ type HTTPProbe struct {
 	NoFollowRedirects            *bool                   `yaml:"no_follow_redirects,omitempty"`
 	FailIfSSL                    bool                    `yaml:"fail_if_ssl,omitempty"`
 	FailIfNotSSL                 bool                    `yaml:"fail_if_not_ssl,omitempty"`
+	Endpoint                     string                  `yaml:"endpoint,omitempty"`
 	Method                       string                  `yaml:"method,omitempty"`
 	Headers                      map[string]string       `yaml:"headers,omitempty"`
 	FailIfBodyMatchesRegexp      []Regexp                `yaml:"fail_if_body_matches_regexp,omitempty"`

--- a/example.yml
+++ b/example.yml
@@ -28,6 +28,16 @@ modules:
         insecure_skip_verify: false
       preferred_ip_protocol: "ip4" # defaults to "ip6"
       ip_protocol_fallback: false  # no fallback to "ip6"
+  http_2xx_example_with_endpoint:
+    prober: http
+    timeout: 5s
+    http:
+      endpoint: "1.1.1.1:443"
+      valid_http_versions: ["HTTP/1.1", "HTTP/2.0"]
+      valid_status_codes: []  # Defaults to 2xx
+      method: GET
+      preferred_ip_protocol: "ip4" # defaults to "ip6"
+      ip_protocol_fallback: false  # no fallback to "ip6"
   http_post_2xx:
     prober: http
     timeout: 5s

--- a/prober/http.go
+++ b/prober/http.go
@@ -234,6 +234,7 @@ func (bc *byteCounter) Read(p []byte) (int, error) {
 
 func ProbeHTTP(ctx context.Context, target string, module config.Module, registry *prometheus.Registry, logger log.Logger) (success bool) {
 	var redirects int
+	var ip *net.IPAddr
 	var (
 		durationGaugeVec = prometheus.NewGaugeVec(prometheus.GaugeOpts{
 			Name: "probe_http_duration_seconds",
@@ -332,12 +333,16 @@ func ProbeHTTP(ctx context.Context, target string, module config.Module, registr
 	targetHost := targetURL.Hostname()
 	targetPort := targetURL.Port()
 
-	ip, lookupTime, err := chooseProtocol(ctx, module.HTTP.IPProtocol, module.HTTP.IPProtocolFallback, targetHost, registry, logger)
-	if err != nil {
-		level.Error(logger).Log("msg", "Error resolving address", "err", err)
-		return false
+	if len(module.HTTP.Endpoint) == 0 {
+		// do DNS lookup when no custom endpoint is set
+		lookupIp, lookupTime, err := chooseProtocol(ctx, module.HTTP.IPProtocol, module.HTTP.IPProtocolFallback, targetHost, registry, logger)
+		if err != nil {
+			level.Error(logger).Log("msg", "Error resolving address", "err", err)
+			return false
+		}
+		durationGaugeVec.WithLabelValues("resolve").Add(lookupTime)
+		ip = lookupIp
 	}
-	durationGaugeVec.WithLabelValues("resolve").Add(lookupTime)
 
 	httpClientConfig := module.HTTP.HTTPClientConfig
 	if len(httpClientConfig.TLSConfig.ServerName) == 0 {
@@ -384,16 +389,21 @@ func ProbeHTTP(ctx context.Context, target string, module config.Module, registr
 		httpConfig.Method = "GET"
 	}
 
-	// Replace the host field in the URL with the IP we resolved.
 	origHost := targetURL.Host
-	if targetPort == "" {
-		if strings.Contains(ip.String(), ":") {
-			targetURL.Host = "[" + ip.String() + "]"
-		} else {
-			targetURL.Host = ip.String()
-		}
+	if len(module.HTTP.Endpoint) != 0 {
+		// Use endpoint from configuration (without DNS lookup)
+		targetURL.Host = module.HTTP.Endpoint
 	} else {
-		targetURL.Host = net.JoinHostPort(ip.String(), targetPort)
+		// Replace the host field in the URL with the IP we resolved.
+		if targetPort == "" {
+			if strings.Contains(ip.String(), ":") {
+				targetURL.Host = "[" + ip.String() + "]"
+			} else {
+				targetURL.Host = ip.String()
+			}
+		} else {
+			targetURL.Host = net.JoinHostPort(ip.String(), targetPort)
+		}
 	}
 
 	var body io.Reader


### PR DESCRIPTION
Add support for custom endpoint (IP/Port or full hostname) to make probes possible in specific and complex environments and to test the service chain:

- support for checking services in a service chain (app gateway -> loadbalancer -> ingress controller -> app) to test http response of eg. the kubernetes ingress (from inside the cluster by using `xxx.xxx.svc.cluster.local` as `endpoint` where you cannot reach the loadbalancer due to cloud limitations) and get the ability to setup alerts on probe failure and TLS certificate expiry
- support for checking of "hidden" services which are not directly reachable (eg where there is a NAT in between cloud and on premise and DNS resolves to on premise IPs)
- easier use of prometheus-operator for such checks/environments

example module configuration:
```
  http_2xx_example_with_endpoint:
    prober: http
    timeout: 5s
    http:
      endpoint: "1.1.1.1:443"
      valid_http_versions: ["HTTP/1.1", "HTTP/2.0"]
      valid_status_codes: []  # Defaults to 2xx
      method: GET
      preferred_ip_protocol: "ip4" # defaults to "ip6"
      ip_protocol_fallback: false  # no fallback to "ip6"

  http_2xx_ingress_internal:
    prober: http
    timeout: 5s
    http:
      endpoint: "controller.ingress.svc.cluster.local:80"
      valid_http_versions: ["HTTP/1.1", "HTTP/2.0"]
      valid_status_codes: []  # Defaults to 2xx
      method: GET
      preferred_ip_protocol: "ip4" # defaults to "ip6"
      ip_protocol_fallback: false  # no fallback to "ip6"
```