### PR TITLE
Add hostname parameter

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,6 +101,33 @@ scrape_configs:
         replacement: 127.0.0.1:9115  # The blackbox exporter's real hostname:port.
 ```
 
+HTTP probes can accept an additional `hostname` parameter that will set `Host` header and TLS SNI. This can be especially useful with `dns_sd_config`:
+```yaml
+scrape_configs:
+  - job_name: blackbox_all
+    metrics_path: /probe
+    params:
+      module: [ http_2xx ]  # Look for a HTTP 200 response.
+    dns_sd_configs:
+      - names:
+          - example.com
+          - prometheus.io
+        type: A
+        port: 443
+    relabel_configs:
+      - source_labels: [__address__]
+        target_label: __param_target
+        replacement: https://$1/  # Make probe URL be like https://1.2.3.4:443/
+      - source_labels: [__param_target]
+        target_label: instance
+      - target_label: __address__
+        replacement: 127.0.0.1:9115  # The blackbox exporter's real hostname:port.
+      - source_labels: [__meta_dns_name]
+        target_label: __param_hostname  # Make domain name become 'Host' header for probe requests
+      - source_labels: [__meta_dns_name]
+        target_label: vhost  # and store it in 'vhost' label
+```
+
 ## Permissions
 
 The ICMP probe requires elevated privileges to function:

--- a/main.go
+++ b/main.go
@@ -122,7 +122,7 @@ func probeHandler(w http.ResponseWriter, r *http.Request, c *config.Config, logg
 
 	hostname := params.Get("hostname")
 	if module.Prober == "http" && hostname != "" {
-		err = setHttpHost(hostname, &module)
+		err = setHTTPHost(hostname, &module)
 		if err != nil {
 			http.Error(w, err.Error(), http.StatusBadRequest)
 			return
@@ -159,7 +159,7 @@ func probeHandler(w http.ResponseWriter, r *http.Request, c *config.Config, logg
 	h.ServeHTTP(w, r)
 }
 
-func setHttpHost(hostname string, module *config.Module) error {
+func setHTTPHost(hostname string, module *config.Module) error {
 	// By creating a new hashmap and copying values there we
 	// ensure that the initial configuration remain intact.
 	headers := make(map[string]string)

--- a/main.go
+++ b/main.go
@@ -120,6 +120,23 @@ func probeHandler(w http.ResponseWriter, r *http.Request, c *config.Config, logg
 		return
 	}
 
+	if module.Prober == "http" {
+		paramHost := params.Get("hostname")
+		if paramHost != "" {
+			if module.HTTP.Headers == nil {
+				module.HTTP.Headers = make(map[string]string)
+			} else {
+				for name, value := range module.HTTP.Headers {
+					if strings.Title(name) == "Host" && value != paramHost {
+						http.Error(w, fmt.Sprintf("Host header defined both in module configuration (%s) and with parameter 'hostname' (%s)", value, paramHost), http.StatusBadRequest)
+						return
+					}
+				}
+			}
+			module.HTTP.Headers["Host"] = paramHost
+		}
+	}
+
 	sl := newScrapeLogger(logger, moduleName, target)
 	level.Info(sl).Log("msg", "Beginning probe", "probe", module.Prober, "timeout_seconds", timeoutSeconds)
 

--- a/prober/http.go
+++ b/prober/http.go
@@ -341,19 +341,17 @@ func ProbeHTTP(ctx context.Context, target string, module config.Module, registr
 
 	httpClientConfig := module.HTTP.HTTPClientConfig
 	if len(httpClientConfig.TLSConfig.ServerName) == 0 {
-		// If there is no `server_name` in tls_config it makes
-		// sense to use the host header value to avoid possible
-		// TLS handshake problems.
-		changed := false
+		// If there is no `server_name` in tls_config, use
+		// the hostname of the target.
+		httpClientConfig.TLSConfig.ServerName = targetHost
+
+		// However, if there is a Host header it is better to use
+		// its value instead. This helps avoid TLS handshake error
+		// if targetHost is an IP address.
 		for name, value := range httpConfig.Headers {
 			if strings.Title(name) == "Host" {
 				httpClientConfig.TLSConfig.ServerName = value
-				changed = true
 			}
-		}
-		if !changed {
-			// Otherwise use the hostname of the target.
-			httpClientConfig.TLSConfig.ServerName = targetHost
 		}
 	}
 	client, err := pconfig.NewClientFromConfig(httpClientConfig, "http_probe", pconfig.WithKeepAlivesDisabled())


### PR DESCRIPTION
This is refactoring of https://github.com/prometheus/blackbox_exporter/pull/816
As per [the design doc](https://docs.google.com/document/d/1VwqXi2TOb5KXaZY6Iio7411x64pJao3GusX8MqYsJ2g), the exporter now accept `hostname` parameter, which sets `Host` header for HTTP probes. It also sets TLS server name (if it is not already defined by module configuration) to avoid TLS handshake problems when `target` is an IP address. Setting `Host` with both module configuration and `hostname` parameter results in 400 Bad Request.