### PR TITLE
Add http failure reason metric #1077

### DIFF
--- a/prober/http.go
+++ b/prober/http.go
@@ -324,7 +324,9 @@ func ProbeHTTP(ctx context.Context, target string, module config.Module, registr
 		level.Error(logger).Log("msg", "Could not parse target URL", "err", err)
 		var ue *url.Error
 		if errors.As(err, &ue) {
-			probeFailureCounter.WithLabelValues(labelFromUrlError("parse", ue)).Inc()
+			probeFailureCounter.WithLabelValues(labelFromUrlError("urlparse", ue)).Inc()
+		} else {
+			probeFailureCounter.WithLabelValues("urlparse_error").Inc()
 		}
 		return false
 	}
@@ -507,7 +509,6 @@ func ProbeHTTP(ctx context.Context, target string, module config.Module, registr
 			var hostnameError x509.HostnameError
 			var certInvalidError x509.CertificateInvalidError
 			var ue *url.Error
-
 			switch {
 			case errors.As(err, &authorityError):
 				probeFailureCounter.WithLabelValues("request_certificate_unknown_authority").Inc()

--- a/prober/http_test.go
+++ b/prober/http_test.go
@@ -945,7 +945,7 @@ func TestFailIfNotSSLLogMsg(t *testing.T) {
 			URL:                goodServer.URL,
 			Success:            false,
 			MessageExpected:    true,
-			ProbeFailureReason: "request_get_error",
+			ProbeFailureReason: "final_request_not_ssl",
 		},
 		"No SSL expected, no message": {
 			Config:          config.Module{HTTP: config.HTTPProbe{IPProtocolFallback: true, FailIfNotSSL: false}},

--- a/prober/utils_test.go
+++ b/prober/utils_test.go
@@ -37,7 +37,11 @@ import (
 func checkRegistryResults(expRes map[string]float64, mfs []*dto.MetricFamily, t *testing.T) {
 	res := make(map[string]float64)
 	for i := range mfs {
-		res[mfs[i].GetName()] = mfs[i].Metric[0].GetGauge().GetValue()
+		if mfs[i].GetType() == dto.MetricType_GAUGE {
+			res[mfs[i].GetName()] = mfs[i].Metric[0].GetGauge().GetValue()
+		} else if mfs[i].GetType() == dto.MetricType_COUNTER {
+			res[mfs[i].GetName()] = mfs[i].Metric[0].GetCounter().GetValue()
+		}
 	}
 	for k, v := range expRes {
 		val, ok := res[k]


### PR DESCRIPTION
Adds `probe_http_failures_total` metric implementing feature for #1077 . This `couter` type metric provides the reason of http probe failures.

For example:
```
probe_http_failures_total{reason="dns_not_found"}
probe_http_failures_total{reason="request_creation_error"}
probe_http_failures_total{reason="request_get_timeout"}
...
```