### PR TITLE
Fix generateCertificate helper function (prober tests)

### DIFF
--- a/prober/utils_test.go
+++ b/prober/utils_test.go
@@ -104,7 +104,7 @@ func generateCertificateTemplate(expiry time.Time, IPAddressSAN bool) *x509.Cert
 }
 
 func generateCertificate(template, parent *x509.Certificate, publickey *rsa.PublicKey, privatekey *rsa.PrivateKey) (*x509.Certificate, []byte) {
-	derCert, err := x509.CreateCertificate(rand.Reader, template, template, publickey, privatekey)
+	derCert, err := x509.CreateCertificate(rand.Reader, template, parent, publickey, privatekey)
 	if err != nil {
 		panic(fmt.Sprintf("Error signing test-certificate: %s", err))
 	}


### PR DESCRIPTION
All certificated created by `generateCertificate()` are self-signed. This PR fixes that by passing the correct argument for `parent`.