### PR TITLE
allow specification of query_name by probe param for dns prober

### DIFF
--- a/README.md
+++ b/README.md
@@ -137,6 +137,30 @@ scrape_configs:
         target_label: vhost  # and store it in 'vhost' label
 ```
 
+DNS probes can also accept additional `hostname` parameter that will set `query_name` on probe
+
+```yaml
+scrape_configs:
+  - job_name: blackbox_all
+    metrics_path: /probe
+    params:
+      module: [ dns_probe ]  
+    static_configs:
+      - targets:
+        - 8.8.8.8
+        labels:
+          queryname: www.google.com
+    relabel_configs:
+      - source_labels: [__address__]
+        target_label: __param_target
+      - source_labels: [__param_target]
+        target_label: instance
+      - target_label: __address__
+        replacement: 127.0.0.1:9115  # The blackbox exporter's real hostname:port.
+      - source_labels: [queryname]
+        target_label: __param_hostname  # Make domain name become 'Host' header for probe requests
+```
+
 ## Permissions
 
 The ICMP probe requires elevated privileges to function:

--- a/prober/handler.go
+++ b/prober/handler.go
@@ -109,6 +109,10 @@ func Handler(w http.ResponseWriter, r *http.Request, c *config.Config, logger lo
 		}
 	}
 
+	if module.Prober == "dns" && hostname != "" {
+		module.DNS.QueryName = hostname
+	}
+
 	sl := newScrapeLogger(logger, moduleName, target, logLevelProber)
 	level.Info(sl).Log("msg", "Beginning probe", "probe", module.Prober, "timeout_seconds", timeoutSeconds)
 


### PR DESCRIPTION
related issues: [#1104](https://github.com/prometheus/blackbox_exporter/issues/1104)
allow specification of query_name by probe param for dns prober