### PR TITLE
Add support for resolving the default gateway.

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,7 +72,7 @@ Additionally, an [example configuration](example.yml) is also available.
 HTTP, HTTPS (via the `http` prober), DNS, TCP socket and ICMP (see permissions section) are currently supported.
 Additional modules can be defined to meet your needs.
 
-The timeout of each probe is automatically determined from the `scrape_timeout` in the [Prometheus config](https://prometheus.io/docs/operating/configuration/#configuration-file), slightly reduced to allow for network delays. 
+The timeout of each probe is automatically determined from the `scrape_timeout` in the [Prometheus config](https://prometheus.io/docs/operating/configuration/#configuration-file), slightly reduced to allow for network delays.
 This can be further limited by the `timeout` in the Blackbox exporter config file. If neither is specified, it defaults to 120 seconds.
 
 ## Prometheus Configuration
@@ -100,6 +100,14 @@ scrape_configs:
       - target_label: __address__
         replacement: 127.0.0.1:9115  # The blackbox exporter's real hostname:port.
 ```
+
+The special hostname `default-gateway.internal` can be used to look up
+the host's default gateway. If you have an actual host named so,
+adding a trailing dot to make fully qualified will circumvent the
+special handling: `default-gateway.internal.`. Only IPv4 is currently
+supported. When the exporter runs in Docker, enabling `host` network
+mode is most useful, as otherwise you will probe the Docker interface
+on the same host.
 
 ## Permissions
 

--- a/go.mod
+++ b/go.mod
@@ -3,6 +3,7 @@ module github.com/prometheus/blackbox_exporter
 require (
 	github.com/andybalholm/brotli v1.0.2
 	github.com/go-kit/kit v0.10.0
+	github.com/jackpal/gateway v1.0.7
 	github.com/miekg/dns v1.1.41
 	github.com/pkg/errors v0.9.1
 	github.com/prometheus/client_golang v1.10.0

--- a/go.sum
+++ b/go.sum
@@ -134,6 +134,8 @@ github.com/hpcloud/tail v1.0.0/go.mod h1:ab1qPbhIpdTxEkNHXyeSf5vhxWSCs/tWer42PpO
 github.com/hudl/fargo v1.3.0/go.mod h1:y3CKSmjA+wD2gak7sUSXTAoopbhU08POFhmITJgmKTg=
 github.com/inconshreveable/mousetrap v1.0.0/go.mod h1:PxqpIevigyE2G7u3NXJIT2ANytuPF1OarO4DADm73n8=
 github.com/influxdata/influxdb1-client v0.0.0-20191209144304-8bf82d3c094d/go.mod h1:qj24IKcXYK6Iy9ceXlo3Tc+vtHo9lIhSX5JddghvEPo=
+github.com/jackpal/gateway v1.0.7 h1:7tIFeCGmpyrMx9qvT0EgYUi7cxVW48a0mMvnIL17bPM=
+github.com/jackpal/gateway v1.0.7/go.mod h1:aRcO0UFKt+MgIZmRmvOmnejdDT4Y1DNiNOsSd1AcIbA=
 github.com/jmespath/go-jmespath v0.0.0-20180206201540-c2b33e8439af/go.mod h1:Nht3zPeWKUH0NzdCt2Blrr5ys8VGpn0CEB0cQHVjt7k=
 github.com/jonboulle/clockwork v0.1.0/go.mod h1:Ii8DK3G1RaLaWxj9trq07+26W01tbo22gdxWY5EU2bo=
 github.com/jpillora/backoff v1.0.0 h1:uvFg412JmmHBHw7iwprIxkPMI+sGQ4kzOWsMeHnm2EA=


### PR DESCRIPTION
The magic hostname "default-gateway.internal" resolves to the host's
default gateway.

Currently, the gateway library only supports IPv4. Supported OSs are
FreeBSD, Linux, OS X (Darwin), Solaris, Windows.