### PR TITLE
Change preferred_ip_protocol of module http to IP version 4

### DIFF
--- a/blackbox.yml
+++ b/blackbox.yml
@@ -1,6 +1,8 @@
 modules:
   http_2xx:
     prober: http
+    http:
+      preferred_ip_protocol: "ip4"
   http_post_2xx:
     prober: http
     http:


### PR DESCRIPTION
Almost all metrics have a value of 0. The last one reads probe_success 0. This means the prober could not successfully reach prometheus.io. The reason is hidden in the metric probe_ip_protocol with the value 6. By default the prober uses [IPv6](https://en.wikipedia.org/wiki/IPv6) until told otherwise. But the Docker daemon blocks IPv6 until told otherwise. Hence our blackbox exporter running in a Docker container can’t connect via IPv6.


Ref. https://prometheus.io/docs/guides/multi-target-exporter/