### PR TITLE
Support multipart/form-data

### DIFF
--- a/CONFIGURATION.md
+++ b/CONFIGURATION.md
@@ -158,9 +158,13 @@ modules:
   [ body: <string> ]
 
   # Read the HTTP request body from from a file.
-  # It is mutually exclusive with `body`.
+  # It is mutually exclusive with `body` and `body_multipart`.
   [ body_file: <filename> ]
 
+  # Read the HTTP request body from from a file.
+  # It is mutually exclusive with `body` and `body_file`.
+  [ body_multipart: <filename> ]
+    [ - <body_multipart_spec>, ... ]
 ```
 
 #### `<http_header_match_spec>`
@@ -169,6 +173,17 @@ modules:
 header: <string>,
 regexp: <regex>,
 [ allow_missing: <boolean> | default = false ]
+```
+
+#### `<body_multipart_spec>`
+
+```yml
+# The type of the multipart body part. Valid values are "file" and "text".
+type: <string>
+# The name of the multipart body part.
+key: <string>
+# The value of the multipart body part. It can be a file path or a string.
+value: <string>
 ```
 
 ### `<tcp_probe>`

--- a/CONFIGURATION.md
+++ b/CONFIGURATION.md
@@ -25,8 +25,8 @@ modules:
 
 ```
 
-
 ### `<module>`
+
 ```yml
 
   # The protocol over which the probe will take place (http, tcp, dns, icmp, grpc).
@@ -45,6 +45,7 @@ modules:
 ```
 
 ### `<http_probe>`
+
 ```yml
 
   # Accepted status codes for this probe. Defaults to 2xx.

--- a/config/config.go
+++ b/config/config.go
@@ -220,9 +220,16 @@ type HTTPProbe struct {
 	FailIfHeaderNotMatchesRegexp []HeaderMatch           `yaml:"fail_if_header_not_matches,omitempty"`
 	Body                         string                  `yaml:"body,omitempty"`
 	BodyFile                     string                  `yaml:"body_file,omitempty"`
+	BodyMultipart                []Multipart             `yaml:"body_multipart,omitempty"`
 	HTTPClientConfig             config.HTTPClientConfig `yaml:"http_client_config,inline"`
 	Compression                  string                  `yaml:"compression,omitempty"`
 	BodySizeLimit                units.Base2Bytes        `yaml:"body_size_limit,omitempty"`
+}
+
+type Multipart struct {
+	Type  string `yaml:"type,omitempty"`
+	Key   string `yaml:"key,omitempty"`
+	Value string `yaml:"value,omitempty"`
 }
 
 type GRPCProbe struct {

--- a/example.yml
+++ b/example.yml
@@ -54,6 +54,18 @@ modules:
     http:
       method: POST
       body_file: "/files/body.txt"
+  http_post_body_multipart:
+    prober: http
+    timeout: 5s
+    http:
+      method: POST
+      body_multipart:
+        - type: "file"
+          key: "file"
+          value: "/files/body.txt"
+        - type: "text"
+          key: "name"
+          value: "arash"
   http_basic_auth_example:
     prober: http
     timeout: 5s


### PR DESCRIPTION
## Description

After this PR, we can send POST requests in `multipart/form-data` format. For example, users can test the upload process quickly.

```yaml
http_post_body_multipart:
    prober: http
    timeout: 5s
    http:
      method: POST
      body_multipart:
        - type: "file"
          key: "file"
          value: "/files/body.txt"
        - type: "text"
          key: "name"
          value: "arash"
```

We can define `text` or `file` fields here.

---

## Changes

- Support `multipart` for HTTP probe
- Update example file
- Update configuration document