### PR TITLE
Negative maxTimeoutSeconds

### DIFF
--- a/main.go
+++ b/main.go
@@ -442,7 +442,7 @@ func getTimeout(r *http.Request, module config.Module, offset float64) (timeoutS
 	}
 
 	var maxTimeoutSeconds = timeoutSeconds - offset
-	if module.Timeout.Seconds() < maxTimeoutSeconds && module.Timeout.Seconds() > 0 {
+	if module.Timeout.Seconds() < maxTimeoutSeconds && module.Timeout.Seconds() > 0 || maxTimeoutSeconds < 0 {
 		timeoutSeconds = module.Timeout.Seconds()
 	} else {
 		timeoutSeconds = maxTimeoutSeconds


### PR DESCRIPTION
Setting a small timeout value in a scraper (Prometheus) without changing the default offset leads to negative timeout values.
Fixes #868

Signed-off-by: Kirill Zhdanov <kzhdanov@mirantis.com>