### PR TITLE
Use textproto.CanonicalMIMEHeaderKey

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -17,6 +17,7 @@ import (
 	"errors"
 	"fmt"
 	"math"
+	"net/textproto"
 	"os"
 	"regexp"
 	"runtime"
@@ -26,8 +27,6 @@ import (
 	"sync"
 	"time"
 
-	"golang.org/x/text/cases"
-	"golang.org/x/text/language"
 	yaml "gopkg.in/yaml.v3"
 
 	"github.com/alecthomas/units"
@@ -88,8 +87,6 @@ var (
 		IPProtocolFallback: true,
 		Recursion:          true,
 	}
-
-	caser = cases.Title(language.Und)
 )
 
 func init() {
@@ -333,7 +330,7 @@ func (s *HTTPProbe) UnmarshalYAML(unmarshal func(interface{}) error) error {
 	}
 
 	for key, value := range s.Headers {
-		switch caser.String(key) {
+		switch textproto.CanonicalMIMEHeaderKey(key) {
 		case "Accept-Encoding":
 			if !isCompressionAcceptEncodingValid(s.Compression, value) {
 				return fmt.Errorf(`invalid configuration "%s: %s", "compression: %s"`, key, value, s.Compression)

--- a/go.mod
+++ b/go.mod
@@ -11,7 +11,6 @@ require (
 	github.com/prometheus/common v0.34.0
 	github.com/prometheus/exporter-toolkit v0.7.1
 	golang.org/x/net v0.0.0-20220425223048-2871e0cb64e4
-	golang.org/x/text v0.3.7
 	google.golang.org/grpc v1.46.0
 	gopkg.in/alecthomas/kingpin.v2 v2.2.6
 	gopkg.in/yaml.v3 v3.0.0-20210107192922-496545a6307b
@@ -31,6 +30,7 @@ require (
 	golang.org/x/mod v0.4.2 // indirect
 	golang.org/x/oauth2 v0.0.0-20220223155221-ee480838109b // indirect
 	golang.org/x/sys v0.0.0-20220114195835-da31bd327af9 // indirect
+	golang.org/x/text v0.3.7 // indirect
 	golang.org/x/tools v0.1.6-0.20210726203631-07bc1bf47fb2 // indirect
 	golang.org/x/xerrors v0.0.0-20200804184101-5ec99f83aff1 // indirect
 	google.golang.org/appengine v1.6.6 // indirect

--- a/main.go
+++ b/main.go
@@ -21,6 +21,7 @@ import (
 	"net"
 	"net/http"
 	_ "net/http/pprof"
+	"net/textproto"
 	"net/url"
 	"os"
 	"os/signal"
@@ -41,8 +42,6 @@ import (
 	"github.com/prometheus/common/version"
 	"github.com/prometheus/exporter-toolkit/web"
 	webflag "github.com/prometheus/exporter-toolkit/web/kingpinflag"
-	"golang.org/x/text/cases"
-	"golang.org/x/text/language"
 	"gopkg.in/alecthomas/kingpin.v2"
 	"gopkg.in/yaml.v3"
 
@@ -76,8 +75,6 @@ var (
 		Name: "blackbox_module_unknown_total",
 		Help: "Count of unknown modules requested by probes",
 	})
-
-	caser = cases.Title(language.Und)
 )
 
 func probeHandler(w http.ResponseWriter, r *http.Request, c *config.Config, logger log.Logger, rh *resultHistory) {
@@ -170,7 +167,7 @@ func setHTTPHost(hostname string, module *config.Module) error {
 	headers := make(map[string]string)
 	if module.HTTP.Headers != nil {
 		for name, value := range module.HTTP.Headers {
-			if caser.String(name) == "Host" && value != hostname {
+			if textproto.CanonicalMIMEHeaderKey(name) == "Host" && value != hostname {
 				return fmt.Errorf("host header defined both in module configuration (%s) and with URL-parameter 'hostname' (%s)", value, hostname)
 			}
 			headers[name] = value

--- a/prober/http_test.go
+++ b/prober/http_test.go
@@ -25,6 +25,7 @@ import (
 	"io/ioutil"
 	"net/http"
 	"net/http/httptest"
+	"net/textproto"
 	"os"
 	"strconv"
 	"strings"
@@ -35,8 +36,6 @@ import (
 	"github.com/go-kit/log"
 	"github.com/prometheus/client_golang/prometheus"
 	pconfig "github.com/prometheus/common/config"
-	"golang.org/x/text/cases"
-	"golang.org/x/text/language"
 
 	"github.com/prometheus/blackbox_exporter/config"
 )
@@ -1070,9 +1069,8 @@ func TestHTTPHeaders(t *testing.T) {
 		"Accept-Language": "en-US",
 	}
 	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		caser := cases.Title(language.Und)
 		for key, value := range headers {
-			if caser.String(key) == "Host" {
+			if textproto.CanonicalMIMEHeaderKey(key) == "Host" {
 				if r.Host != value {
 					t.Errorf("Unexpected host: expected %q, got %q.", value, r.Host)
 				}


### PR DESCRIPTION
Using the full i18n library isn't needed, this just needs to be ASCII
per MIME style header standards.

Signed-off-by: David Leadbeater <dgl@dgl.cx>