### PR TITLE
feat: Implement byte matching in TCP query responses

### DIFF
--- a/CONFIGURATION.md
+++ b/CONFIGURATION.md
@@ -182,9 +182,11 @@ regexp: <regex>,
 [ source_ip_address: <string> ]
 
 # The query sent in the TCP probe and the expected associated response.
+# expect_bytes does exact byte-by-byte match.
 # starttls upgrades TCP connection to TLS.
 query_response:
   [ - [ [ expect: <string> ],
+        [ expect_bytes: <string> ],
         [ send: <string> ],
         [ starttls: <boolean | default = false> ]
       ], ...

--- a/blackbox.yml
+++ b/blackbox.yml
@@ -49,3 +49,10 @@ modules:
     timeout: 5s
     icmp:
       ttl: 5
+  postgresql:
+    prober: tcp
+    tcp:
+      query_response:
+      - send: !!binary AAAACATSFi8= # 0x00, 0x00, 0x00, 0x08, 0x04, 0xD2, 0x16, 0x2F - PostgreSQL SSLRequest
+      - expect_bytes: S # 0x53 - Reply will be 'S' if SSL is enabled, and 'N' if it is not.
+      - starttls: true

--- a/config/config.go
+++ b/config/config.go
@@ -240,9 +240,10 @@ type HeaderMatch struct {
 }
 
 type QueryResponse struct {
-	Expect   Regexp `yaml:"expect,omitempty"`
-	Send     string `yaml:"send,omitempty"`
-	StartTLS bool   `yaml:"starttls,omitempty"`
+	Expect      Regexp `yaml:"expect,omitempty"`
+	ExpectBytes string `yaml:"expect_bytes,omitempty"`
+	Send        string `yaml:"send,omitempty"`
+	StartTLS    bool   `yaml:"starttls,omitempty"`
 }
 
 type TCPProbe struct {

--- a/prober/tcp_test.go
+++ b/prober/tcp_test.go
@@ -563,6 +563,49 @@ func TestTCPConnectionQueryResponseMatching(t *testing.T) {
 
 }
 
+func TestTCPConnectionQueryResponseByteMode(t *testing.T) {
+	ln, err := net.Listen("tcp", "localhost:0")
+	if err != nil {
+		t.Fatalf("Error listening on socket: %s", err)
+	}
+	defer ln.Close()
+
+	testCTX, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+	module := config.Module{
+		TCP: config.TCPProbe{
+			IPProtocolFallback: true,
+			QueryResponse: []config.QueryResponse{
+				{
+					ExpectBytes: "not-a-line",
+				},
+			},
+		},
+	}
+
+	go func() {
+		conn, err := ln.Accept()
+		if err != nil {
+			panic(fmt.Sprintf("Error accepting on socket: %s", err))
+		}
+		conn.SetDeadline(time.Now().Add(1 * time.Second))
+		conn.Write([]byte("not-a-line"))
+		conn.Close()
+	}()
+	registry := prometheus.NewRegistry()
+	if !ProbeTCP(testCTX, ln.Addr().String(), module, registry, log.NewLogfmtLogger(os.Stderr)) {
+		t.Fatalf("TCP module failed, expected success.")
+	}
+	mfs, err := registry.Gather()
+	if err != nil {
+		t.Fatal(err)
+	}
+	expectedResults := map[string]float64{
+		"probe_failed_due_to_regex": 0,
+	}
+	checkRegistryResults(expectedResults, mfs, t)
+}
+
 func TestTCPConnectionProtocol(t *testing.T) {
 	if os.Getenv("CI") == "true" {
 		t.Skip("skipping; CI is failing on ipv6 dns requests")


### PR DESCRIPTION
Currently the exporter only supports lines, which breaks byte-oriented protocols such as the PostgreSQL StartTLS handshake.

We also give a working example for Postgres in the sample configuration.

Fixes: https://github.com/prometheus/blackbox_exporter/issues/801