### PR TITLE
feat: Add discovery support

### DIFF
--- a/config/testdata/blackbox-good.yml
+++ b/config/testdata/blackbox-good.yml
@@ -78,3 +78,13 @@ modules:
       - header: Access-Control-Allow-Origin
         regexp: '(\*|example\.com)'
         allow_missing: false
+discovery:
+  files:
+    - test.yml
+  configs:
+    - module: http_2xx
+      targets:
+        - http://www.google.com/
+      hostname: www.google.com
+      scrape_interval: 10m
+      scrape_timeout: 10s

--- a/discovery/discovery.go
+++ b/discovery/discovery.go
@@ -1,0 +1,149 @@
+// Copyright 2016 The Prometheus Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package discovery
+
+import (
+	"context"
+	"net/http"
+	"os"
+	"strings"
+	"time"
+
+	yaml "gopkg.in/yaml.v3"
+
+	"github.com/go-kit/log"
+	"github.com/go-kit/log/level"
+	"github.com/prometheus/blackbox_exporter/config"
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/promauto"
+)
+
+var (
+	discoveryCount = promauto.With(prometheus.DefaultRegisterer).NewCounter(prometheus.CounterOpts{
+		Namespace: "blackbox_exporter",
+		Subsystem: "discovery",
+		Name:      "count",
+		Help:      "Displays count of discoveries",
+	})
+	discoveryErrors = promauto.With(prometheus.DefaultRegisterer).NewCounterVec(prometheus.CounterOpts{
+		Namespace: "blackbox_exporter",
+		Subsystem: "discovery",
+		Name:      "errors",
+		Help:      "Displays count of discovery errors",
+	},
+		[]string{"file", "module"})
+)
+
+func Handler(w http.ResponseWriter, r *http.Request, path string, c *config.Config, logger log.Logger) {
+	ctx, cancel := context.WithTimeout(r.Context(), time.Duration(float64(10*time.Second)))
+	defer cancel()
+	r = r.WithContext(ctx)
+
+	discoveryCount.Inc()
+
+	ds := c.Discoveries.Configs
+
+	df := getDiscoveriesFromFiles(c.Discoveries.Files, logger)
+	if df != nil {
+		ds = append(ds, df...)
+	}
+
+	comma := false
+	host := "localhost"
+	path = strings.TrimRight(path, "/")
+	port := "9115"
+	if strings.Contains(r.Host, ":") {
+		host = strings.Split(r.Host, ":")[0]
+		port = strings.Split(r.Host, ":")[1]
+	} else if r.Host != "" {
+		host = r.Host
+	}
+	scheme := "http"
+	dest := host + ":" + port
+	if r.TLS != nil {
+		scheme = "https"
+	}
+
+	w.Header().Set("Content-Type", "application/json")
+	w.Write([]byte(`[`))
+	for _, d := range ds {
+		if _, ok := c.Modules[d.Module]; !ok {
+			discoveryErrors.WithLabelValues(d.Filename, d.Module).Inc()
+			level.Debug(logger).Log("msg", "Unknown module in discovery", "module", d.Module, "file", d.Filename)
+			continue
+		}
+		for _, t := range d.Targets {
+			if comma {
+				w.Write([]byte(`,`))
+			} else {
+				comma = true
+			}
+			writeTarget(w, scheme, dest, path, t, d)
+		}
+	}
+	w.Write([]byte(`]`))
+}
+
+func getDiscoveriesFromFiles(files []string, logger log.Logger) []*config.Discovery {
+	d := make([]*config.Discovery, 0)
+	for _, file := range files {
+		ds, err := yamlDiscoveryFile(file, logger)
+		if err == nil {
+			d = append(d, ds...)
+		}
+	}
+	return d
+}
+
+func yamlDiscoveryFile(file string, logger log.Logger) ([]*config.Discovery, error) {
+	d := make([]*config.Discovery, 0)
+	yamlReader, err := os.Open(file)
+	if err != nil {
+		discoveryErrors.WithLabelValues(file, "").Inc()
+		level.Debug(logger).Log("msg", "Unable to open discovery file", "file", file)
+		return nil, err
+	}
+	defer yamlReader.Close()
+	decoder := yaml.NewDecoder(yamlReader)
+	decoder.KnownFields(true)
+
+	err = decoder.Decode(&d)
+	if err != nil {
+		discoveryErrors.WithLabelValues(file, "").Inc()
+		level.Debug(logger).Log("msg", "Discovery file is not valid yaml", "file", file)
+		return nil, err
+	}
+	for _, e := range d {
+		e.Filename = file
+	}
+	return d, nil
+}
+
+func writeTarget(w http.ResponseWriter, scheme string, dest string, path string, target string, d *config.Discovery) {
+	w.Write([]byte(`{"targets": ["` + dest + `"],`))
+	w.Write([]byte(`"labels":{"__scheme__":"` + scheme + `"`))
+	w.Write([]byte(`,"__metrics_path__":"` + path + `/probe"`))
+	w.Write([]byte(`,"__param_module":"` + d.Module + `"`))
+	w.Write([]byte(`,"__param_target":"` + target + `"`))
+	if d.Hostname != nil {
+		w.Write([]byte(`,__param_hostname":"` + *d.Hostname + `"`))
+	}
+	if d.ScrapeInterval != nil {
+		w.Write([]byte(`,__scrape_interval__":"` + d.ScrapeInterval.String() + `"`))
+	}
+	if d.ScrapeTimeout != nil {
+		w.Write([]byte(`,__scrape_timeout__":"` + d.ScrapeInterval.String() + `"`))
+	}
+	w.Write([]byte(`}}`))
+}

--- a/discovery/discovery_test.go
+++ b/discovery/discovery_test.go
@@ -1,0 +1,77 @@
+// Copyright 2016 The Prometheus Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package discovery
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/go-kit/log"
+
+	"github.com/prometheus/blackbox_exporter/config"
+)
+
+var c = &config.Config{
+	Modules: map[string]config.Module{
+		"http_2xx": {
+			Prober:  "http",
+			Timeout: 10 * time.Second,
+			HTTP:    config.HTTPProbe{},
+		},
+	},
+	Discoveries: config.Discoveries{
+		Configs: []*config.Discovery{
+			&config.Discovery{
+				Hostname: str("hostname"),
+				Module:   "http_2xx",
+				Targets: []string{
+					"http://www.google.com",
+				},
+			},
+			&config.Discovery{
+				Module: "non-existing-module",
+				Targets: []string{
+					"http://www.google.com",
+				},
+			},
+		},
+	},
+}
+
+func str(s string) *string {
+	return &s
+}
+
+func TestDiscoveryConfigs(t *testing.T) {
+	req, err := http.NewRequest("GET", "", nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	rr := httptest.NewRecorder()
+	handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		Handler(w, r, "/", c, log.NewNopLogger())
+	})
+
+	handler.ServeHTTP(rr, req)
+
+	if status := rr.Code; status != http.StatusOK {
+		t.Errorf("discovery request handler returned wrong status code: %v, want %v", status, http.StatusOK)
+	}
+	if body := rr.Body.String(); string(body) != `[{"targets": ["localhost:9115"],"labels":{"__scheme__":"http","__metrics_path__":"/probe","__param_module":"http_2xx","__param_target":"http://www.google.com",__param_hostname":"hostname"}}]` {
+		t.Errorf("discovery returns unexpected body:\n%v\ninsted of:\n"+`[{"targets": ["localhost:9115"],"labels":{"__scheme__":"http","__metrics_path__":"/probe","__param_module":"http_2xx","__param_target":"http://www.google.com",__param_hostname":"hostname"}}]`, body)
+	}
+}

--- a/main.go
+++ b/main.go
@@ -41,6 +41,7 @@ import (
 	"gopkg.in/yaml.v3"
 
 	"github.com/prometheus/blackbox_exporter/config"
+	"github.com/prometheus/blackbox_exporter/discovery"
 	"github.com/prometheus/blackbox_exporter/prober"
 )
 
@@ -177,6 +178,12 @@ func run() int {
 				http.Error(w, fmt.Sprintf("failed to reload config: %s", err), http.StatusInternalServerError)
 			}
 		})
+	http.HandleFunc(path.Join(*routePrefix, "/discovery"), func(w http.ResponseWriter, r *http.Request) {
+		sc.Lock()
+		conf := sc.C
+		sc.Unlock()
+		discovery.Handler(w, r, *routePrefix, conf, logger)
+	})
 	http.Handle(path.Join(*routePrefix, "/metrics"), promhttp.Handler())
 	http.HandleFunc(path.Join(*routePrefix, "/-/healthy"), func(w http.ResponseWriter, r *http.Request) {
 		w.WriteHeader(http.StatusOK)


### PR DESCRIPTION
I think it's good practice to give the machine owners possibility to define also discoveries.

I added /discovery endpoint in this PR which is configured in config file:
```
discovery:
  files:
  - <fileglob>
  configs:
  - module: http_2xx
    targets:
    - <host/url>
```

It should be used in prometheus this way for scraping:
```
- job_name: "exported-blackbox-probes"
  http_sd_configs:
  - url: http://prometheus-blackbox-exporter:9115/discovery
```