### PR TITLE
Add body_matches & status_codes as target url params

### DIFF
--- a/prober/handler.go
+++ b/prober/handler.go
@@ -107,9 +107,9 @@ func Handler(w http.ResponseWriter, r *http.Request, c *config.Config, logger lo
 	body_matches := params.Get("body_matches")
 	if module.Prober == "http" && len(body_matches) != 0 {
 		var failIfBodyNotMatchesRegexp []config.Regexp
-		patterns := strings.Split(body_matches, ",")
-		for _, pattern := range patterns {
-			regexp := config.MustNewRegexp(pattern)
+		items := strings.Split(body_matches, ",")
+		for _, item := range items {
+			regexp := config.MustNewRegexp(item)
 			failIfBodyNotMatchesRegexp = append(failIfBodyNotMatchesRegexp, regexp)
 		}
 		err = setFailIfBodyNotMatchesRegexp(failIfBodyNotMatchesRegexp, &module)


### PR DESCRIPTION
Adds two new URL passable parameters via "csv list" in target param URL for setting http config values:

- status codes for valid_status_codes
- body_matches for fail_if_body_not_matches_regexp

Allows you to pass in a "list" of comma separated items to probe for  via  status_codes & valid_status_codes via status codes to set config http modules values

- I feel these two parameters are extremely useful to cut down on having to make a lot of custom config modules to match different regex items & status codes. They make the usability of the http probe much easier.
- I shortened the param names for less characters for less typing & reading URL.

Example using curl:
```
curl -s "http://localhost:9115/probe?target=https://example.com&body_matches=example,exam&status_codes=200,401"
````