### PR TITLE
allow specification of source address for probes (http, grpc)

### DIFF
--- a/CONFIGURATION.md
+++ b/CONFIGURATION.md
@@ -153,6 +153,9 @@ modules:
   [ preferred_ip_protocol: <string> | default = "ip6" ]
   [ ip_protocol_fallback: <boolean> | default = true ]
 
+  # The source IP address.
+  [ source_ip_address: <string> ]
+
   # The body of the HTTP request used in probe.
   [ body: <string> ]
 
@@ -309,6 +312,9 @@ validate_additional_rrs:
 # The IP protocol of the gRPC probe (ip4, ip6).
 [ preferred_ip_protocol: <string> ]
 [ ip_protocol_fallback: <boolean> | default = true ]
+
+# The source IP address.
+[ source_ip_address: <string> ]
 
 # Whether to connect to the endpoint with TLS.
 [ tls: <boolean | default = false> ]

--- a/config/config.go
+++ b/config/config.go
@@ -208,6 +208,7 @@ type HTTPProbe struct {
 	ValidHTTPVersions            []string                `yaml:"valid_http_versions,omitempty"`
 	IPProtocol                   string                  `yaml:"preferred_ip_protocol,omitempty"`
 	IPProtocolFallback           bool                    `yaml:"ip_protocol_fallback,omitempty"`
+	SourceIPAddress              string                  `yaml:"source_ip_address,omitempty"`
 	SkipResolvePhaseWithProxy    bool                    `yaml:"skip_resolve_phase_with_proxy,omitempty"`
 	NoFollowRedirects            *bool                   `yaml:"no_follow_redirects,omitempty"`
 	FailIfSSL                    bool                    `yaml:"fail_if_ssl,omitempty"`
@@ -230,6 +231,7 @@ type GRPCProbe struct {
 	TLS                 bool             `yaml:"tls,omitempty"`
 	TLSConfig           config.TLSConfig `yaml:"tls_config,omitempty"`
 	IPProtocolFallback  bool             `yaml:"ip_protocol_fallback,omitempty"`
+	SourceIPAddress     string           `yaml:"source_ip_address,omitempty"`
 	PreferredIPProtocol string           `yaml:"preferred_ip_protocol,omitempty"`
 }
 


### PR DESCRIPTION
This adds the configuration option source_ip_address to modules HTTP and GRPC which changes the
prober's local address.