### PR TITLE
Update Go build

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -5,7 +5,7 @@ executors:
   # Whenever the Go version is updated here, .promu.yml should also be updated.
   golang:
     docker:
-      - image: cimg/go:1.20
+      - image: cimg/go:1.21
 jobs:
   test:
     executor: golang
@@ -20,10 +20,9 @@ jobs:
   test-ipv6:
     machine: true
     working_directory: /home/circleci/.go_workspace/src/github.com/prometheus/blackbox_exporter
-    # Whenever the Go version is updated here, .travis.yml and .promu.yml
-    # should also be updated.
+    # Whenever the Go version is updated here, .promu.yml should also be updated.
     environment:
-      DOCKER_TEST_IMAGE_NAME: quay.io/prometheus/golang-builder:1.20-base
+      DOCKER_TEST_IMAGE_NAME: quay.io/prometheus/golang-builder:1.21-base
     steps:
       - checkout
       - run:

--- a/.promu.yml
+++ b/.promu.yml
@@ -1,11 +1,9 @@
 go:
-    # Whenever the Go version is updated here, .travis.yml and
-    # .circle/config.yml should also be updated.
-    version: 1.20
+    # Whenever the Go version is updated here, .circle/config.yml should also be updated.
+    version: 1.21
 repository:
     path: github.com/prometheus/blackbox_exporter
 build:
-    flags: -a -tags netgo
     ldflags: |
         -X github.com/prometheus/common/version.Version={{.Version}}
         -X github.com/prometheus/common/version.Revision={{.Revision}}

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Blackbox exporter [![Build Status](https://travis-ci.org/prometheus/blackbox_exporter.svg)][travis]
+# Blackbox exporter
 
 [![CircleCI](https://circleci.com/gh/prometheus/blackbox_exporter/tree/master.svg?style=shield)][circleci]
 [![Docker Repository on Quay](https://quay.io/repository/prometheus/blackbox-exporter/status)][quay]
@@ -161,5 +161,4 @@ The ICMP probe requires elevated privileges to function:
 
 [circleci]: https://circleci.com/gh/prometheus/blackbox_exporter
 [hub]: https://hub.docker.com/r/prom/blackbox-exporter/
-[travis]: https://travis-ci.org/prometheus/blackbox_exporter
 [quay]: https://quay.io/repository/prometheus/blackbox-exporter

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/prometheus/blackbox_exporter
 
-go 1.19
+go 1.20
 
 require (
 	github.com/alecthomas/kingpin/v2 v2.4.0


### PR DESCRIPTION
* Update Go to 1.21.
* Update minimum Go version to 1.20.
* Remove obsolete extra build flgas.

Fixes: https://github.com/prometheus/blackbox_exporter/issues/1005