### PR TITLE
Added log line for received html body.

### DIFF
--- a/prober/http.go
+++ b/prober/http.go
@@ -50,6 +50,10 @@ func matchRegularExpressions(reader io.Reader, httpConfig config.HTTPProbe, logg
 		level.Error(logger).Log("msg", "Error reading HTTP body", "err", err)
 		return false
 	}
+
+	// Display received html body
+	level.Info(logger).Log("msg", "Received html body", "body", body)
+
 	for _, expression := range httpConfig.FailIfBodyMatchesRegexp {
 		if expression.Regexp.Match(body) {
 			level.Error(logger).Log("msg", "Body matched regular expression", "regexp", expression)


### PR DESCRIPTION
We had some troubles identifying why a specific HTTP probe with a `fail_if_body_matches_regexp` did not work for a specific website. In the end, the website started to deliver compressed data, so the regex was not working. For identifying such cases, printing the received HTML body would be handy.