### PR TITLE
Make caser a local varialbe, not a global one.

### DIFF
--- a/prober/http_test.go
+++ b/prober/http_test.go
@@ -35,6 +35,8 @@ import (
 	"github.com/go-kit/log"
 	"github.com/prometheus/client_golang/prometheus"
 	pconfig "github.com/prometheus/common/config"
+	"golang.org/x/text/cases"
+	"golang.org/x/text/language"
 
 	"github.com/prometheus/blackbox_exporter/config"
 )
@@ -1068,6 +1070,7 @@ func TestHTTPHeaders(t *testing.T) {
 		"Accept-Language": "en-US",
 	}
 	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		caser := cases.Title(language.Und)
 		for key, value := range headers {
 			if caser.String(key) == "Host" {
 				if r.Host != value {


### PR DESCRIPTION
The cases.Caser returned by calling cases.Title *cannot* be shared among
goroutines. This might happen when Prometheus tries to scrape multiple
targets at the same time. From the docs:

A Caser may be stateful and should therefore not be shared between
goroutines.

Fixes: #922

Signed-off-by: Marcelo E. Magallon <marcelo.magallon@grafana.com>