### PR TITLE
Accept HTTP headers in request parameters

### DIFF
--- a/prober/http.go
+++ b/prober/http.go
@@ -341,9 +341,20 @@ func ProbeHTTP(ctx context.Context, target string, module config.Module, registr
 
 	httpClientConfig := module.HTTP.HTTPClientConfig
 	if len(httpClientConfig.TLSConfig.ServerName) == 0 {
-		// If there is no `server_name` in tls_config, use
-		// the hostname of the target.
-		httpClientConfig.TLSConfig.ServerName = targetHost
+		// If there is no `server_name` in tls_config it makes
+		// sense to use a host header value to avoid possible
+		// TLS handshake problems.
+		changed := false
+		for name, value := range httpConfig.Headers {
+			if strings.Title(name) == "Host" {
+				httpClientConfig.TLSConfig.ServerName = value
+				changed = true
+			}
+		}
+		if !changed {
+			// Otherwise use the hostname of the target.
+			httpClientConfig.TLSConfig.ServerName = targetHost
+		}
 	}
 	client, err := pconfig.NewClientFromConfig(httpClientConfig, "http_probe", pconfig.WithKeepAlivesDisabled())
 	if err != nil {


### PR DESCRIPTION
Hello,

I've come to a problem when I need to setup blackbox monitoring for each edge server under a domain name. I found this way to acheive that:

* use `dns_sd_config` to get a list of server IP addresses;
* create a module with hard-coded Host header in it:
```yml
modules:
  http_2xx_example:
    http:
      headers:
        Host: vhost.example.com
```
* disable SSL check (still fails with CloudFlare) or try to set `httpClientConfig.TLSConfig.ServerName` via module configuration (I saw it as a part of the module but found no example). 

Having several dozens domains to monitor, I considered this approach unsatisfying and so I made this feature. See the updated README.md for examples.

Also, this can be used to change User-Agent (https://github.com/prometheus/blackbox_exporter/pull/557).