### PR TITLE
Add missing probe_tls_version_info and probe_ssl_last_chain_info metrics to STARTTLS TCP probes

### DIFF
--- a/prober/tcp.go
+++ b/prober/tcp.go
@@ -192,7 +192,7 @@ func ProbeTCP(ctx context.Context, target string, module config.Module, registry
 
 			// Get certificate expiry.
 			state := tlsConn.ConnectionState()
-			registry.MustRegister(probeSSLEarliestCertExpiry, probeSSLLastChainExpiryTimestampSeconds)
+			registry.MustRegister(probeSSLEarliestCertExpiry, probeTLSVersion, probeSSLLastChainExpiryTimestampSeconds, probeSSLLastInformation)
 			probeSSLEarliestCertExpiry.Set(float64(getEarliestCertExpiry(&state).Unix()))
 			probeTLSVersion.WithLabelValues(getTLSVersion(&state)).Set(1)
 			probeSSLLastChainExpiryTimestampSeconds.Set(float64(getLastChainExpiry(&state).Unix()))


### PR DESCRIPTION
I noticed the probe_tls_version_info and probe_ssl_last_chain_info metrics were missing from STARTTLS TCP probes and added them.

Signed-off-by: Lyas Spiehler <lspiehler@gmail.com>