### PR TITLE
Add root (`modules`) key to CONFIGURATION.md

### DIFF
--- a/CONFIGURATION.md
+++ b/CONFIGURATION.md
@@ -16,6 +16,8 @@ Generic placeholders are defined as follows:
 
 The other placeholders are specified separately.
 
+See [example.yml](example.yml) for configuration examples.
+
 ```yml
 
 modules:

--- a/CONFIGURATION.md
+++ b/CONFIGURATION.md
@@ -16,7 +16,15 @@ Generic placeholders are defined as follows:
 
 The other placeholders are specified separately.
 
-### Module
+```yml
+
+modules:
+     [ <string>: <module> ... ]
+
+```
+
+
+### `<module>`
 ```yml
 
   # The protocol over which the probe will take place (http, tcp, dns, icmp, grpc).
@@ -34,7 +42,7 @@ The other placeholders are specified separately.
 
 ```
 
-### <http_probe>
+### `<http_probe>`
 ```yml
 
   # Accepted status codes for this probe. Defaults to 2xx.
@@ -136,7 +144,7 @@ The other placeholders are specified separately.
 
 ```
 
-#### <http_header_match_spec>
+#### `<http_header_match_spec>`
 
 ```yml
 header: <string>,
@@ -144,7 +152,7 @@ regexp: <regex>,
 [ allow_missing: <boolean> | default = false ]
 ```
 
-### <tcp_probe>
+### `<tcp_probe>`
 
 ```yml
 
@@ -173,7 +181,7 @@ tls_config:
 
 ```
 
-### <dns_probe>
+### `<dns_probe>`
 
 ```yml
 
@@ -249,7 +257,7 @@ validate_additional_rrs:
 
 ```
 
-### <icmp_probe>
+### `<icmp_probe>`
 
 ```yml
 
@@ -274,7 +282,7 @@ validate_additional_rrs:
 
 ```
 
-### <grpc_probe>
+### `<grpc_probe>`
 
 ```yml
 # The service name to query for health status.
@@ -292,7 +300,7 @@ tls_config:
   [ <tls_config> ]
 ```
 
-### <tls_config>
+### `<tls_config>`
 
 ```yml
 
@@ -318,7 +326,7 @@ tls_config:
 [ min_version: <string> ]
 ```
 
-#### <oauth2>
+#### `<oauth2>`
 
 OAuth 2.0 authentication using the client credentials grant type. Blackbox
 exporter fetches an access token from the specified endpoint with the given


### PR DESCRIPTION
The Exporter configuration is complicated by the omission of the root (`modules`) key from the configuration document.

Not only must configuration begin with `modules` but each module is a map of module names to module values.

I think I've correctly reflected this here using the document's schema.

Signed-off-by: Daz Wilkin <DazWilkin@users.noreply.github.com>