### PR TITLE
Add control of recursion desired flag for DNS probes

### DIFF
--- a/CONFIGURATION.md
+++ b/CONFIGURATION.md
@@ -189,6 +189,8 @@ query_name: <string>
 [ query_type: <string> | default = "ANY" ]
 [ query_class: <string> | default = "IN" ]
 
+[ recursion_desired: <boolean> | default = true ]
+
 # List of valid response codes.
 valid_rcodes:
   [ - <string> ... | default = "NOERROR" ]

--- a/CONFIGURATION.md
+++ b/CONFIGURATION.md
@@ -189,7 +189,8 @@ query_name: <string>
 [ query_type: <string> | default = "ANY" ]
 [ query_class: <string> | default = "IN" ]
 
-[ recursion_desired: <boolean> | default = true ]
+# Set the recursion desired (RD) flag in the request.
+[ recursion: <boolean> | default = true ]
 
 # List of valid response codes.
 valid_rcodes:

--- a/config/config.go
+++ b/config/config.go
@@ -82,7 +82,7 @@ var (
 	// DefaultDNSProbe set default value for DNSProbe
 	DefaultDNSProbe = DNSProbe{
 		IPProtocolFallback: true,
-		RecursionDesired:   true,
+		Recursion:          true,
 	}
 )
 
@@ -266,7 +266,7 @@ type DNSProbe struct {
 	QueryClass         string           `yaml:"query_class,omitempty"` // Defaults to IN.
 	QueryName          string           `yaml:"query_name,omitempty"`
 	QueryType          string           `yaml:"query_type,omitempty"`        // Defaults to ANY.
-	RecursionDesired   bool             `yaml:"recursion_desired,omitempty"` // Defaults to true.
+	Recursion          bool             `yaml:"recursion_desired,omitempty"` // Defaults to true.
 	ValidRcodes        []string         `yaml:"valid_rcodes,omitempty"`      // Defaults to NOERROR.
 	ValidateAnswer     DNSRRValidator   `yaml:"validate_answer_rrs,omitempty"`
 	ValidateAuthority  DNSRRValidator   `yaml:"validate_authority_rrs,omitempty"`

--- a/config/config.go
+++ b/config/config.go
@@ -82,6 +82,7 @@ var (
 	// DefaultDNSProbe set default value for DNSProbe
 	DefaultDNSProbe = DNSProbe{
 		IPProtocolFallback: true,
+		RecursionDesired:   true,
 	}
 )
 
@@ -264,8 +265,9 @@ type DNSProbe struct {
 	TransportProtocol  string           `yaml:"transport_protocol,omitempty"`
 	QueryClass         string           `yaml:"query_class,omitempty"` // Defaults to IN.
 	QueryName          string           `yaml:"query_name,omitempty"`
-	QueryType          string           `yaml:"query_type,omitempty"`   // Defaults to ANY.
-	ValidRcodes        []string         `yaml:"valid_rcodes,omitempty"` // Defaults to NOERROR.
+	QueryType          string           `yaml:"query_type,omitempty"`        // Defaults to ANY.
+	RecursionDesired   bool             `yaml:"recursion_desired,omitempty"` // Defaults to true.
+	ValidRcodes        []string         `yaml:"valid_rcodes,omitempty"`      // Defaults to NOERROR.
 	ValidateAnswer     DNSRRValidator   `yaml:"validate_answer_rrs,omitempty"`
 	ValidateAuthority  DNSRRValidator   `yaml:"validate_authority_rrs,omitempty"`
 	ValidateAdditional DNSRRValidator   `yaml:"validate_additional_rrs,omitempty"`

--- a/prober/dns.go
+++ b/prober/dns.go
@@ -250,7 +250,7 @@ func ProbeDNS(ctx context.Context, target string, module config.Module, registry
 
 	msg := new(dns.Msg)
 	msg.Id = dns.Id()
-	msg.RecursionDesired = true
+	msg.RecursionDesired = module.DNS.RecursionDesired
 	msg.Question = make([]dns.Question, 1)
 	msg.Question[0] = dns.Question{dns.Fqdn(module.DNS.QueryName), qt, qc}
 

--- a/prober/dns.go
+++ b/prober/dns.go
@@ -250,7 +250,7 @@ func ProbeDNS(ctx context.Context, target string, module config.Module, registry
 
 	msg := new(dns.Msg)
 	msg.Id = dns.Id()
-	msg.RecursionDesired = module.DNS.RecursionDesired
+	msg.RecursionDesired = module.DNS.Recursion
 	msg.Question = make([]dns.Question, 1)
 	msg.Question[0] = dns.Question{dns.Fqdn(module.DNS.QueryName), qt, qc}
 

--- a/prober/dns_test.go
+++ b/prober/dns_test.go
@@ -103,7 +103,7 @@ func TestRecursiveDNSResponse(t *testing.T) {
 				IPProtocol:         "ip4",
 				IPProtocolFallback: true,
 				QueryName:          "example.com",
-				RecursionDesired:   true,
+				Recursion:          true,
 			}, true,
 		},
 		{
@@ -111,7 +111,7 @@ func TestRecursiveDNSResponse(t *testing.T) {
 				IPProtocol:         "ip4",
 				IPProtocolFallback: true,
 				QueryName:          "example.com",
-				RecursionDesired:   true,
+				Recursion:          true,
 				ValidRcodes:        []string{"SERVFAIL", "NXDOMAIN"},
 			}, false,
 		},
@@ -120,7 +120,7 @@ func TestRecursiveDNSResponse(t *testing.T) {
 				IPProtocol:         "ip4",
 				IPProtocolFallback: true,
 				QueryName:          "example.com",
-				RecursionDesired:   true,
+				Recursion:          true,
 				ValidateAnswer: config.DNSRRValidator{
 					FailIfMatchesRegexp:    []string{".*7200.*"},
 					FailIfNotMatchesRegexp: []string{".*3600.*"},
@@ -132,7 +132,7 @@ func TestRecursiveDNSResponse(t *testing.T) {
 				IPProtocol:         "ip4",
 				IPProtocolFallback: true,
 				QueryName:          "example.com",
-				RecursionDesired:   true,
+				Recursion:          true,
 				ValidateAuthority: config.DNSRRValidator{
 					FailIfMatchesRegexp: []string{".*7200.*"},
 				},
@@ -143,7 +143,7 @@ func TestRecursiveDNSResponse(t *testing.T) {
 				IPProtocol:         "ip4",
 				IPProtocolFallback: true,
 				QueryName:          "example.com",
-				RecursionDesired:   true,
+				Recursion:          true,
 				ValidateAdditional: config.DNSRRValidator{
 					FailIfNotMatchesRegexp: []string{".*3600.*"},
 				},
@@ -154,7 +154,7 @@ func TestRecursiveDNSResponse(t *testing.T) {
 				IPProtocol:         "ip4",
 				IPProtocolFallback: true,
 				QueryName:          "example.com",
-				RecursionDesired:   false,
+				Recursion:          false,
 			}, false,
 		},
 	}
@@ -183,7 +183,7 @@ func TestRecursiveDNSResponse(t *testing.T) {
 				"probe_dns_authority_rrs":  0,
 				"probe_dns_additional_rrs": 0,
 			}
-			if !test.Probe.RecursionDesired {
+			if !test.Probe.Recursion {
 				expectedResults["probe_dns_answer_rrs"] = 0
 			}
 			checkRegistryResults(expectedResults, mfs, t)
@@ -494,7 +494,7 @@ func TestDNSProtocol(t *testing.T) {
 				QueryName:         "example.com",
 				TransportProtocol: protocol,
 				IPProtocol:        "ip6",
-				RecursionDesired:  true,
+				Recursion:         true,
 			},
 		}
 		registry := prometheus.NewRegistry()
@@ -518,7 +518,7 @@ func TestDNSProtocol(t *testing.T) {
 			Timeout: time.Second,
 			DNS: config.DNSProbe{
 				QueryName:         "example.com",
-				RecursionDesired:  true,
+				Recursion:         true,
 				TransportProtocol: protocol,
 				IPProtocol:        "ip4",
 			},
@@ -545,7 +545,7 @@ func TestDNSProtocol(t *testing.T) {
 			Timeout: time.Second,
 			DNS: config.DNSProbe{
 				QueryName:         "example.com",
-				RecursionDesired:  true,
+				Recursion:         true,
 				TransportProtocol: protocol,
 			},
 		}
@@ -570,8 +570,8 @@ func TestDNSProtocol(t *testing.T) {
 		module = config.Module{
 			Timeout: time.Second,
 			DNS: config.DNSProbe{
-				QueryName:        "example.com",
-				RecursionDesired: true,
+				QueryName: "example.com",
+				Recursion: true,
 			},
 		}
 		registry = prometheus.NewRegistry()
@@ -614,7 +614,7 @@ func TestDNSMetrics(t *testing.T) {
 			IPProtocol:         "ip4",
 			IPProtocolFallback: true,
 			QueryName:          "example.com",
-			RecursionDesired:   true,
+			Recursion:          true,
 		},
 	}
 	registry := prometheus.NewRegistry()

--- a/prober/utils_test.go
+++ b/prober/utils_test.go
@@ -162,7 +162,7 @@ func TestChooseProtocol(t *testing.T) {
 	registry = prometheus.NewPedanticRegistry()
 
 	ip, _, err = chooseProtocol(ctx, "ip4", false, "ipv6.google.com", registry, logger)
-	if err != nil && err.Error() != "address ipv6.google.com: no suitable address found" {
+	if err != nil && err.Error() != "address ipv6.google.com: no suitable address found" && err.Error() != "lookup ipv6.google.com: no such host" {
 		t.Error(err)
 	} else if err == nil {
 		t.Error("should set error")

--- a/prober/utils_test.go
+++ b/prober/utils_test.go
@@ -162,7 +162,7 @@ func TestChooseProtocol(t *testing.T) {
 	registry = prometheus.NewPedanticRegistry()
 
 	ip, _, err = chooseProtocol(ctx, "ip4", false, "ipv6.google.com", registry, logger)
-	if err != nil && err.Error() != "address ipv6.google.com: no suitable address found" && err.Error() != "lookup ipv6.google.com: no such host" {
+	if err != nil && err.Error() != "address ipv6.google.com: no suitable address found" {
 		t.Error(err)
 	} else if err == nil {
 		t.Error("should set error")


### PR DESCRIPTION
This defaults recursion desired to on to preserve existing behaviour,
but allows it to be configured.

Asked for in a comment in #474 and generally useful.

Signed-off-by: David Leadbeater <dgl@dgl.cx>