### PR TITLE
Fix example.yml: no_follow_redirects is deprecated in favor of follow_redirects

### DIFF
--- a/example.yml
+++ b/example.yml
@@ -10,7 +10,7 @@ modules:
         Host: vhost.example.com
         Accept-Language: en-US
         Origin: example.com
-      no_follow_redirects: false
+      follow_redirects: true
       fail_if_ssl: false
       fail_if_not_ssl: false
       fail_if_body_matches_regexp:


### PR DESCRIPTION
From [changelog](https://github.com/prometheus/blackbox_exporter/blob/master/CHANGELOG.md):

![image](https://user-images.githubusercontent.com/2951285/220966089-082c588d-aff5-4f0d-aaaa-208f6dba7a0b.png)
