### PR TITLE
Build blackbox_exporter with go 1.19.9 

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -5,7 +5,7 @@ executors:
   # Whenever the Go version is updated here, .promu.yml should also be updated.
   golang:
     docker:
-      - image: cimg/go:1.19
+      - image: cimg/go:1.19.9
 jobs:
   test:
     executor: golang

--- a/.promu.yml
+++ b/.promu.yml
@@ -1,7 +1,7 @@
 go:
     # Whenever the Go version is updated here, .travis.yml and
     # .circle/config.yml should also be updated.
-    version: 1.19
+    version: 1.19.9
 repository:
     path: github.com/prometheus/blackbox_exporter
 build:

--- a/.promu.yml
+++ b/.promu.yml
@@ -1,7 +1,7 @@
 go:
     # Whenever the Go version is updated here, .travis.yml and
     # .circle/config.yml should also be updated.
-    version: 1.19.9
+    version: 1.19
 repository:
     path: github.com/prometheus/blackbox_exporter
 build:

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/prometheus/blackbox_exporter
 
-go 1.18
+go 1.19
 
 require (
 	github.com/alecthomas/units v0.0.0-20211218093645-b94a6e3cc137


### PR DESCRIPTION
Go came out with new secruity release with [fixes for bunch of CVEs](https://go.dev/doc/devel/release#go1.20), Update go to build blackbox_exporter.

Also see #1070

