### PR TITLE
Remove ioutil

### DIFF
--- a/prober/grpc_test.go
+++ b/prober/grpc_test.go
@@ -19,6 +19,11 @@ import (
 	"crypto/x509"
 	"encoding/pem"
 	"fmt"
+	"net"
+	"os"
+	"testing"
+	"time"
+
 	"github.com/go-kit/log"
 	"github.com/prometheus/blackbox_exporter/config"
 	"github.com/prometheus/client_golang/prometheus"
@@ -27,11 +32,6 @@ import (
 	"google.golang.org/grpc/credentials"
 	"google.golang.org/grpc/health"
 	"google.golang.org/grpc/health/grpc_health_v1"
-	"io/ioutil"
-	"net"
-	"os"
-	"testing"
-	"time"
 )
 
 func TestGRPCConnection(t *testing.T) {
@@ -173,7 +173,7 @@ func TestGRPCTLSConnection(t *testing.T) {
 	_, testcertPem, testKey := generateSelfSignedCertificate(testCertTmpl)
 
 	// CAFile must be passed via filesystem, use a tempfile.
-	tmpCaFile, err := ioutil.TempFile("", "cafile.pem")
+	tmpCaFile, err := os.CreateTemp("", "cafile.pem")
 	if err != nil {
 		t.Fatalf("Error creating CA tempfile: %s", err)
 	}

--- a/prober/http.go
+++ b/prober/http.go
@@ -21,7 +21,6 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"net"
 	"net/http"
 	"net/http/cookiejar"
@@ -47,7 +46,7 @@ import (
 )
 
 func matchRegularExpressions(reader io.Reader, httpConfig config.HTTPProbe, logger log.Logger) bool {
-	body, err := ioutil.ReadAll(reader)
+	body, err := io.ReadAll(reader)
 	if err != nil {
 		level.Error(logger).Log("msg", "Error reading HTTP body", "err", err)
 		return false
@@ -554,7 +553,7 @@ func ProbeHTTP(ctx context.Context, target string, module config.Module, registr
 		}
 
 		if !requestErrored {
-			_, err = io.Copy(ioutil.Discard, byteCounter)
+			_, err = io.Copy(io.Discard, byteCounter)
 			if err != nil {
 				level.Info(logger).Log("msg", "Failed to read HTTP response body", "err", err)
 				success = false
@@ -672,7 +671,7 @@ func ProbeHTTP(ctx context.Context, target string, module config.Module, registr
 func getDecompressionReader(algorithm string, origBody io.ReadCloser) (io.ReadCloser, error) {
 	switch strings.ToLower(algorithm) {
 	case "br":
-		return ioutil.NopCloser(brotli.NewReader(origBody)), nil
+		return io.NopCloser(brotli.NewReader(origBody)), nil
 
 	case "deflate":
 		return flate.NewReader(origBody), nil

--- a/prober/http_test.go
+++ b/prober/http_test.go
@@ -22,7 +22,6 @@ import (
 	"crypto/x509"
 	"encoding/pem"
 	"fmt"
-	"io/ioutil"
 	"net/http"
 	"net/http/httptest"
 	"net/url"
@@ -1196,7 +1195,7 @@ func TestHTTPUsesTargetAsTLSServerName(t *testing.T) {
 	_, testcertPem, testKey := generateSelfSignedCertificate(testCertTmpl)
 
 	// CAFile must be passed via filesystem, use a tempfile.
-	tmpCaFile, err := ioutil.TempFile("", "cafile.pem")
+	tmpCaFile, err := os.CreateTemp("", "cafile.pem")
 	if err != nil {
 		t.Fatalf("Error creating CA tempfile: %s", err)
 	}

--- a/prober/tcp_test.go
+++ b/prober/tcp_test.go
@@ -22,7 +22,6 @@ import (
 	"crypto/x509"
 	"encoding/pem"
 	"fmt"
-	"io/ioutil"
 	"net"
 	"os"
 	"runtime"
@@ -94,7 +93,7 @@ func TestTCPConnectionWithTLS(t *testing.T) {
 	_, rootCertPem, rootKey := generateSelfSignedCertificate(rootCertTmpl)
 
 	// CAFile must be passed via filesystem, use a tempfile.
-	tmpCaFile, err := ioutil.TempFile("", "cafile.pem")
+	tmpCaFile, err := os.CreateTemp("", "cafile.pem")
 	if err != nil {
 		t.Fatalf(fmt.Sprintf("Error creating CA tempfile: %s", err))
 	}
@@ -240,7 +239,7 @@ func TestTCPConnectionWithTLSAndVerifiedCertificateChain(t *testing.T) {
 	_, serverCertPem, serverKey := generateSignedCertificate(serverCertTmpl, olderRootCert, rootPrivatekey)
 
 	// CAFile must be passed via filesystem, use a tempfile.
-	tmpCaFile, err := ioutil.TempFile("", "cafile.pem")
+	tmpCaFile, err := os.CreateTemp("", "cafile.pem")
 	if err != nil {
 		t.Fatalf(fmt.Sprintf("Error creating CA tempfile: %s", err))
 	}
@@ -343,7 +342,7 @@ func TestTCPConnectionQueryResponseStartTLS(t *testing.T) {
 	_, testCertPem, testKey := generateSelfSignedCertificate(testCertTmpl)
 
 	// CAFile must be passed via filesystem, use a tempfile.
-	tmpCaFile, err := ioutil.TempFile("", "cafile.pem")
+	tmpCaFile, err := os.CreateTemp("", "cafile.pem")
 	if err != nil {
 		t.Fatalf(fmt.Sprintf("Error creating CA tempfile: %s", err))
 	}


### PR DESCRIPTION
`ioutil` is deprecated from go1.16 (ref: https://go.dev/doc/go1.16#ioutil).
So removed them.

Signed-off-by: inosato <si17_21@yahoo.co.jp>