### PR TITLE
Add body matches to url params

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -28,3 +28,4 @@ dependencies-stamp
 .deps
 *.tar.gz
 /vendor
+trash

--- a/blackbox.yml
+++ b/blackbox.yml
@@ -1,8 +1,35 @@
 modules:
+  # fhttp_custom_headers:
+  #   prober: http
+  #   timeout: 5s
+  #   http:
+  #     method: GET
+  #   target: '${target}'
+  http_1:
+    prober: http
+    timeout: 5s
+    http:
+      method: GET
+      # headers:
+      #   Host: "uvoo.me"
+        # Host: '${host}'
+          # target: 'https://192.168.254.9/'
+  http_custom:
+    prober: http
+    timeout: 5s
+    http:
+      method: GET
+      headers:
+        Host: '${host}'
+      valid_status_codes: [200]
   http_2xx:
     prober: http
     http:
       preferred_ip_protocol: "ip4"
+      fail_if_body_matches_regexp:
+        - "Could not connect to database"
+      fail_if_body_not_matches_regexp:
+        - "Download the latest version here"
   http_post_2xx:
     prober: http
     http:

--- a/blackbox.yml
+++ b/blackbox.yml
@@ -19,17 +19,17 @@ modules:
     timeout: 5s
     http:
       method: GET
-      headers:
-        Host: '${host}'
+      # headers:
+      #   Host: '${host}'
       valid_status_codes: [200]
-  http_2xx:
-    prober: http
-    http:
-      preferred_ip_protocol: "ip4"
       fail_if_body_matches_regexp:
         - "Could not connect to database"
       fail_if_body_not_matches_regexp:
         - "Download the latest version here"
+  http_2xx:
+    prober: http
+    http:
+      preferred_ip_protocol: "ip4"
   http_post_2xx:
     prober: http
     http:

--- a/curl.sh
+++ b/curl.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+set -eu
+# curl -s "http://localhost:9115/probe?target=https://104.197.78.225/ip2&module=http_1&hostname=g.uvoo.io&debug=true"
+curl -s "http://localhost:9115/probe?target=https://104.197.78.225/ip2&module=http_2xx&hostname=g.uvoo.io&debug=true&fail_if_body_not_matches_regexp=fooo1,fooo1,fooo3"

--- a/curl.sh
+++ b/curl.sh
@@ -7,4 +7,4 @@ set -eu
 # curl -s "http://localhost:9115/probe?target=https://104.197.78.225/ip&module=http_2xx&hostname=g.uvoo.io&debug=true&fail_if_body_not_matches_regexp=104"
 # curl -s "http://localhost:9115/probe?target=https://g.uvoo.io/ip&module=http_2xx&debug=true&fail_if_body_not_matches_regexp=104"
 # curl -s "http://localhost:9115/probe?target=https://uvoo.me&module=http_2xx&debug=true&fail_if_body_not_matches_regexp=uvoofff,asdf"
-curl -s "http://localhost:9115/probe?target=https://uvoo.me&module=http_2xx&debug=true&fail_if_body_not_matches_regexp=uvoox"
+curl -s "http://localhost:9115/probe?target=https://uvoo.me&module=http_2xx&debug=true&body_matches=uvoo,wp-content"

--- a/curl.sh
+++ b/curl.sh
@@ -1,4 +1,10 @@
 #!/bin/bash
 set -eu
 # curl -s "http://localhost:9115/probe?target=https://104.197.78.225/ip2&module=http_1&hostname=g.uvoo.io&debug=true"
-curl -s "http://localhost:9115/probe?target=https://104.197.78.225/ip2&module=http_2xx&hostname=g.uvoo.io&debug=true&fail_if_body_not_matches_regexp=fooo1,fooo1,fooo3"
+
+# curl -s "http://localhost:9115/probe?target=https://104.197.78.225/ip&module=http_custom&hostname=g.uvoo.io&debug=true&fail_if_body_not_matches_regexp=fooo1,fooo1,fooo3"
+
+# curl -s "http://localhost:9115/probe?target=https://104.197.78.225/ip&module=http_2xx&hostname=g.uvoo.io&debug=true&fail_if_body_not_matches_regexp=104"
+# curl -s "http://localhost:9115/probe?target=https://g.uvoo.io/ip&module=http_2xx&debug=true&fail_if_body_not_matches_regexp=104"
+# curl -s "http://localhost:9115/probe?target=https://uvoo.me&module=http_2xx&debug=true&fail_if_body_not_matches_regexp=uvoofff,asdf"
+curl -s "http://localhost:9115/probe?target=https://uvoo.me&module=http_2xx&debug=true&fail_if_body_not_matches_regexp=uvoox"

--- a/prober/handler.go
+++ b/prober/handler.go
@@ -104,12 +104,10 @@ func Handler(w http.ResponseWriter, r *http.Request, c *config.Config, logger lo
 		}
 	}
 
-	fail_if_body_not_matches_regexp := params.Get("fail_if_body_not_matches_regexp")
-	if module.Prober == "http" && len(fail_if_body_not_matches_regexp) != 0 {
+	body_matches := params.Get("body_matches")
+	if module.Prober == "http" && len(body_matches) != 0 {
 		var failIfBodyNotMatchesRegexp []config.Regexp
-		// paramValue := "pattern1,pattern2,pattern3"
-		// patterns := strings.Split(paramValue, ",")
-		patterns := strings.Split(fail_if_body_not_matches_regexp, ",")
+		patterns := strings.Split(body_matches, ",")
 		for _, pattern := range patterns {
 			regexp := config.MustNewRegexp(pattern)
 			failIfBodyNotMatchesRegexp = append(failIfBodyNotMatchesRegexp, regexp)
@@ -120,26 +118,6 @@ func Handler(w http.ResponseWriter, r *http.Request, c *config.Config, logger lo
 			return
 		}
 	}
-	/*
-		// for _, pattern := range fail_if_body_not_matches_regexp {
-		failIfBodyNotMatchesRegexp = params.Get("fail_if_body_not_matches_regexp")
-		for _, pattern := range failIfBodyNotMatchesRegexp {
-			// Convert each string pattern to a config.Regexp type
-			regexp := config.MustNewRegexp(pattern)
-
-			// Append the config.Regexp to the list
-			failIfBodyNotMatchesRegexp = append(failIfBodyNotMatchesRegexp, regexp)
-		}
-	*/
-	// failIfBodyNotMatchesRegexp = params.Get("fail_if_body_not_matches_regexp")
-	// failIfBodyNotMatchesRegexp = ["foo1"]
-	// regexp1 := config.MustNewRegexp("uvoo")
-	// regexp2 := config.MustNewRegexp("Uvoo")
-	// failIfBodyNotMatchesRegexp = append(failIfBodyNotMatchesRegexp, regexp1, regexp2)
-	// failIfBodyNotMatchesRegexp = config.MustNewRegexp("pattern1")
-	// FailIfBodyNotMatchesRegexp
-	// busk
-	// if module.Prober == "http" && failIfBodyNotMatchesRegexp != "" {
 
 	if module.Prober == "tcp" && hostname != "" {
 		if module.TCP.TLSConfig.ServerName == "" {
@@ -194,12 +172,9 @@ func setHTTPHost(hostname string, module *config.Module) error {
 	return nil
 }
 
-// func setFailIfBodyNotMatchesRegexp(failIfBodyNotMatchesRegexp string, module *config.Module) error {
 func setFailIfBodyNotMatchesRegexp(failIfBodyNotMatchesRegexp []config.Regexp, module *config.Module) error {
 	if module.HTTP.FailIfBodyNotMatchesRegexp != nil {
-		return fmt.Errorf("FailIfBodyNotMatchesRegex is defined both in module configuration and with URL-parameter 'fail_if_body_not_matches_regexp' (%s)", failIfBodyNotMatchesRegexp)
-		// return fmt.Errorf("FailIfBodyNotMatchesRegex is defined both in module configuration (%s) and with URL-parameter 'fail-if-body-not-matches-regexp' (%s)", value, hostname)
-		// return fmt.Errorf("fail_if_body_not_matches_regexp is defined both in module configuration (%s) and with URL-parameter 'fail-if-body-not-matches-regexp' (%s)", value, hostname)
+		return fmt.Errorf("fail_if_body_not_matches_regexp is defined both in module configuration and with URL-parameter 'body_matches' (%s)", failIfBodyNotMatchesRegexp)
 	}
 	module.HTTP.FailIfBodyNotMatchesRegexp = failIfBodyNotMatchesRegexp
 	return nil

--- a/prober/handler.go
+++ b/prober/handler.go
@@ -103,6 +103,16 @@ func Handler(w http.ResponseWriter, r *http.Request, c *config.Config, logger lo
 		}
 	}
 
+	failIfBodyNotMatchesRegexp := params.Get("fail_if_body_not_matches_regexp")
+	// FailIfBodyNotMatchesRegexp
+	// busk
+	if module.Prober == "http" && failIfBodyNotMatchesRegexp != "" {
+		if err != nil {
+			http.Error(w, err.Error(), http.StatusBadRequest)
+			return
+		}
+	}
+
 	if module.Prober == "tcp" && hostname != "" {
 		if module.TCP.TLSConfig.ServerName == "" {
 			module.TCP.TLSConfig.ServerName = hostname
@@ -153,6 +163,17 @@ func setHTTPHost(hostname string, module *config.Module) error {
 	}
 	headers["Host"] = hostname
 	module.HTTP.Headers = headers
+	return nil
+}
+
+// func setFailIfBodyNotMatchesRegexp(failIfBodyNotMatchesRegexp string, module *config.Module) error {
+func setFailIfBodyNotMatchesRegexp(failIfBodyNotMatchesRegexp []config.Regexp, module *config.Module) error {
+	if module.HTTP.FailIfBodyNotMatchesRegexp != nil {
+		return fmt.Errorf("FailIfBodyNotMatchesRegex is defined both in module configuration and with URL-parameter 'fail_if_body_not_matches_regexp' (%s)", failIfBodyNotMatchesRegexp)
+		// return fmt.Errorf("FailIfBodyNotMatchesRegex is defined both in module configuration (%s) and with URL-parameter 'fail-if-body-not-matches-regexp' (%s)", value, hostname)
+		// return fmt.Errorf("fail_if_body_not_matches_regexp is defined both in module configuration (%s) and with URL-parameter 'fail-if-body-not-matches-regexp' (%s)", value, hostname)
+	}
+	module.HTTP.FailIfBodyNotMatchesRegexp = failIfBodyNotMatchesRegexp
 	return nil
 }
 

--- a/prober/handler.go
+++ b/prober/handler.go
@@ -21,6 +21,7 @@ import (
 	"net/textproto"
 	"net/url"
 	"strconv"
+	"strings"
 	"time"
 
 	"github.com/go-kit/log"
@@ -103,15 +104,42 @@ func Handler(w http.ResponseWriter, r *http.Request, c *config.Config, logger lo
 		}
 	}
 
-	failIfBodyNotMatchesRegexp := params.Get("fail_if_body_not_matches_regexp")
-	// FailIfBodyNotMatchesRegexp
-	// busk
-	if module.Prober == "http" && failIfBodyNotMatchesRegexp != "" {
+	fail_if_body_not_matches_regexp := params.Get("fail_if_body_not_matches_regexp")
+	if module.Prober == "http" && len(fail_if_body_not_matches_regexp) != 0 {
+		var failIfBodyNotMatchesRegexp []config.Regexp
+		// paramValue := "pattern1,pattern2,pattern3"
+		// patterns := strings.Split(paramValue, ",")
+		patterns := strings.Split(fail_if_body_not_matches_regexp, ",")
+		for _, pattern := range patterns {
+			regexp := config.MustNewRegexp(pattern)
+			failIfBodyNotMatchesRegexp = append(failIfBodyNotMatchesRegexp, regexp)
+		}
+		err = setFailIfBodyNotMatchesRegexp(failIfBodyNotMatchesRegexp, &module)
 		if err != nil {
 			http.Error(w, err.Error(), http.StatusBadRequest)
 			return
 		}
 	}
+	/*
+		// for _, pattern := range fail_if_body_not_matches_regexp {
+		failIfBodyNotMatchesRegexp = params.Get("fail_if_body_not_matches_regexp")
+		for _, pattern := range failIfBodyNotMatchesRegexp {
+			// Convert each string pattern to a config.Regexp type
+			regexp := config.MustNewRegexp(pattern)
+
+			// Append the config.Regexp to the list
+			failIfBodyNotMatchesRegexp = append(failIfBodyNotMatchesRegexp, regexp)
+		}
+	*/
+	// failIfBodyNotMatchesRegexp = params.Get("fail_if_body_not_matches_regexp")
+	// failIfBodyNotMatchesRegexp = ["foo1"]
+	// regexp1 := config.MustNewRegexp("uvoo")
+	// regexp2 := config.MustNewRegexp("Uvoo")
+	// failIfBodyNotMatchesRegexp = append(failIfBodyNotMatchesRegexp, regexp1, regexp2)
+	// failIfBodyNotMatchesRegexp = config.MustNewRegexp("pattern1")
+	// FailIfBodyNotMatchesRegexp
+	// busk
+	// if module.Prober == "http" && failIfBodyNotMatchesRegexp != "" {
 
 	if module.Prober == "tcp" && hostname != "" {
 		if module.TCP.TLSConfig.ServerName == "" {

--- a/run.sh
+++ b/run.sh
@@ -1,4 +1,6 @@
 #!/bin/bash
 set -eu
 
-blackbox_exporter --config.file="blackbox.yml"
+# blackbox_exporter --config.file="blackbox.yml"
+# ./blackbox_exporter_j --config.file="blackbox.yml"
+./blackbox_exporter --config.file="blackbox.yml"

--- a/run.sh
+++ b/run.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+set -eu
+
+blackbox_exporter --config.file="blackbox.yml"


### PR DESCRIPTION
Allows you to pass in a "list" of comma separated items to probe fail_if_body_not_matches_regexp with URL parameter body_matches

I feel this would be very useful option to cut down on having to make a lot of modules to match different regex items. I shortened param name for less characters is URL.

Example:
```
curl -s "http://localhost:9115/probe?target=https://example.com&module=http_2xx&debug=true&body_matches=example,item1,item2"
````