### PR TITLE
Set probe_success metric to 0 on failure

### DIFF
--- a/prober/handler.go
+++ b/prober/handler.go
@@ -123,6 +123,7 @@ func Handler(w http.ResponseWriter, r *http.Request, c *config.Config, logger lo
 		probeSuccessGauge.Set(1)
 		level.Info(sl).Log("msg", "Probe succeeded", "duration_seconds", duration)
 	} else {
+		probeSuccessGuage.Set(0)
 		level.Error(sl).Log("msg", "Probe failed", "duration_seconds", duration)
 	}
 


### PR DESCRIPTION
Sets probe_success output to 0 on failure to avoid guessing if probe failed or was running.

Dealing with these metrics in Grafana and elsewhere is problematic, as you don't know if it failed to emit, or the actual action failed. This makes it clear and unambiguous and makes it much easier to interpret the data.