### PR TITLE
prober/tls: Add fingerprint info for the first certificate

### DIFF
--- a/prober/tcp_test.go
+++ b/prober/tcp_test.go
@@ -197,6 +197,7 @@ func TestTCPConnectionWithTLS(t *testing.T) {
 	expectedResults := map[string]float64{
 		"probe_ssl_earliest_cert_expiry": float64(certExpiry.Unix()),
 		"probe_ssl_last_chain_info":      1,
+		"probe_ssl_first_chain_info":     1,
 		"probe_tls_version_info":         1,
 	}
 	checkRegistryResults(expectedResults, mfs, t)
@@ -321,6 +322,7 @@ func TestTCPConnectionWithTLSAndVerifiedCertificateChain(t *testing.T) {
 		"probe_ssl_earliest_cert_expiry":                float64(olderRootCertExpiry.Unix()),
 		"probe_ssl_last_chain_expiry_timestamp_seconds": float64(serverCertExpiry.Unix()),
 		"probe_ssl_last_chain_info":                     1,
+		"probe_ssl_first_chain_info":                    1,
 		"probe_tls_version_info":                        1,
 	}
 	checkRegistryResults(expectedResults, mfs, t)

--- a/prober/tls.go
+++ b/prober/tls.go
@@ -30,8 +30,15 @@ func getEarliestCertExpiry(state *tls.ConnectionState) time.Time {
 	return earliest
 }
 
-func getFingerprint(state *tls.ConnectionState) string {
+func getLastFingerprint(state *tls.ConnectionState) string {
 	cert := state.PeerCertificates[0]
+	fingerprint := sha256.Sum256(cert.Raw)
+	return hex.EncodeToString(fingerprint[:])
+}
+
+func getFirstFingerprint(state *tls.ConnectionState) string {
+	first := len(state.PeerCertificates) - 1
+	cert := state.PeerCertificates[first]
 	fingerprint := sha256.Sum256(cert.Raw)
 	return hex.EncodeToString(fingerprint[:])
 }


### PR DESCRIPTION
We use Let's Encrypt and specifically request[1] the "ISRG Root X1"
certificate _only_ in our preferred chain, in order to preserve
compatibility with some older OpenSSL clients that have the expired
"DST Root CA X3" certificate in their trust store[2]. We'd like to
monitor that we're continuing to request and serve the right chain, so
add fingerprint for the first certificate too.

Tested against two endpoints with different preferred chains
(cloud.mongdb.com is ISRG only)

james@SeeZero ~/src/blackbox_exporter $ ./blackbox_exporter &> /dev/null &
james@SeeZero ~/src/blackbox_exporter $ curl 'localhost:9115/probe?target=cloud.mongodb.com/api/client&module=http_2xx' 2> /dev/null |grep first_chain_info
probe_ssl_first_chain_info{fingerprint_sha256="67add1166b020ae61b8f5fc96813c04c2aa589960796865572a3c7e737613dfd"} 1
james@SeeZero ~/src/blackbox_exporter $ curl 'localhost:9115/probe?target=realm.mongodb.com/api/client&module=http_2xx' 2> /dev/null |grep first_chain_info
probe_ssl_first_chain_info{fingerprint_sha256="6d99fb265eb1c5b3744765fcbc648f3cd8e1bffafdc4c2f99b9d47cf7ff1c24f"} 1
james@SeeZero ~/src/blackbox_exporter $

[1] https://github.com/nginx-proxy/acme-companion/blob/main/docs/Let's-Encrypt-and-ACME.md#preferred-chain
[2] https://www.openssl.org/blog/blog/2021/09/13/LetsEncryptRootCertExpire/