### PR TITLE
Remove initialization of metrics from init functions

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -34,17 +34,18 @@ import (
 	"github.com/go-kit/log/level"
 	"github.com/miekg/dns"
 	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/promauto"
 	"github.com/prometheus/common/config"
 )
 
 var (
-	configReloadSuccess = prometheus.NewGauge(prometheus.GaugeOpts{
+	configReloadSuccess = promauto.NewGauge(prometheus.GaugeOpts{
 		Namespace: "blackbox_exporter",
 		Name:      "config_last_reload_successful",
 		Help:      "Blackbox exporter config loaded successfully.",
 	})
 
-	configReloadSeconds = prometheus.NewGauge(prometheus.GaugeOpts{
+	configReloadSeconds = promauto.NewGauge(prometheus.GaugeOpts{
 		Namespace: "blackbox_exporter",
 		Name:      "config_last_reload_success_timestamp_seconds",
 		Help:      "Timestamp of the last successful configuration reload.",
@@ -88,11 +89,6 @@ var (
 		Recursion:          true,
 	}
 )
-
-func init() {
-	prometheus.MustRegister(configReloadSuccess)
-	prometheus.MustRegister(configReloadSeconds)
-}
 
 type Config struct {
 	Modules map[string]Module `yaml:"modules"`

--- a/prober/handler.go
+++ b/prober/handler.go
@@ -27,6 +27,7 @@ import (
 	"github.com/go-kit/log/level"
 	"github.com/prometheus/blackbox_exporter/config"
 	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/promauto"
 	"github.com/prometheus/client_golang/prometheus/promhttp"
 	"github.com/prometheus/common/expfmt"
 	"gopkg.in/yaml.v2"
@@ -40,15 +41,11 @@ var (
 		"dns":  ProbeDNS,
 		"grpc": ProbeGRPC,
 	}
-	moduleUnknownCounter = prometheus.NewCounter(prometheus.CounterOpts{
+	moduleUnknownCounter = promauto.NewCounter(prometheus.CounterOpts{
 		Name: "blackbox_module_unknown_total",
 		Help: "Count of unknown modules requested by probes",
 	})
 )
-
-func init() {
-	prometheus.MustRegister(moduleUnknownCounter)
-}
 
 func Handler(w http.ResponseWriter, r *http.Request, c *config.Config, logger log.Logger,
 	rh *ResultHistory, timeoutOffset float64, params url.Values) {


### PR DESCRIPTION
When blackbox exporter is imported as package (i.e in Grafana Agent) is exporting metrics event if the exporter is not enabled (see https://github.com/grafana/agent/issues/2627).

This PR moves the initialization of some of the internal metrics of the exporter out of `init` functions.