### PR TITLE
document tls max_version option

### DIFF
--- a/CONFIGURATION.md
+++ b/CONFIGURATION.md
@@ -342,6 +342,13 @@ tls_config:
 # If unset, Prometheus will use Go default minimum version, which is TLS 1.2.
 # See MinVersion in https://pkg.go.dev/crypto/tls#Config.
 [ min_version: <string> ]
+
+# Maximum acceptable TLS version. Accepted values: TLS10 (TLS 1.0), TLS11 (TLS
+# 1.1), TLS12 (TLS 1.2), TLS13 (TLS 1.3).
+# Can be used to test for the presence of insecure TLS versions.
+# If unset, Prometheus will use Go default maximum version, which is TLS 1.3.
+# See MaxVersion in https://pkg.go.dev/crypto/tls#Config.
+[ max_version: <string> ]
 ```
 
 #### `<oauth2>`


### PR DESCRIPTION
This is useful for checking for insecure TLS versions, see #1121 