### PR TITLE
Print to stdout, not stderr

### DIFF
--- a/main.go
+++ b/main.go
@@ -244,6 +244,7 @@ func main() {
 }
 
 func run() int {
+	kingpin.CommandLine.UsageWriter(os.Stdout)
 	promlogConfig := &promlog.Config{}
 	flag.AddFlags(kingpin.CommandLine, promlogConfig)
 	kingpin.Version(version.Print("blackbox_exporter"))


### PR DESCRIPTION
Following the change in
https://github.com/prometheus/prometheus/pull/8542 blackbox_exporter
will send all usage out to stdout, not stderr.

Fixes: #912
Signed-off-by: Marcelo E. Magallon <marcelo.magallon@grafana.com>