### PR TITLE
Support matching JSON body with CEL expressions

### DIFF
--- a/CONFIGURATION.md
+++ b/CONFIGURATION.md
@@ -89,6 +89,12 @@ modules:
   # Probe fails if SSL is not present.
   [ fail_if_not_ssl: <boolean> | default = false ]
 
+  # Probe fails if response body JSON matches CEL:
+  fail_if_body_json_matches_cel: <cel expression, root field is called body>
+
+  # Probe fails if response body JSON does not match CEL:
+  fail_if_body_json_not_matches_cel: <cel expression, root field is called body>
+
   # Probe fails if response body matches regex.
   fail_if_body_matches_regexp:
     [ - <regex>, ... ]

--- a/CONFIGURATION.md
+++ b/CONFIGURATION.md
@@ -89,11 +89,11 @@ modules:
   # Probe fails if SSL is not present.
   [ fail_if_not_ssl: <boolean> | default = false ]
 
-  # Probe fails if response body JSON matches CEL:
-  fail_if_body_json_matches_cel: <cel expression, root field is called body>
+  # Probe fails if response body JSON matches the CEL expression or if response is not JSON. See: https://github.com/google/cel-spec:
+  fail_if_body_json_matches_cel: <string>
 
-  # Probe fails if response body JSON does not match CEL:
-  fail_if_body_json_not_matches_cel: <cel expression, root field is called body>
+  # Probe fails if response body JSON does not match CEL expression or if response is not JSON. See: https://github.com/google/cel-spec:
+  fail_if_body_json_not_matches_cel: <string>
 
   # Probe fails if response body matches regex.
   fail_if_body_matches_regexp:

--- a/config/config.go
+++ b/config/config.go
@@ -173,7 +173,7 @@ func NewCelProgram(s string) (CelProgram, error) {
 		return program, fmt.Errorf("error compiling CEL program: %s", issues.Err())
 	}
 
-	celProg, err := env.Program(ast)
+	celProg, err := env.Program(ast, cel.InterruptCheckFrequency(100))
 	if err != nil {
 		return program, fmt.Errorf("error creating CEL program: %s", err)
 	}

--- a/config/config.go
+++ b/config/config.go
@@ -149,14 +149,14 @@ func (sc *SafeConfig) ReloadConfig(confFile string, logger *slog.Logger) (err er
 // CelProgram encapsulates a cel.Program and makes it YAML marshalable.
 type CelProgram struct {
 	cel.Program
-	expression string
+	Expression string
 }
 
 // NewCelProgram creates a new CEL Program and returns an error if the
 // passed-in CEL expression does not compile.
 func NewCelProgram(s string) (CelProgram, error) {
 	program := CelProgram{
-		expression: s,
+		Expression: s,
 	}
 
 	env, err := cel.NewEnv(
@@ -199,8 +199,8 @@ func (c *CelProgram) UnmarshalYAML(unmarshal func(interface{}) error) error {
 
 // MarshalYAML implements the yaml.Marshaler interface.
 func (c CelProgram) MarshalYAML() (interface{}, error) {
-	if c.expression != "" {
-		return c.expression, nil
+	if c.Expression != "" {
+		return c.Expression, nil
 	}
 	return nil, nil
 }

--- a/config/config.go
+++ b/config/config.go
@@ -159,7 +159,7 @@ func NewCELProgram(s string) (CELProgram, error) {
 	}
 
 	env, err := cel.NewEnv(
-		cel.Variable("body", cel.MapType(cel.StringType, cel.DynType)),
+		cel.Variable("body", cel.DynType),
 	)
 	if err != nil {
 		return program, fmt.Errorf("error creating CEL environment: %s", err)

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -213,3 +213,36 @@ func TestIsEncodingAcceptable(t *testing.T) {
 		})
 	}
 }
+
+func TestNewCELProgram(t *testing.T) {
+	tests := []struct {
+		name    string
+		expr    string
+		wantErr bool
+	}{
+		{
+			name:    "valid expression",
+			expr:    "body.foo == 'bar'",
+			wantErr: false,
+		},
+		{
+			name:    "invalid expression",
+			expr:    "foo.bar",
+			wantErr: true,
+		},
+		{
+			name:    "empty expression",
+			expr:    "",
+			wantErr: true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			_, err := NewCELProgram(tt.expr)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("NewCELProgram() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+		})
+	}
+}

--- a/example.yml
+++ b/example.yml
@@ -69,7 +69,7 @@ modules:
     timeout: 5s
     http:
       method: GET
-      fail_if_body_not_matches_cel: "body.foo == 'bar' && body.baz.startsWith('q')" # { 'foo': 'bar', 'baz': 'qux' }
+      fail_if_body_json_not_matches_cel: "body.foo == 'bar' && body.baz.startsWith('q')" # { "foo": "bar", "baz": "qux" }
   http_2xx_oauth_client_credentials:
     prober: http
     timeout: 5s

--- a/example.yml
+++ b/example.yml
@@ -64,6 +64,12 @@ modules:
       basic_auth:
         username: "username"
         password: "mysecret"
+  http_json_cel_match:
+    prober: http
+    timeout: 5s
+    http:
+      method: GET
+      fail_if_body_not_matches_cel: "body.foo == 'bar' && body.baz.startsWith('q')" # { 'foo': 'bar', 'baz': 'qux' }
   http_2xx_oauth_client_credentials:
     prober: http
     timeout: 5s

--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,7 @@ require (
 	github.com/alecthomas/kingpin/v2 v2.4.0
 	github.com/alecthomas/units v0.0.0-20231202071711-9a357b53e9c9
 	github.com/andybalholm/brotli v1.1.1
-	github.com/google/cel-go v0.20.1
+	github.com/google/cel-go v0.24.0
 	github.com/miekg/dns v1.1.63
 	github.com/prometheus/client_golang v1.20.5
 	github.com/prometheus/client_model v0.6.1
@@ -19,6 +19,7 @@ require (
 )
 
 require (
+	cel.dev/expr v0.19.1 // indirect
 	github.com/antlr4-go/antlr/v4 v4.13.1 // indirect
 	github.com/beorn7/perks v1.0.1 // indirect
 	github.com/cespare/xxhash/v2 v2.3.0 // indirect

--- a/go.mod
+++ b/go.mod
@@ -6,6 +6,7 @@ require (
 	github.com/alecthomas/kingpin/v2 v2.4.0
 	github.com/alecthomas/units v0.0.0-20231202071711-9a357b53e9c9
 	github.com/andybalholm/brotli v1.1.1
+	github.com/google/cel-go v0.20.1
 	github.com/miekg/dns v1.1.63
 	github.com/prometheus/client_golang v1.20.5
 	github.com/prometheus/client_model v0.6.1
@@ -18,6 +19,7 @@ require (
 )
 
 require (
+	github.com/antlr4-go/antlr/v4 v4.13.1 // indirect
 	github.com/beorn7/perks v1.0.1 // indirect
 	github.com/cespare/xxhash/v2 v2.3.0 // indirect
 	github.com/coreos/go-systemd/v22 v22.5.0 // indirect
@@ -28,14 +30,17 @@ require (
 	github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822 // indirect
 	github.com/mwitkow/go-conntrack v0.0.0-20190716064945-2f068394615f // indirect
 	github.com/prometheus/procfs v0.15.1 // indirect
+	github.com/stoewer/go-strcase v1.2.0 // indirect
 	github.com/xhit/go-str2duration/v2 v2.1.0 // indirect
 	golang.org/x/crypto v0.33.0 // indirect
+	golang.org/x/exp v0.0.0-20240506185415-9bf2ced13842 // indirect
 	golang.org/x/mod v0.18.0 // indirect
 	golang.org/x/oauth2 v0.24.0 // indirect
 	golang.org/x/sync v0.11.0 // indirect
 	golang.org/x/sys v0.30.0 // indirect
 	golang.org/x/text v0.22.0 // indirect
 	golang.org/x/tools v0.22.0 // indirect
+	google.golang.org/genproto/googleapis/api v0.0.0-20241202173237-19429a94021a // indirect
 	google.golang.org/genproto/googleapis/rpc v0.0.0-20241202173237-19429a94021a // indirect
 	google.golang.org/protobuf v1.36.1 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -4,6 +4,8 @@ github.com/alecthomas/units v0.0.0-20231202071711-9a357b53e9c9 h1:ez/4by2iGztzR4
 github.com/alecthomas/units v0.0.0-20231202071711-9a357b53e9c9/go.mod h1:OMCwj8VM1Kc9e19TLln2VL61YJF0x1XFtfdL4JdbSyE=
 github.com/andybalholm/brotli v1.1.1 h1:PR2pgnyFznKEugtsUo0xLdDop5SKXd5Qf5ysW+7XdTA=
 github.com/andybalholm/brotli v1.1.1/go.mod h1:05ib4cKhjx3OQYUY22hTVd34Bc8upXjOLL2rKwwZBoA=
+github.com/antlr4-go/antlr/v4 v4.13.1 h1:SqQKkuVZ+zWkMMNkjy5FZe5mr5WURWnlpmOuzYWrPrQ=
+github.com/antlr4-go/antlr/v4 v4.13.1/go.mod h1:GKmUxMtwp6ZgGwZSva4eWPC5mS6vUAmOABFgjdkM7Nw=
 github.com/beorn7/perks v1.0.1 h1:VlbKKnNfV8bJzeqoa4cOKqO6bYr3WgKZxO8Z16+hsOM=
 github.com/beorn7/perks v1.0.1/go.mod h1:G2ZrVWU2WbWT9wwq4/hrbKbnv/1ERSJQ0ibhJ6rlkpw=
 github.com/cespare/xxhash/v2 v2.3.0 h1:UL815xU9SqsFlibzuggzjXhog7bL6oX9BbNZnL2UFvs=
@@ -20,6 +22,8 @@ github.com/go-logr/stdr v1.2.2/go.mod h1:mMo/vtBO5dYbehREoey6XUKy/eSumjCCveDpRre
 github.com/godbus/dbus/v5 v5.0.4/go.mod h1:xhWf0FNVPg57R7Z0UbKHbJfkEywrmjJnf7w5xrFpKfA=
 github.com/golang/protobuf v1.5.4 h1:i7eJL8qZTpSEXOPTxNKhASYpMn+8e5Q6AdndVa1dWek=
 github.com/golang/protobuf v1.5.4/go.mod h1:lnTiLA8Wa4RWRcIUkrtSVa5nRhsEGBg48fD6rSs7xps=
+github.com/google/cel-go v0.20.1 h1:nDx9r8S3L4pE61eDdt8igGj8rf5kjYR3ILxWIpWNi84=
+github.com/google/cel-go v0.20.1/go.mod h1:kWcIzTsPX0zmQ+H3TirHstLLf9ep5QTsZBN9u4dOYLg=
 github.com/google/go-cmp v0.6.0 h1:ofyhxvXcZhMsU5ulbFiLKl/XBFqE1GSq7atu8tAmTRI=
 github.com/google/go-cmp v0.6.0/go.mod h1:17dUlkBOakJ0+DkrSSNjCkIjxS6bF9zb3elmeNGIjoY=
 github.com/google/uuid v1.6.0 h1:NIvaJDMOsjHA8n1jAhLSgzrAzy1Hgr+hNrb57e+94F0=
@@ -58,8 +62,11 @@ github.com/prometheus/procfs v0.15.1 h1:YagwOFzUgYfKKHX6Dr+sHT7km/hxC76UB0leargg
 github.com/prometheus/procfs v0.15.1/go.mod h1:fB45yRUv8NstnjriLhBQLuOUt+WW4BsoGhij/e3PBqk=
 github.com/rogpeppe/go-internal v1.10.0 h1:TMyTOH3F/DB16zRVcYyreMH6GnZZrwQVAoYjRBZyWFQ=
 github.com/rogpeppe/go-internal v1.10.0/go.mod h1:UQnix2H7Ngw/k4C5ijL5+65zddjncjaFoBhdsK/akog=
+github.com/stoewer/go-strcase v1.2.0 h1:Z2iHWqGXH00XYgqDmNgQbIBxf3wrNq0F3feEy0ainaU=
+github.com/stoewer/go-strcase v1.2.0/go.mod h1:IBiWB2sKIp3wVVQ3Y035++gc+knqhUQag1KpM8ahLw8=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/testify v1.4.0/go.mod h1:j7eGeouHqKxXV5pUuKE4zz7dFj8WfuZ+81PSLYec5m4=
+github.com/stretchr/testify v1.5.1/go.mod h1:5W2xD1RspED5o8YsWQXVCued0rvSQ+mT+I5cxcmMvtA=
 github.com/stretchr/testify v1.10.0 h1:Xv5erBjTwe/5IxqUQTdXv5kgmIvbHo3QQyRwhJsOfJA=
 github.com/stretchr/testify v1.10.0/go.mod h1:r2ic/lqez/lEtzL7wO/rwa5dbSLXVDPFyf8C91i36aY=
 github.com/xhit/go-str2duration/v2 v2.1.0 h1:lxklc02Drh6ynqX+DdPyp5pCKLUQpRT8bp8Ydu2Bstc=
@@ -78,6 +85,8 @@ go.opentelemetry.io/otel/trace v1.32.0 h1:WIC9mYrXf8TmY/EXuULKc8hR17vE+Hjv2cssQD
 go.opentelemetry.io/otel/trace v1.32.0/go.mod h1:+i4rkvCraA+tG6AzwloGaCtkx53Fa+L+V8e9a7YvhT8=
 golang.org/x/crypto v0.33.0 h1:IOBPskki6Lysi0lo9qQvbxiQ+FvsCC/YWOecCHAixus=
 golang.org/x/crypto v0.33.0/go.mod h1:bVdXmD7IV/4GdElGPozy6U7lWdRXA4qyRVGJV57uQ5M=
+golang.org/x/exp v0.0.0-20240506185415-9bf2ced13842 h1:vr/HnozRka3pE4EsMEg1lgkXJkTFJCVUX+S/ZT6wYzM=
+golang.org/x/exp v0.0.0-20240506185415-9bf2ced13842/go.mod h1:XtvwrStGgqGPLc4cjQfWqZHG1YFdYs6swckp8vpsjnc=
 golang.org/x/mod v0.18.0 h1:5+9lSbEzPSdWkH32vYPBwEpX8KwDbM52Ud9xBUvNlb0=
 golang.org/x/mod v0.18.0/go.mod h1:hTbmBsO62+eylJbnUtE2MGJUyE7QWk4xUqPFrRgJ+7c=
 golang.org/x/net v0.35.0 h1:T5GQRQb2y08kTAByq9L4/bz8cipCdA8FbRTXewonqY8=
@@ -92,6 +101,8 @@ golang.org/x/text v0.22.0 h1:bofq7m3/HAFvbF51jz3Q9wLg3jkvSPuiZu/pD1XwgtM=
 golang.org/x/text v0.22.0/go.mod h1:YRoo4H8PVmsu+E3Ou7cqLVH8oXWIHVoX0jqUWALQhfY=
 golang.org/x/tools v0.22.0 h1:gqSGLZqv+AI9lIQzniJ0nZDRG5GBPsSi+DRNHWNz6yA=
 golang.org/x/tools v0.22.0/go.mod h1:aCwcsjqvq7Yqt6TNyX7QMU2enbQ/Gt0bo6krSeEri+c=
+google.golang.org/genproto/googleapis/api v0.0.0-20241202173237-19429a94021a h1:OAiGFfOiA0v9MRYsSidp3ubZaBnteRUyn3xB2ZQ5G/E=
+google.golang.org/genproto/googleapis/api v0.0.0-20241202173237-19429a94021a/go.mod h1:jehYqy3+AhJU9ve55aNOaSml7wUXjF9x6z2LcCfpAhY=
 google.golang.org/genproto/googleapis/rpc v0.0.0-20241202173237-19429a94021a h1:hgh8P4EuoxpsuKMXX/To36nOFD7vixReXgn8lPGnt+o=
 google.golang.org/genproto/googleapis/rpc v0.0.0-20241202173237-19429a94021a/go.mod h1:5uTbfoYQed2U9p3KIj2/Zzm02PYhndfdmML0qC3q3FU=
 google.golang.org/grpc v1.70.0 h1:pWFv03aZoHzlRKHWicjsZytKAiYCtNS0dHbXnIdq7jQ=

--- a/go.sum
+++ b/go.sum
@@ -1,3 +1,5 @@
+cel.dev/expr v0.19.1 h1:NciYrtDRIR0lNCnH1LFJegdjspNx9fI59O7TWcua/W4=
+cel.dev/expr v0.19.1/go.mod h1:MrpN08Q+lEBs+bGYdLxxHkZoUSsCp0nSKTs0nTymJgw=
 github.com/alecthomas/kingpin/v2 v2.4.0 h1:f48lwail6p8zpO1bC4TxtqACaGqHYA22qkHjHpqDjYY=
 github.com/alecthomas/kingpin/v2 v2.4.0/go.mod h1:0gyi0zQnjuFk8xrkNKamJoyUo382HRL7ATRpFZCw6tE=
 github.com/alecthomas/units v0.0.0-20231202071711-9a357b53e9c9 h1:ez/4by2iGztzR4L0zgAOR8lTQK9VlyBVVd7G4omaOQs=
@@ -22,8 +24,8 @@ github.com/go-logr/stdr v1.2.2/go.mod h1:mMo/vtBO5dYbehREoey6XUKy/eSumjCCveDpRre
 github.com/godbus/dbus/v5 v5.0.4/go.mod h1:xhWf0FNVPg57R7Z0UbKHbJfkEywrmjJnf7w5xrFpKfA=
 github.com/golang/protobuf v1.5.4 h1:i7eJL8qZTpSEXOPTxNKhASYpMn+8e5Q6AdndVa1dWek=
 github.com/golang/protobuf v1.5.4/go.mod h1:lnTiLA8Wa4RWRcIUkrtSVa5nRhsEGBg48fD6rSs7xps=
-github.com/google/cel-go v0.20.1 h1:nDx9r8S3L4pE61eDdt8igGj8rf5kjYR3ILxWIpWNi84=
-github.com/google/cel-go v0.20.1/go.mod h1:kWcIzTsPX0zmQ+H3TirHstLLf9ep5QTsZBN9u4dOYLg=
+github.com/google/cel-go v0.24.0 h1:2K5N+wjlzhvmznGd31j4gHE3XYQhW4CES8rgcgGEzAA=
+github.com/google/cel-go v0.24.0/go.mod h1:Hdf9TqOaTNSFQA1ybQaRqATVoK7m/zcf7IMhGXP5zI8=
 github.com/google/go-cmp v0.6.0 h1:ofyhxvXcZhMsU5ulbFiLKl/XBFqE1GSq7atu8tAmTRI=
 github.com/google/go-cmp v0.6.0/go.mod h1:17dUlkBOakJ0+DkrSSNjCkIjxS6bF9zb3elmeNGIjoY=
 github.com/google/uuid v1.6.0 h1:NIvaJDMOsjHA8n1jAhLSgzrAzy1Hgr+hNrb57e+94F0=

--- a/prober/http.go
+++ b/prober/http.go
@@ -66,16 +66,16 @@ func matchRegularExpressions(reader io.Reader, httpConfig config.HTTPProbe, logg
 	return true
 }
 
-func matchCelExpressions(reader io.Reader, httpConfig config.HTTPProbe, logger *slog.Logger) bool {
+func matchCelExpressions(ctx context.Context, reader io.Reader, httpConfig config.HTTPProbe, logger *slog.Logger) bool {
 	body, err := io.ReadAll(reader)
 	if err != nil {
-		logger.Error("msg", "Error reading HTTP body", "err", err)
+		logger.Error("Error reading HTTP body", "err", err)
 		return false
 	}
 
 	bodyJSON := make(map[string]interface{})
 	if err := json.Unmarshal(body, &bodyJSON); err != nil {
-		logger.Error("msg", "Error unmarshalling HTTP body", "err", err)
+		logger.Error("Error unmarshalling HTTP body", "err", err)
 		return false
 	}
 
@@ -86,15 +86,15 @@ func matchCelExpressions(reader io.Reader, httpConfig config.HTTPProbe, logger *
 	if httpConfig.FailIfBodyJSONMatchesCel != nil {
 		result, details, err := httpConfig.FailIfBodyJSONMatchesCel.ContextEval(ctx, evalPayload)
 		if err != nil {
-			logger.Error("msg", "Error evaluating CEL expression", "err", err)
+			logger.Error("Error evaluating CEL expression", "err", err)
 			return false
 		}
 		if result.Type() != cel.BoolType {
-			logger.Error("msg", "CEL evaluation result is not a boolean", "details", details)
+			logger.Error("CEL evaluation result is not a boolean", "details", details)
 			return false
 		}
 		if result.Type() == cel.BoolType && result.Value().(bool) {
-			logger.Error("msg", "Body matched CEL expression", "expression", httpConfig.FailIfBodyJSONMatchesCel)
+			logger.Error("Body matched CEL expression", "expression", httpConfig.FailIfBodyJSONMatchesCel.Expression)
 			return false
 		}
 	}
@@ -102,15 +102,15 @@ func matchCelExpressions(reader io.Reader, httpConfig config.HTTPProbe, logger *
 	if httpConfig.FailIfBodyJSONNotMatchesCel != nil {
 		result, details, err := httpConfig.FailIfBodyJSONNotMatchesCel.ContextEval(ctx, evalPayload)
 		if err != nil {
-			logger.Error("msg", "Error evaluating CEL expression", "err", err)
+			logger.Error("Error evaluating CEL expression", "err", err)
 			return false
 		}
 		if result.Type() != cel.BoolType {
-			logger.Error("msg", "CEL evaluation result is not a boolean", "details", details)
+			logger.Error("CEL evaluation result is not a boolean", "details", details)
 			return false
 		}
 		if result.Type() == cel.BoolType && !result.Value().(bool) {
-			logger.Error("msg", "Body did not match CEL expression", "expression", httpConfig.FailIfBodyJSONNotMatchesCel)
+			logger.Error("Body did not match CEL expression", "expression", httpConfig.FailIfBodyJSONNotMatchesCel.Expression)
 			return false
 		}
 	}

--- a/prober/http.go
+++ b/prober/http.go
@@ -84,7 +84,7 @@ func matchCelExpressions(reader io.Reader, httpConfig config.HTTPProbe, logger *
 	}
 
 	if httpConfig.FailIfBodyJSONMatchesCel != nil {
-		result, details, err := httpConfig.FailIfBodyJSONMatchesCel.Eval(evalPayload)
+		result, details, err := httpConfig.FailIfBodyJSONMatchesCel.ContextEval(ctx, evalPayload)
 		if err != nil {
 			logger.Error("msg", "Error evaluating CEL expression", "err", err)
 			return false
@@ -100,7 +100,7 @@ func matchCelExpressions(reader io.Reader, httpConfig config.HTTPProbe, logger *
 	}
 
 	if httpConfig.FailIfBodyJSONNotMatchesCel != nil {
-		result, details, err := httpConfig.FailIfBodyJSONNotMatchesCel.Eval(evalPayload)
+		result, details, err := httpConfig.FailIfBodyJSONNotMatchesCel.ContextEval(ctx, evalPayload)
 		if err != nil {
 			logger.Error("msg", "Error evaluating CEL expression", "err", err)
 			return false
@@ -608,7 +608,7 @@ func ProbeHTTP(ctx context.Context, target string, module config.Module, registr
 		}
 
 		if success && (httpConfig.FailIfBodyJSONMatchesCel != nil || httpConfig.FailIfBodyJSONNotMatchesCel != nil) {
-			success = matchCelExpressions(byteCounter, httpConfig, logger)
+			success = matchCelExpressions(ctx, byteCounter, httpConfig, logger)
 			if success {
 				probeFailedDueToCel.Set(0)
 			} else {

--- a/prober/http.go
+++ b/prober/http.go
@@ -75,7 +75,7 @@ func matchCelExpressions(ctx context.Context, reader io.Reader, httpConfig confi
 
 	bodyJSON := make(map[string]interface{})
 	if err := json.Unmarshal(body, &bodyJSON); err != nil {
-		logger.Error("Error unmarshalling HTTP body", "err", err)
+		logger.Error("Error unmarshalling HTTP body to JSON", "err", err)
 		return false
 	}
 

--- a/prober/http.go
+++ b/prober/http.go
@@ -369,9 +369,12 @@ func ProbeHTTP(ctx context.Context, target string, module config.Module, registr
 	registry.MustRegister(statusCodeGauge)
 	registry.MustRegister(probeHTTPVersionGauge)
 	registry.MustRegister(probeFailedDueToRegex)
-	registry.MustRegister(probeFailedDueToCel)
 
 	httpConfig := module.HTTP
+
+	if httpConfig.FailIfBodyJSONMatchesCel != nil || httpConfig.FailIfBodyJSONNotMatchesCel != nil {
+		registry.MustRegister(probeFailedDueToCel)
+	}
 
 	if !strings.HasPrefix(target, "http://") && !strings.HasPrefix(target, "https://") {
 		target = "http://" + target

--- a/prober/http_test.go
+++ b/prober/http_test.go
@@ -980,7 +980,7 @@ func TestFailIfBodyMatchesCel(t *testing.T) {
 			registry := prometheus.NewRegistry()
 			testCTX, cancel := context.WithTimeout(context.Background(), 10*time.Second)
 			defer cancel()
-			result := ProbeHTTP(testCTX, ts.URL, config.Module{Timeout: time.Second, HTTP: config.HTTPProbe{IPProtocolFallback: true, FailIfBodyJSONMatchesCel: &testcase.cel}}, registry, log.NewNopLogger())
+			result := ProbeHTTP(testCTX, ts.URL, config.Module{Timeout: time.Second, HTTP: config.HTTPProbe{IPProtocolFallback: true, FailIfBodyJSONMatchesCel: &testcase.cel}}, registry, promslog.NewNopLogger())
 			if testcase.expectedResult && !result {
 				t.Fatalf("CEL test failed unexpectedly, got %s", recorder.Body.String())
 			} else if !testcase.expectedResult && result {
@@ -1050,7 +1050,7 @@ func TestFailIfBodyNotMatchesCel(t *testing.T) {
 			registry := prometheus.NewRegistry()
 			testCTX, cancel := context.WithTimeout(context.Background(), 10*time.Second)
 			defer cancel()
-			result := ProbeHTTP(testCTX, ts.URL, config.Module{Timeout: time.Second, HTTP: config.HTTPProbe{IPProtocolFallback: true, FailIfBodyJSONNotMatchesCel: &testcase.cel}}, registry, log.NewNopLogger())
+			result := ProbeHTTP(testCTX, ts.URL, config.Module{Timeout: time.Second, HTTP: config.HTTPProbe{IPProtocolFallback: true, FailIfBodyJSONNotMatchesCel: &testcase.cel}}, registry, promslog.NewNopLogger())
 			if testcase.expectedResult && !result {
 				t.Fatalf("CEL test failed unexpectedly, got %s", recorder.Body.String())
 			} else if !testcase.expectedResult && result {

--- a/prober/http_test.go
+++ b/prober/http_test.go
@@ -967,9 +967,24 @@ func TestFailIfBodyMatchesCEL(t *testing.T) {
 			celExpression:  "body.foo.bar == 'baz'",
 			expectedResult: false,
 		},
-		"body is empty json": {
+		"body is empty json object": {
 			respBody:       "{}",
 			celExpression:  "body.foo.bar == 'baz'",
+			expectedResult: false,
+		},
+		"body is json string": {
+			respBody:       `"foo"`,
+			celExpression:  "body == 'foo'",
+			expectedResult: false,
+		},
+		"body is json list": {
+			respBody:       `["foo","bar","baz"]`,
+			celExpression:  "body[2] == 'baz'",
+			expectedResult: false,
+		},
+		"body is json boolean": {
+			respBody:       `true`,
+			celExpression:  "body",
 			expectedResult: false,
 		},
 		"body is empty": {
@@ -1059,9 +1074,24 @@ func TestFailIfBodyNotMatchesCEL(t *testing.T) {
 			celExpression:  "body.foo.bar == 'baz'",
 			expectedResult: false,
 		},
-		"body is empty json": {
+		"body is empty json object": {
 			respBody:       "{}",
 			celExpression:  "!has(body.foo)",
+			expectedResult: true,
+		},
+		"body is json string": {
+			respBody:       `"foo"`,
+			celExpression:  "body == 'foo'",
+			expectedResult: true,
+		},
+		"body is json list": {
+			respBody:       `["foo","bar","baz"]`,
+			celExpression:  "body[2] == 'baz'",
+			expectedResult: true,
+		},
+		"body is json boolean": {
+			respBody:       `true`,
+			celExpression:  "body",
 			expectedResult: true,
 		},
 		"body is empty": {


### PR DESCRIPTION
This PR implements parsing a JSON response from the body and checking the result using a CEL query. Looking for feedback on this.

Sample usage:

```
modules:
  http_2xx:
    prober: http
    http:
      fail_if_body_json_not_matches_cel: "body.foo.bar == 'baz'"
```

If response is `{"foo": { "bar": "qux" } }` the probe fails. fail_if_body_json_matches_cel is also implemented and should work as expected.