### PR TITLE
add metric to record tls ciphersuite negotiated during handshake

### DIFF
--- a/prober/prober.go
+++ b/prober/prober.go
@@ -28,6 +28,7 @@ const (
 	helpSSLEarliestCertExpiry     = "Returns last SSL chain expiry in unixtime"
 	helpSSLChainExpiryInTimeStamp = "Returns last SSL chain expiry in timestamp"
 	helpProbeTLSInfo              = "Returns the TLS version used or NaN when unknown"
+	helpProbeTLSCipher            = "Returns the TLS cipher negotiated during handshake or 0x000 when unknown"
 )
 
 var (
@@ -44,5 +45,10 @@ var (
 	probeTLSInfoGaugeOpts = prometheus.GaugeOpts{
 		Name: "probe_tls_version_info",
 		Help: helpProbeTLSInfo,
+	}
+
+	probeTLSCipherGaugeOpts = prometheus.GaugeOpts{
+		Name: "probe_tls_cipher_info",
+		Help: helpProbeTLSCipher,
 	}
 )

--- a/prober/prober.go
+++ b/prober/prober.go
@@ -28,7 +28,7 @@ const (
 	helpSSLEarliestCertExpiry     = "Returns last SSL chain expiry in unixtime"
 	helpSSLChainExpiryInTimeStamp = "Returns last SSL chain expiry in timestamp"
 	helpProbeTLSInfo              = "Returns the TLS version used or NaN when unknown"
-	helpProbeTLSCipher            = "Returns the TLS cipher negotiated during handshake or 0x000 when unknown"
+	helpProbeTLSCipher            = "Returns the TLS cipher negotiated during handshake"
 )
 
 var (

--- a/prober/tls.go
+++ b/prober/tls.go
@@ -83,3 +83,7 @@ func getTLSVersion(state *tls.ConnectionState) string {
 		return "unknown"
 	}
 }
+
+func getTLSCipher(state *tls.ConnectionState) string {
+	return tls.CipherSuiteName(state.CipherSuite)
+}


### PR DESCRIPTION
Record name of ciphersuite negotiated during handshake in new `probe_tls_cipher_info` metric, useful for evaluating ciphers in use by monitored endpoints.

Example:

```shell
$ curl http://localhost:9115/probe?target=https://google.com&module=http_2xx

<...abbreviated...>

# HELP probe_tls_cipher_info Returns the TLS cipher negotiated during handshake or 0x000 when unknown
# TYPE probe_tls_cipher_info gauge
probe_tls_cipher_info{cipher="TLS_AES_128_GCM_SHA256"} 1
# HELP probe_tls_version_info Returns the TLS version used or NaN when unknown
# TYPE probe_tls_version_info gauge
probe_tls_version_info{version="TLS 1.3"} 1
```