### PR TITLE
gRPC added to README and Configuration

### DIFF
--- a/CONFIGURATION.md
+++ b/CONFIGURATION.md
@@ -30,6 +30,7 @@ The other placeholders are specified separately.
   [ tcp: <tcp_probe> ]
   [ dns: <dns_probe> ]
   [ icmp: <icmp_probe> ]
+  [ grpc: <grpc_probe> ]
 
 ```
 
@@ -258,6 +259,18 @@ validate_additional_rrs:
 # The size of the payload.
 [ payload_size: <int> ]
 
+```
+
+### <grpc_probe>
+
+```yml
+
+# The IP protocol of the gRPC probe (ip4, ip6).
+[ preferred_ip_protocol: <string> ]
+
+# Configuration for TLS protocol of gRPC probe.
+tls_config:
+  [ <tls_config> ]
 ```
 
 ### <tls_config>

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 [![Docker Pulls](https://img.shields.io/docker/pulls/prom/blackbox-exporter.svg?maxAge=604800)][hub]
 
 The blackbox exporter allows blackbox probing of endpoints over
-HTTP, HTTPS, DNS, TCP and ICMP.
+HTTP, HTTPS, DNS, TCP, ICMP and gRPC.
 
 ## Running this software
 

--- a/README.md
+++ b/README.md
@@ -69,7 +69,7 @@ To specify which [configuration file](CONFIGURATION.md) to load, use the `--conf
 
 Additionally, an [example configuration](example.yml) is also available.
 
-HTTP, HTTPS (via the `http` prober), DNS, TCP socket and ICMP (see permissions section) are currently supported.
+HTTP, HTTPS (via the `http` prober), DNS, TCP socket, ICMP and gRPC (see permissions section) are currently supported.
 Additional modules can be defined to meet your needs.
 
 The timeout of each probe is automatically determined from the `scrape_timeout` in the [Prometheus config](https://prometheus.io/docs/operating/configuration/#configuration-file), slightly reduced to allow for network delays. 


### PR DESCRIPTION
Currenly gRPC is being supported by Blackbox exporter but not mentioned in the documentation. 
https://github.com/prometheus/blackbox_exporter/issues/893