### PR TITLE
Add ip_filter support to block certain IP addresses

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -95,7 +95,8 @@ func init() {
 }
 
 type Config struct {
-	Modules map[string]Module `yaml:"modules"`
+	Modules  map[string]Module `yaml:"modules"`
+	IPFilter *IPFilter         `yaml:"ip_filter,omitempty"`
 }
 
 type SafeConfig struct {
@@ -192,13 +193,14 @@ func MustNewRegexp(s string) Regexp {
 }
 
 type Module struct {
-	Prober  string        `yaml:"prober,omitempty"`
-	Timeout time.Duration `yaml:"timeout,omitempty"`
-	HTTP    HTTPProbe     `yaml:"http,omitempty"`
-	TCP     TCPProbe      `yaml:"tcp,omitempty"`
-	ICMP    ICMPProbe     `yaml:"icmp,omitempty"`
-	DNS     DNSProbe      `yaml:"dns,omitempty"`
-	GRPC    GRPCProbe     `yaml:"grpc,omitempty"`
+	Prober   string        `yaml:"prober,omitempty"`
+	Timeout  time.Duration `yaml:"timeout,omitempty"`
+	HTTP     HTTPProbe     `yaml:"http,omitempty"`
+	TCP      TCPProbe      `yaml:"tcp,omitempty"`
+	ICMP     ICMPProbe     `yaml:"icmp,omitempty"`
+	DNS      DNSProbe      `yaml:"dns,omitempty"`
+	GRPC     GRPCProbe     `yaml:"grpc,omitempty"`
+	IPFilter *IPFilter     `yaml:"ip_filter,omitempty"`
 }
 
 type HTTPProbe struct {

--- a/config/ipfilter.go
+++ b/config/ipfilter.go
@@ -1,0 +1,195 @@
+// Copyright 2016 The Prometheus Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package config
+
+import (
+	"errors"
+	"net"
+	"strings"
+
+	"github.com/yl2chen/cidranger"
+)
+
+// IPFilter is used to filter network traffic so that
+// probes are limited in the destination addresses they
+// can probe.
+//
+// The configuration looks like:
+//
+//	  ip_filter:
+//		   default: allow|deny
+//		   allowed:
+//		     [... list of networks in CIDR format ...]
+//		   denied:
+//		     [... list of networks in CIDR format ...]
+//
+// The longest prefix match takes precedence:
+//
+//	ip_filter:
+//	  default: deny
+//	  allowed:
+//	    - 10.0.0.0/8
+//	  denied:
+//	    - 10.0.1.0/24
+//
+// Only traffic to 10.0.0.0/8 is allowed, except the 10.0.1.0/24
+// subnet, which is blocked.
+//
+// The default key is only mandatory when both allowed and denied
+// are defined. Otherwise, it is implicitly deny or allow.
+type IPFilter struct {
+	ranger       cidranger.Ranger
+	allowed      []net.IPNet
+	denied       []net.IPNet
+	defaultAllow bool
+}
+
+// NewIPFilter creates a new IPFilter object with the given configuration.
+func NewIPFilter(allowed []net.IPNet, denied []net.IPNet, defaultAllow bool) (*IPFilter, error) {
+	f := &IPFilter{
+		ranger:       cidranger.NewPCTrieRanger(),
+		defaultAllow: defaultAllow,
+		allowed:      allowed,
+		denied:       denied,
+	}
+	if err := f.insert(allowed, true); err != nil {
+		return nil, err
+	}
+	if err := f.insert(denied, false); err != nil {
+		return nil, err
+	}
+	return f, nil
+}
+
+// IsAllowed returns if the IP address is allowed by the filter.
+// A nil or zero-value filter allows all traffic.
+func (f *IPFilter) IsAllowed(ip net.IP) bool {
+	if f == nil || f.ranger == nil {
+		return true
+	}
+	lst, err := f.ranger.ContainingNetworks(ip)
+	if err != nil || len(lst) < 1 {
+		return f.defaultAllow
+	}
+	return lst[len(lst)-1].(filterEntry).allow
+}
+
+// UnmarshalYAML constructs an IPFilter from its YAML definition.
+func (f *IPFilter) UnmarshalYAML(decode func(interface{}) error) error {
+	var base struct {
+		DefValue *string  `yaml:"default"`
+		Allowed  []string `yaml:"allowed"`
+		Denied   []string `yaml:"denied"`
+	}
+	err := decode(&base)
+	if err != nil {
+		return err
+	}
+
+	defAllow := len(base.Allowed) == 0
+	if base.DefValue == nil && len(base.Allowed) > 0 && len(base.Denied) > 0 {
+		return errors.New("missing field ip_filter.default")
+	}
+	if base.DefValue != nil {
+		switch strings.ToLower(*base.DefValue) {
+		case "allow", "allowed":
+			defAllow = true
+		case "deny", "denied", "block", "blocked":
+			defAllow = false
+		default:
+			return errors.New("unsupported value for ip_filter.default, use `allowed` or `denied`")
+		}
+	}
+	allowed, err := parseCIDRNets(base.Allowed)
+	if err != nil {
+		return err
+	}
+	denied, err := parseCIDRNets(base.Denied)
+	if err != nil {
+		return err
+	}
+	filter, err := NewIPFilter(allowed, denied, defAllow)
+	if err != nil {
+		return err
+	}
+	*f = *filter
+	return err
+}
+
+// MarshalYAML returns the YAML representation of the IPFilter.
+func (f *IPFilter) MarshalYAML() (interface{}, error) {
+	if f == nil || f.ranger == nil {
+		return nil, nil
+	}
+	body := make(map[string]interface{})
+	hasAllowed := len(f.allowed) > 0
+	hasDenied := len(f.denied) > 0
+	if hasAllowed {
+		body["allowed"] = netsToString(f.allowed)
+	}
+	if hasDenied {
+		body["denied"] = netsToString(f.denied)
+	}
+	if (hasAllowed && hasDenied) || f.defaultAllow != !hasAllowed {
+		body["default"] = "deny"
+		if f.defaultAllow {
+			body["default"] = "allow"
+		}
+	}
+	return body, nil
+}
+
+func (f *IPFilter) insert(lst []net.IPNet, allow bool) error {
+	for _, nt := range lst {
+		if err := f.ranger.Insert(filterEntry{
+			net:   nt,
+			allow: allow,
+		}); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func parseCIDRNets(lst []string) ([]net.IPNet, error) {
+	out := make([]net.IPNet, len(lst))
+
+	for i, s := range lst {
+		_, nt, err := net.ParseCIDR(s)
+		if err != nil {
+			return nil, err
+		}
+		out[i] = *nt
+	}
+	return out, nil
+}
+
+func netsToString(lst []net.IPNet) []string {
+	r := make([]string, len(lst))
+	for i, n := range lst {
+		r[i] = n.String()
+	}
+	return r
+}
+
+type filterEntry struct {
+	net   net.IPNet
+	allow bool
+}
+
+var _ cidranger.RangerEntry = filterEntry{}
+
+func (e filterEntry) Network() net.IPNet {
+	return e.net
+}

--- a/config/ipfilter_test.go
+++ b/config/ipfilter_test.go
@@ -1,0 +1,245 @@
+// Copyright 2016 The Prometheus Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package config
+
+import (
+	"errors"
+	"gopkg.in/yaml.v3"
+	"net"
+	"strings"
+	"testing"
+)
+
+var anyIP = []string{
+	"127.0.0.1",
+	"10.1.2.3",
+	"192.0.2.1",
+	"2002::1",
+	"::1",
+}
+
+func TestIPFilter(t *testing.T) {
+	for title, tc := range map[string]struct {
+		input    string
+		err      error
+		defAllow bool
+		accepts  []string
+		rejects  []string
+	}{
+		"empty": {
+			input:    `{}`,
+			defAllow: true,
+			accepts:  anyIP,
+		},
+		"allow all": {
+			input:    `default: allow`,
+			defAllow: true,
+			accepts:  anyIP,
+		},
+		"deny all": {
+			input:    `default: deny`,
+			defAllow: false,
+			rejects:  anyIP,
+		},
+		"implicit allow": {
+			input:    `denied: [ "127.0.0.0/8" ]`,
+			defAllow: true,
+			accepts: []string{
+				"10.1.2.3",
+				"192.168.123.10",
+				"198.51.100.250",
+			},
+			rejects: []string{
+				"127.0.0.1",
+				"127.255.255.255",
+			},
+		},
+		"implicit deny": {
+			input:    `allowed: [ "127.0.0.0/8" ]`,
+			defAllow: false,
+			rejects: []string{
+				"10.1.2.3",
+				"192.168.123.10",
+				"198.51.100.250",
+			},
+			accepts: []string{
+				"127.0.0.1",
+				"127.255.255.255",
+			},
+		},
+		"required default": {
+			input: `
+allowed: [ "127.0.0.1/32" ]
+denied: [ "127.0.0.2/32" ]`,
+			err: errors.New("missing field ip_filter.default"),
+		},
+		"invalid default": {
+			input: `default: drop`,
+			err:   errors.New("unsupported value for ip_filter.default, use `allowed` or `denied`"),
+		},
+		"invalid allowed network": {
+			input: `allowed: [ "10.20.30.40" ]`,
+			err:   errors.New("invalid CIDR address: 10.20.30.40"),
+		},
+		"invalid denied network": {
+			input: `denied: [ "10.20.30.40" ]`,
+			err:   errors.New("invalid CIDR address: 10.20.30.40"),
+		},
+		"invalid type": {
+			input: `allowed: "10.0.0.0/8"`,
+			err:   errors.New("yaml: unmarshal errors:\n  line 1: cannot unmarshal !!str `10.0.0.0/8` into []string"),
+		},
+		"longest prefix match": {
+			input: `
+default: deny
+allowed: [ "10.0.0.0/8", "192.168.0.0/16" ]
+denied: [ "10.0.1.1/32", "192.168.255.0/24" ]
+`,
+			accepts: []string{
+				"10.1.2.3",
+				"10.0.1.2",
+				"192.168.1.2",
+			},
+			rejects: []string{
+				"10.0.1.1",
+				"192.168.255.30",
+				"203.0.113.2",
+			},
+		},
+	} {
+		t.Run(title, func(t *testing.T) {
+			var ipf IPFilter
+			decoder := yaml.NewDecoder(strings.NewReader(tc.input))
+			decoder.KnownFields(true)
+			err := decoder.Decode(&ipf)
+			if (err != nil) != (tc.err != nil) || err != nil && err.Error() != tc.err.Error() {
+				t.Fatalf("expected error `%v` but got `%v`", tc.err, err)
+			}
+			if ipf.defaultAllow != tc.defAllow {
+				t.Fatal("invalid default. expected:", tc.defAllow, "actual:", ipf.defaultAllow)
+			}
+			checkList(t, &ipf, tc.accepts, true)
+			checkList(t, &ipf, tc.rejects, false)
+		})
+	}
+}
+
+func TestIPFilterNilOrZero(t *testing.T) {
+	mod := Module{}
+	checkList(t, mod.IPFilter, anyIP, true)
+	checkList(t, &IPFilter{}, anyIP, true)
+}
+
+func newIPFilter(t *testing.T, allowed []string, denied []string, def bool) *IPFilter {
+	a, err := parseCIDRNets(allowed)
+	if err != nil {
+		t.Fatal(err)
+	}
+	d, err := parseCIDRNets(denied)
+	if err != nil {
+		t.Fatal(err)
+	}
+	ipf, err := NewIPFilter(a, d, def)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return ipf
+}
+
+func TestNewIPFilterToYAML(t *testing.T) {
+	for title, tc := range map[string]struct {
+		ipf      *IPFilter
+		expected string
+	}{
+		"implicit deny": {
+			ipf: newIPFilter(t, []string{"10.0.0.0/8"}, nil, false),
+			expected: `ip_filter:
+	allowed:
+		- 10.0.0.0/8
+`,
+		},
+		"implicit allow": {
+			ipf: newIPFilter(t, nil, []string{"10.0.0.0/8"}, true),
+			expected: `ip_filter:
+	denied:
+		- 10.0.0.0/8
+`,
+		},
+		"explicit deny": {
+			ipf: newIPFilter(t, nil, []string{"10.0.0.0/8"}, false),
+			expected: `ip_filter:
+	default: deny
+	denied:
+		- 10.0.0.0/8
+`,
+		},
+		"explicit allow": {
+			ipf: newIPFilter(t, []string{"10.0.0.0/8"}, nil, true),
+			expected: `ip_filter:
+	allowed:
+		- 10.0.0.0/8
+	default: allow
+`,
+		},
+		"complex allow": {
+			ipf: newIPFilter(t, []string{"10.0.0.0/8"}, []string{"2002::1/64"}, true),
+			expected: `ip_filter:
+	allowed:
+		- 10.0.0.0/8
+	default: allow
+	denied:
+		- 2002::/64
+`,
+		},
+		"complex deny": {
+			ipf: newIPFilter(t, []string{"10.0.0.0/8"}, []string{"2002::1/64"}, false),
+			expected: `ip_filter:
+	allowed:
+		- 10.0.0.0/8
+	default: deny
+	denied:
+		- 2002::/64
+`,
+		},
+		"nil": {
+			expected: "{}\n",
+		},
+	} {
+		t.Run(title, func(t *testing.T) {
+			body := struct {
+				IPFilter *IPFilter `yaml:"ip_filter,omitempty"`
+			}{
+				IPFilter: tc.ipf,
+			}
+			b, err := yaml.Marshal(body)
+			if err != nil {
+				t.Fatal(err)
+			}
+			exp := strings.ReplaceAll(tc.expected, "\t", "    ")
+			if string(b) != exp {
+				t.Fatalf("yaml doesn't match. Expected: `%s` actual: `%s`",
+					exp, string(b))
+			}
+		})
+	}
+}
+
+func checkList(t *testing.T, ipf *IPFilter, lst []string, expected bool) {
+	t.Helper()
+	for _, addr := range lst {
+		if ipf.IsAllowed(net.ParseIP(addr)) != expected {
+			t.Fatal("allow test failed for", addr, "expected:", expected, "actual:", !expected)
+		}
+	}
+}

--- a/config/testdata/ipfilter-bad.yml
+++ b/config/testdata/ipfilter-bad.yml
@@ -1,0 +1,10 @@
+modules:
+  http_2xx:
+    prober: http
+    timeout: 5s
+    http:
+    ip_filter:
+      denied:
+        - 127.0.0.1
+      allowed:
+        - localhost/32

--- a/config/testdata/ipfilter-good.yml
+++ b/config/testdata/ipfilter-good.yml
@@ -1,0 +1,30 @@
+modules:
+  http_2xx:
+    prober: http
+    timeout: 5s
+    http:
+    ip_filter:
+      default: allow
+      denied:
+        - 127.0.0.0/8
+        - 192.168.0.0/16
+        - 10.0.0.0/8
+        - fc00::/7
+        - fec0::/10
+      allowed:
+        - 192.168.0.15/32
+        - 10.0.10.0/24
+  http_post_2xx:
+    prober: http
+    timeout: 5s
+    http:
+      method: POST
+      basic_auth:
+        username: "username"
+        password: "mysecret"
+      body_size_limit: 1MB
+ip_filter:
+  default: deny
+  allowed:
+    - ::1/128
+    - 127.0.0.1/32

--- a/go.mod
+++ b/go.mod
@@ -10,6 +10,7 @@ require (
 	github.com/prometheus/client_model v0.2.0
 	github.com/prometheus/common v0.37.0
 	github.com/prometheus/exporter-toolkit v0.7.1
+	github.com/yl2chen/cidranger v1.0.2
 	golang.org/x/net v0.0.0-20220728211354-c7608f3a8462
 	google.golang.org/grpc v1.48.0
 	gopkg.in/alecthomas/kingpin.v2 v2.2.6

--- a/go.sum
+++ b/go.sum
@@ -224,6 +224,8 @@ github.com/stretchr/testify v1.4.0/go.mod h1:j7eGeouHqKxXV5pUuKE4zz7dFj8WfuZ+81P
 github.com/stretchr/testify v1.5.1/go.mod h1:5W2xD1RspED5o8YsWQXVCued0rvSQ+mT+I5cxcmMvtA=
 github.com/stretchr/testify v1.7.0 h1:nwc3DEeHmmLAfoZucVR881uASk0Mfjw8xYJ99tb5CcY=
 github.com/stretchr/testify v1.7.0/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
+github.com/yl2chen/cidranger v1.0.2 h1:lbOWZVCG1tCRX4u24kuM1Tb4nHqWkDxwLdoS+SevawU=
+github.com/yl2chen/cidranger v1.0.2/go.mod h1:9U1yz7WPYDwf0vpNWFaeRh0bjwz5RVgRy/9UEQfHl0g=
 github.com/yuin/goldmark v1.1.25/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=
 github.com/yuin/goldmark v1.1.27/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=
 github.com/yuin/goldmark v1.1.32/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=

--- a/prober/dns.go
+++ b/prober/dns.go
@@ -198,6 +198,10 @@ func ProbeDNS(ctx context.Context, target string, module config.Module, registry
 		return false
 	}
 	probeDNSDurationGaugeVec.WithLabelValues("resolve").Add(lookupTime)
+	if !module.IPFilter.IsAllowed(ip.IP) {
+		level.Error(logger).Log("msg", "Forbidden destination IP address", "ip", ip.String())
+		return false
+	}
 	targetIP := net.JoinHostPort(ip.String(), port)
 
 	if ip.IP.To4() == nil {

--- a/prober/grpc.go
+++ b/prober/grpc.go
@@ -153,6 +153,12 @@ func ProbeGRPC(ctx context.Context, target string, module config.Module, registr
 		return false
 	}
 	durationGaugeVec.WithLabelValues("resolve").Add(lookupTime)
+
+	if !module.IPFilter.IsAllowed(ip.IP) {
+		level.Error(logger).Log("msg", "Forbidden destination IP address", "ip", ip.String())
+		return false
+	}
+
 	checkStart := time.Now()
 	if len(tlsConfig.ServerName) == 0 {
 		// If there is no `server_name` in tls_config, use

--- a/prober/icmp.go
+++ b/prober/icmp.go
@@ -96,6 +96,11 @@ func ProbeICMP(ctx context.Context, target string, module config.Module, registr
 	}
 	durationGaugeVec.WithLabelValues("resolve").Add(lookupTime)
 
+	if !module.IPFilter.IsAllowed(dstIPAddr.IP) {
+		level.Error(logger).Log("msg", "Forbidden destination IP address", "ip", dstIPAddr.String())
+		return false
+	}
+
 	var srcIP net.IP
 	if len(module.ICMP.SourceIPAddress) > 0 {
 		if srcIP = net.ParseIP(module.ICMP.SourceIPAddress); srcIP == nil {

--- a/prober/tcp.go
+++ b/prober/tcp.go
@@ -17,6 +17,7 @@ import (
 	"bufio"
 	"context"
 	"crypto/tls"
+	"errors"
 	"fmt"
 	"net"
 
@@ -42,7 +43,10 @@ func dialTCP(ctx context.Context, target string, module config.Module, registry 
 		level.Error(logger).Log("msg", "Error resolving address", "err", err)
 		return nil, err
 	}
-
+	if !module.IPFilter.IsAllowed(ip.IP) {
+		level.Error(logger).Log("msg", "Forbidden destination IP address", "ip", ip.String())
+		return nil, errors.New("access to unauthorized address")
+	}
 	if ip.IP.To4() == nil {
 		dialProtocol = "tcp6"
 	} else {

--- a/prober/utils_test.go
+++ b/prober/utils_test.go
@@ -35,6 +35,7 @@ import (
 
 // Check if expected results are in the registry
 func checkRegistryResults(expRes map[string]float64, mfs []*dto.MetricFamily, t *testing.T) {
+	t.Helper()
 	res := make(map[string]float64)
 	for i := range mfs {
 		res[mfs[i].GetName()] = mfs[i].Metric[0].GetGauge().GetValue()


### PR DESCRIPTION
IPFilter is used to filter network traffic so that probes are limited in the destination addresses they can probe.

The configuration looks like:
```
      ip_filter:
               default: allow|deny
               allowed:
                 [... list of networks in CIDR format ...]
               denied:
                 [... list of networks in CIDR format ...]
```

This can be specified at the top level or inside each module definition. All keys are optional: an empty undefined `ip_filter` allows all traffic. When just `allowed` or `denied` is defined, `default` takes the implicit reasonable value:

```
    ip_filter:
      # implicit default: allow
      denied:
        - 127.0.0.0/8
        - 10.0.0.0/8
        - 192.168.0.0/16
        - ::1/128
        - fd00::/8
        - fc00::/7    
```

The longest prefix match takes precedence:

```
    ip_filter:
      default: deny
      allowed:
        - 10.0.0.0/8
      denied:
        - 10.0.1.0/24
```

Only traffic to 10.0.0.0/8 is allowed, except the 10.0.1.0/24 subnet which is blocked.

Closes #905
