### PR TITLE
Updated ipHash to calculate over the actual IP

### DIFF
--- a/prober/utils.go
+++ b/prober/utils.go
@@ -135,6 +135,6 @@ func chooseProtocol(ctx context.Context, IPProtocol string, fallbackIPProtocol b
 
 func ipHash(ip net.IP) float64 {
 	h := fnv.New32a()
-	h.Write(ip)
+	h.Write([]byte(ip.String()))
 	return float64(h.Sum32())
 }


### PR DESCRIPTION
The ipHash() function generates a hash from the resolved IP.

Because net.IP is a 16 bytes array, sometimes the array have leading 0 (depending if the target is an IP or hostname). Also, an IPv4 address could be represented as 0.0.0.0.0.0.0.0.0.0.255.255.8.8.8.8 in the byte array or just 8.8.8.8.0.0.0.0.0.0.0.0.0.0.0.0. This makes the hash unreliable.

Example:

```
host www.whatsmyip.org
www.whatsmyip.org has address 208.79.209.138

curl -s "localhost:9115/probe?target=www.whatsmyip.org&module=icmp&debug=true" | grep ^probe_ip_addr_hash
probe_ip_addr_hash 3.248520427e+09

curl -s "localhost:9115/probe?target=208.79.209.138&module=icmp&debug=true" | grep ^probe_ip_addr_hash
probe_ip_addr_hash 6.13293073e+08
```

Simply using String() and calculate checksum over the actual IP-string instead will fix this. Also, as a side effect, it is easier to precalculate hash and compare it (for example, I calculate the hash in Python that create metrics that is later compared to see if address resolves correct or not).