### PR TITLE
Refactor prober gauges

### DIFF
--- a/prober/grpc.go
+++ b/prober/grpc.go
@@ -97,15 +97,10 @@ func ProbeGRPC(ctx context.Context, target string, module config.Module, registr
 			Help: "Response HealthCheck response",
 		}, []string{"serving_status"})
 
-		probeSSLEarliestCertExpiryGauge = prometheus.NewGauge(prometheus.GaugeOpts{
-			Name: "probe_ssl_earliest_cert_expiry",
-			Help: helpSSLEarliestCertExpiry,
-		})
+		probeSSLEarliestCertExpiryGauge = prometheus.NewGauge(sslEarliestCertExpiryGaugeOpts)
 
-		probeTLSVersion = prometheus.NewGaugeVec(prometheus.GaugeOpts{
-			Name: "probe_tls_version_info",
-			Help: helpProbeTLSInfo,
-		},
+		probeTLSVersion = prometheus.NewGaugeVec(
+			probeTLSInfoGaugeOpts,
 			[]string{"version"},
 		)
 

--- a/prober/http.go
+++ b/prober/http.go
@@ -266,15 +266,9 @@ func ProbeHTTP(ctx context.Context, target string, module config.Module, registr
 			Help: "Response HTTP status code",
 		})
 
-		probeSSLEarliestCertExpiryGauge = prometheus.NewGauge(prometheus.GaugeOpts{
-			Name: "probe_ssl_earliest_cert_expiry",
-			Help: helpSSLEarliestCertExpiry,
-		})
+		probeSSLEarliestCertExpiryGauge = prometheus.NewGauge(sslEarliestCertExpiryGaugeOpts)
 
-		probeSSLLastChainExpiryTimestampSeconds = prometheus.NewGauge(prometheus.GaugeOpts{
-			Name: "probe_ssl_last_chain_expiry_timestamp_seconds",
-			Help: helpSSLChainExpiryInTimeStamp,
-		})
+		probeSSLLastChainExpiryTimestampSeconds = prometheus.NewGauge(sslChainExpiryInTimeStampGaugeOpts)
 
 		probeSSLLastInformation = prometheus.NewGaugeVec(
 			prometheus.GaugeOpts{
@@ -285,10 +279,7 @@ func ProbeHTTP(ctx context.Context, target string, module config.Module, registr
 		)
 
 		probeTLSVersion = prometheus.NewGaugeVec(
-			prometheus.GaugeOpts{
-				Name: "probe_tls_version_info",
-				Help: helpProbeTLSInfo,
-			},
+			probeTLSInfoGaugeOpts,
 			[]string{"version"},
 		)
 

--- a/prober/prober.go
+++ b/prober/prober.go
@@ -29,3 +29,20 @@ const (
 	helpSSLChainExpiryInTimeStamp = "Returns last SSL chain expiry in timestamp"
 	helpProbeTLSInfo              = "Returns the TLS version used or NaN when unknown"
 )
+
+var (
+	sslEarliestCertExpiryGaugeOpts = prometheus.GaugeOpts{
+		Name: "probe_ssl_earliest_cert_expiry",
+		Help: helpSSLEarliestCertExpiry,
+	}
+
+	sslChainExpiryInTimeStampGaugeOpts = prometheus.GaugeOpts{
+		Name: "probe_ssl_last_chain_expiry_timestamp_seconds",
+		Help: helpSSLChainExpiryInTimeStamp,
+	}
+
+	probeTLSInfoGaugeOpts = prometheus.GaugeOpts{
+		Name: "probe_tls_version_info",
+		Help: helpProbeTLSInfo,
+	}
+)

--- a/prober/tcp.go
+++ b/prober/tcp.go
@@ -89,14 +89,8 @@ func dialTCP(ctx context.Context, target string, module config.Module, registry 
 }
 
 func ProbeTCP(ctx context.Context, target string, module config.Module, registry *prometheus.Registry, logger log.Logger) bool {
-	probeSSLEarliestCertExpiry := prometheus.NewGauge(prometheus.GaugeOpts{
-		Name: "probe_ssl_earliest_cert_expiry",
-		Help: helpSSLEarliestCertExpiry,
-	})
-	probeSSLLastChainExpiryTimestampSeconds := prometheus.NewGauge(prometheus.GaugeOpts{
-		Name: "probe_ssl_last_chain_expiry_timestamp_seconds",
-		Help: helpSSLChainExpiryInTimeStamp,
-	})
+	probeSSLEarliestCertExpiry := prometheus.NewGauge(sslEarliestCertExpiryGaugeOpts)
+	probeSSLLastChainExpiryTimestampSeconds := prometheus.NewGauge(sslChainExpiryInTimeStampGaugeOpts)
 	probeSSLLastInformation := prometheus.NewGaugeVec(
 		prometheus.GaugeOpts{
 			Name: "probe_ssl_last_chain_info",
@@ -105,10 +99,7 @@ func ProbeTCP(ctx context.Context, target string, module config.Module, registry
 		[]string{"fingerprint_sha256", "subject", "issuer", "subjectalternative"},
 	)
 	probeTLSVersion := prometheus.NewGaugeVec(
-		prometheus.GaugeOpts{
-			Name: "probe_tls_version_info",
-			Help: helpProbeTLSInfo,
-		},
+		probeTLSInfoGaugeOpts,
 		[]string{"version"},
 	)
 	probeFailedDueToRegex := prometheus.NewGauge(prometheus.GaugeOpts{


### PR DESCRIPTION
Move prober metric GaugeOpts into prober.go to reduce copy-n-paste.

Signed-off-by: SuperQ <superq@gmail.com>