### PR TITLE
Added collection_duration_seconds internal metric per module

### DIFF
--- a/config/config_test.go
+++ b/config/config_test.go
@@ -22,7 +22,7 @@ import (
 )
 
 func TestLoadConfig(t *testing.T) {
-	sc := NewSafeConfig(prometheus.NewRegistry())
+	sc := NewSafeConfig(prometheus.NewRegistry(), nil)
 
 	err := sc.ReloadConfig("testdata/blackbox-good.yml", nil)
 	if err != nil {
@@ -31,7 +31,7 @@ func TestLoadConfig(t *testing.T) {
 }
 
 func TestLoadBadConfigs(t *testing.T) {
-	sc := NewSafeConfig(prometheus.NewRegistry())
+	sc := NewSafeConfig(prometheus.NewRegistry(), nil)
 	tests := []struct {
 		input string
 		want  string
@@ -112,7 +112,7 @@ func TestLoadBadConfigs(t *testing.T) {
 }
 
 func TestHideConfigSecrets(t *testing.T) {
-	sc := NewSafeConfig(prometheus.NewRegistry())
+	sc := NewSafeConfig(prometheus.NewRegistry(), nil)
 
 	err := sc.ReloadConfig("testdata/blackbox-good.yml", nil)
 	if err != nil {

--- a/prober/handler.go
+++ b/prober/handler.go
@@ -44,6 +44,7 @@ var (
 
 func Handler(w http.ResponseWriter, r *http.Request, c *config.Config, logger log.Logger, rh *ResultHistory, timeoutOffset float64, params url.Values,
 	moduleUnknownCounter prometheus.Counter,
+	probeCollectionDuration *prometheus.HistogramVec,
 	logLevelProber level.Option) {
 
 	if params == nil {
@@ -119,6 +120,9 @@ func Handler(w http.ResponseWriter, r *http.Request, c *config.Config, logger lo
 	success := prober(ctx, target, module, registry, sl)
 	duration := time.Since(start).Seconds()
 	probeDurationGauge.Set(duration)
+	if probeCollectionDuration != nil {
+		probeCollectionDuration.WithLabelValues(moduleName).Observe(duration)
+	}
 	if success {
 		probeSuccessGauge.Set(1)
 		level.Info(sl).Log("msg", "Probe succeeded", "duration_seconds", duration)

--- a/prober/handler_test.go
+++ b/prober/handler_test.go
@@ -60,7 +60,7 @@ func TestPrometheusTimeoutHTTP(t *testing.T) {
 
 	rr := httptest.NewRecorder()
 	handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		Handler(w, r, c, log.NewNopLogger(), &ResultHistory{}, 0.5, nil, nil, level.AllowNone())
+		Handler(w, r, c, log.NewNopLogger(), &ResultHistory{}, 0.5, nil, nil, nil, level.AllowNone())
 	})
 
 	handler.ServeHTTP(rr, req)
@@ -82,7 +82,7 @@ func TestPrometheusConfigSecretsHidden(t *testing.T) {
 	}
 	rr := httptest.NewRecorder()
 	handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		Handler(w, r, c, log.NewNopLogger(), &ResultHistory{}, 0.5, nil, nil, level.AllowNone())
+		Handler(w, r, c, log.NewNopLogger(), &ResultHistory{}, 0.5, nil, nil, nil, level.AllowNone())
 	})
 	handler.ServeHTTP(rr, req)
 
@@ -178,7 +178,7 @@ func TestHostnameParam(t *testing.T) {
 	rr := httptest.NewRecorder()
 
 	handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		Handler(w, r, c, log.NewNopLogger(), &ResultHistory{}, 0.5, nil, nil, level.AllowNone())
+		Handler(w, r, c, log.NewNopLogger(), &ResultHistory{}, 0.5, nil, nil, nil, level.AllowNone())
 	})
 
 	handler.ServeHTTP(rr, req)
@@ -196,7 +196,7 @@ func TestHostnameParam(t *testing.T) {
 	c.Modules["http_2xx"].HTTP.Headers["Host"] = hostname + ".something"
 
 	handler = http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		Handler(w, r, c, log.NewNopLogger(), &ResultHistory{}, 0.5, nil, nil, level.AllowNone())
+		Handler(w, r, c, log.NewNopLogger(), &ResultHistory{}, 0.5, nil, nil, nil, level.AllowNone())
 	})
 
 	rr = httptest.NewRecorder()
@@ -243,7 +243,7 @@ func TestTCPHostnameParam(t *testing.T) {
 	rr := httptest.NewRecorder()
 
 	handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		Handler(w, r, c, log.NewNopLogger(), &ResultHistory{}, 0.5, nil, nil, level.AllowNone())
+		Handler(w, r, c, log.NewNopLogger(), &ResultHistory{}, 0.5, nil, nil, nil, level.AllowNone())
 	})
 
 	handler.ServeHTTP(rr, req)


### PR DESCRIPTION
Closes #1131.

Adds new internal metric for histogram of collection durations per exporter module as requested in #1131.

My Go is quite rusty so all improvements are very welcome. Implementation has been done in a similar manner to the SNMP Exporter.

Metric for say the `http_2xx` module would look like:

```
blackbox_collection_duration_seconds_bucket{module="http_2xx",le="0.005"} 0
blackbox_collection_duration_seconds_bucket{module="http_2xx",le="0.01"} 0
blackbox_collection_duration_seconds_bucket{module="http_2xx",le="0.025"} 0
blackbox_collection_duration_seconds_bucket{module="http_2xx",le="0.05"} 0
blackbox_collection_duration_seconds_bucket{module="http_2xx",le="0.1"} 4
blackbox_collection_duration_seconds_bucket{module="http_2xx",le="0.25"} 5
blackbox_collection_duration_seconds_bucket{module="http_2xx",le="0.5"} 5
blackbox_collection_duration_seconds_bucket{module="http_2xx",le="1"} 5
blackbox_collection_duration_seconds_bucket{module="http_2xx",le="2.5"} 5
blackbox_collection_duration_seconds_bucket{module="http_2xx",le="5"} 5
blackbox_collection_duration_seconds_bucket{module="http_2xx",le="10"} 5
blackbox_collection_duration_seconds_bucket{module="http_2xx",le="+Inf"} 5
blackbox_collection_duration_seconds_sum{module="http_2xx"} 0.387132424
blackbox_collection_duration_seconds_count{module="http_2xx"} 5
```