### PR TITLE
Fixed target parsing

### DIFF
--- a/prober/http.go
+++ b/prober/http.go
@@ -309,7 +309,8 @@ func ProbeHTTP(ctx context.Context, target string, module config.Module, registr
 
 	httpConfig := module.HTTP
 
-	if !strings.HasPrefix(target, "http://") && !strings.HasPrefix(target, "https://") {
+	targetLower := strings.ToLower(target)
+	if !strings.HasPrefix(targetLower, "http://") && !strings.HasPrefix(targetLower, "https://") {
 		target = "http://" + target
 	}
 


### PR DESCRIPTION
Improved http(s) scheme check so that target may be passed in lower and upper cases.

Before the fix works only schemes:
 - http://
 - https://

After the fix also works schemes alike:
- HTTPS://
- HtTp://
