### PR TITLE
Explicit registration of internal exporter metrics

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -34,18 +34,17 @@ import (
 	"github.com/go-kit/log/level"
 	"github.com/miekg/dns"
 	"github.com/prometheus/client_golang/prometheus"
-	"github.com/prometheus/client_golang/prometheus/promauto"
 	"github.com/prometheus/common/config"
 )
 
 var (
-	configReloadSuccess = promauto.NewGauge(prometheus.GaugeOpts{
+	configReloadSuccess = prometheus.NewGauge(prometheus.GaugeOpts{
 		Namespace: "blackbox_exporter",
 		Name:      "config_last_reload_successful",
 		Help:      "Blackbox exporter config loaded successfully.",
 	})
 
-	configReloadSeconds = promauto.NewGauge(prometheus.GaugeOpts{
+	configReloadSeconds = prometheus.NewGauge(prometheus.GaugeOpts{
 		Namespace: "blackbox_exporter",
 		Name:      "config_last_reload_success_timestamp_seconds",
 		Help:      "Timestamp of the last successful configuration reload.",
@@ -97,6 +96,12 @@ type Config struct {
 type SafeConfig struct {
 	sync.RWMutex
 	C *Config
+}
+
+func NewSafeConfig(reg prometheus.Registerer) *SafeConfig {
+	reg.MustRegister(configReloadSuccess)
+	reg.MustRegister(configReloadSeconds)
+	return &SafeConfig{C: &Config{}}
 }
 
 func (sc *SafeConfig) ReloadConfig(confFile string, logger log.Logger) (err error) {

--- a/config/config.go
+++ b/config/config.go
@@ -34,6 +34,7 @@ import (
 	"github.com/go-kit/log/level"
 	"github.com/miekg/dns"
 	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/promauto"
 	"github.com/prometheus/common/config"
 )
 
@@ -89,19 +90,17 @@ type SafeConfig struct {
 }
 
 func NewSafeConfig(reg prometheus.Registerer) *SafeConfig {
-	configReloadSuccess := prometheus.NewGauge(prometheus.GaugeOpts{
+	configReloadSuccess := promauto.With(reg).NewGauge(prometheus.GaugeOpts{
 		Namespace: "blackbox_exporter",
 		Name:      "config_last_reload_successful",
 		Help:      "Blackbox exporter config loaded successfully.",
 	})
 
-	configReloadSeconds := prometheus.NewGauge(prometheus.GaugeOpts{
+	configReloadSeconds := promauto.With(reg).NewGauge(prometheus.GaugeOpts{
 		Namespace: "blackbox_exporter",
 		Name:      "config_last_reload_success_timestamp_seconds",
 		Help:      "Timestamp of the last successful configuration reload.",
 	})
-	reg.MustRegister(configReloadSuccess)
-	reg.MustRegister(configReloadSeconds)
 	return &SafeConfig{C: &Config{}, configReloadSuccess: configReloadSuccess, configReloadSeconds: configReloadSeconds}
 }
 

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -17,13 +17,12 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/prometheus/client_golang/prometheus"
 	yaml "gopkg.in/yaml.v3"
 )
 
 func TestLoadConfig(t *testing.T) {
-	sc := &SafeConfig{
-		C: &Config{},
-	}
+	sc := NewSafeConfig(prometheus.NewRegistry())
 
 	err := sc.ReloadConfig("testdata/blackbox-good.yml", nil)
 	if err != nil {
@@ -32,9 +31,7 @@ func TestLoadConfig(t *testing.T) {
 }
 
 func TestLoadBadConfigs(t *testing.T) {
-	sc := &SafeConfig{
-		C: &Config{},
-	}
+	sc := NewSafeConfig(prometheus.NewRegistry())
 	tests := []struct {
 		input string
 		want  string
@@ -115,9 +112,7 @@ func TestLoadBadConfigs(t *testing.T) {
 }
 
 func TestHideConfigSecrets(t *testing.T) {
-	sc := &SafeConfig{
-		C: &Config{},
-	}
+	sc := NewSafeConfig(prometheus.NewRegistry())
 
 	err := sc.ReloadConfig("testdata/blackbox-good.yml", nil)
 	if err != nil {

--- a/main.go
+++ b/main.go
@@ -182,7 +182,7 @@ func run() int {
 		sc.Lock()
 		conf := sc.C
 		sc.Unlock()
-		prober.Handler(w, r, conf, logger, rh, *timeoutOffset, nil, &moduleUnknownCounter)
+		prober.Handler(w, r, conf, logger, rh, *timeoutOffset, nil, moduleUnknownCounter)
 	})
 	http.HandleFunc(*routePrefix, func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "text/html")

--- a/main.go
+++ b/main.go
@@ -30,6 +30,7 @@ import (
 	"github.com/go-kit/log/level"
 	"github.com/pkg/errors"
 	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/promauto"
 	"github.com/prometheus/client_golang/prometheus/promhttp"
 	"github.com/prometheus/common/promlog"
 	"github.com/prometheus/common/promlog/flag"
@@ -54,7 +55,7 @@ var (
 	routePrefix   = kingpin.Flag("web.route-prefix", "Prefix for the internal routes of web endpoints. Defaults to path of --web.external-url.").PlaceHolder("<path>").String()
 	toolkitFlags  = webflag.AddFlags(kingpin.CommandLine, ":9115")
 
-	moduleUnknownCounter = prometheus.NewCounter(prometheus.CounterOpts{
+	moduleUnknownCounter = promauto.NewCounter(prometheus.CounterOpts{
 		Name: "blackbox_module_unknown_total",
 		Help: "Count of unknown modules requested by probes",
 	})
@@ -62,7 +63,6 @@ var (
 
 func init() {
 	prometheus.MustRegister(version.NewCollector("blackbox_exporter"))
-	prometheus.MustRegister(moduleUnknownCounter)
 }
 
 func main() {

--- a/prober/handler.go
+++ b/prober/handler.go
@@ -43,7 +43,7 @@ var (
 )
 
 func Handler(w http.ResponseWriter, r *http.Request, c *config.Config, logger log.Logger,
-	rh *ResultHistory, timeoutOffset float64, params url.Values, moduleUnknownCounter *prometheus.Counter) {
+	rh *ResultHistory, timeoutOffset float64, params url.Values, moduleUnknownCounter prometheus.Counter) {
 
 	if params == nil {
 		params = r.URL.Query()
@@ -57,7 +57,7 @@ func Handler(w http.ResponseWriter, r *http.Request, c *config.Config, logger lo
 		http.Error(w, fmt.Sprintf("Unknown module %q", moduleName), http.StatusBadRequest)
 		level.Debug(logger).Log("msg", "Unknown module", "module", moduleName)
 		if moduleUnknownCounter != nil {
-			(*moduleUnknownCounter).Add(1)
+			moduleUnknownCounter.Add(1)
 		}
 		return
 	}

--- a/prober/handler.go
+++ b/prober/handler.go
@@ -27,7 +27,6 @@ import (
 	"github.com/go-kit/log/level"
 	"github.com/prometheus/blackbox_exporter/config"
 	"github.com/prometheus/client_golang/prometheus"
-	"github.com/prometheus/client_golang/prometheus/promauto"
 	"github.com/prometheus/client_golang/prometheus/promhttp"
 	"github.com/prometheus/common/expfmt"
 	"gopkg.in/yaml.v2"
@@ -41,14 +40,11 @@ var (
 		"dns":  ProbeDNS,
 		"grpc": ProbeGRPC,
 	}
-	moduleUnknownCounter = promauto.NewCounter(prometheus.CounterOpts{
-		Name: "blackbox_module_unknown_total",
-		Help: "Count of unknown modules requested by probes",
-	})
 )
 
 func Handler(w http.ResponseWriter, r *http.Request, c *config.Config, logger log.Logger,
-	rh *ResultHistory, timeoutOffset float64, params url.Values) {
+	rh *ResultHistory, timeoutOffset float64, params url.Values, moduleUnknownCounter *prometheus.Counter) {
+
 	if params == nil {
 		params = r.URL.Query()
 	}
@@ -60,7 +56,9 @@ func Handler(w http.ResponseWriter, r *http.Request, c *config.Config, logger lo
 	if !ok {
 		http.Error(w, fmt.Sprintf("Unknown module %q", moduleName), http.StatusBadRequest)
 		level.Debug(logger).Log("msg", "Unknown module", "module", moduleName)
-		moduleUnknownCounter.Add(1)
+		if moduleUnknownCounter != nil {
+			(*moduleUnknownCounter).Add(1)
+		}
 		return
 	}
 

--- a/prober/handler_test.go
+++ b/prober/handler_test.go
@@ -59,7 +59,7 @@ func TestPrometheusTimeoutHTTP(t *testing.T) {
 
 	rr := httptest.NewRecorder()
 	handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		Handler(w, r, c, log.NewNopLogger(), &ResultHistory{}, 0.5, nil)
+		Handler(w, r, c, log.NewNopLogger(), &ResultHistory{}, 0.5, nil, nil)
 	})
 
 	handler.ServeHTTP(rr, req)
@@ -81,7 +81,7 @@ func TestPrometheusConfigSecretsHidden(t *testing.T) {
 	}
 	rr := httptest.NewRecorder()
 	handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		Handler(w, r, c, log.NewNopLogger(), &ResultHistory{}, 0.5, nil)
+		Handler(w, r, c, log.NewNopLogger(), &ResultHistory{}, 0.5, nil, nil)
 	})
 	handler.ServeHTTP(rr, req)
 
@@ -177,7 +177,7 @@ func TestHostnameParam(t *testing.T) {
 	rr := httptest.NewRecorder()
 
 	handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		Handler(w, r, c, log.NewNopLogger(), &ResultHistory{}, 0.5, nil)
+		Handler(w, r, c, log.NewNopLogger(), &ResultHistory{}, 0.5, nil, nil)
 	})
 
 	handler.ServeHTTP(rr, req)
@@ -195,7 +195,7 @@ func TestHostnameParam(t *testing.T) {
 	c.Modules["http_2xx"].HTTP.Headers["Host"] = hostname + ".something"
 
 	handler = http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		Handler(w, r, c, log.NewNopLogger(), &ResultHistory{}, 0.5, nil)
+		Handler(w, r, c, log.NewNopLogger(), &ResultHistory{}, 0.5, nil, nil)
 	})
 
 	rr = httptest.NewRecorder()
@@ -242,7 +242,7 @@ func TestTCPHostnameParam(t *testing.T) {
 	rr := httptest.NewRecorder()
 
 	handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		Handler(w, r, c, log.NewNopLogger(), &ResultHistory{}, 0.5, nil)
+		Handler(w, r, c, log.NewNopLogger(), &ResultHistory{}, 0.5, nil, nil)
 	})
 
 	handler.ServeHTTP(rr, req)


### PR DESCRIPTION
- The first attempt to de-register internal metrics in #1056 was not sucessful.
- Added a `NewSafeConfig` function that gets a `prometheus.Registerer` as parameter and register config reloading metrics.
- Moved `moduleUnknownCounter` again to main and now it's passed (optionally) to `Handler` function.