### PR TITLE
pass params as a struct to ProbeFn

### DIFF
--- a/prober/dns.go
+++ b/prober/dns.go
@@ -124,7 +124,7 @@ func validRcode(rcode int, valid []string, logger log.Logger) bool {
 	return false
 }
 
-func ProbeDNS(ctx context.Context, target string, module config.Module, registry *prometheus.Registry, logger log.Logger) bool {
+func ProbeDNS(ctx context.Context, opts probeOpts, module config.Module, registry *prometheus.Registry, logger log.Logger) bool {
 	var dialProtocol string
 	probeDNSDurationGaugeVec := prometheus.NewGaugeVec(prometheus.GaugeOpts{
 		Name: "probe_dns_duration_seconds",
@@ -187,7 +187,7 @@ func ProbeDNS(ctx context.Context, target string, module config.Module, registry
 		return false
 	}
 
-	targetAddr, port, err := net.SplitHostPort(target)
+	targetAddr, port, err := net.SplitHostPort(opts.target)
 	if err != nil {
 		// Target only contains host so fallback to default port and set targetAddr as target.
 		if module.DNS.DNSOverTLS {
@@ -195,7 +195,7 @@ func ProbeDNS(ctx context.Context, target string, module config.Module, registry
 		} else {
 			port = "53"
 		}
-		targetAddr = target
+		targetAddr = opts.target
 	}
 	ip, lookupTime, err := chooseProtocol(ctx, module.DNS.IPProtocol, module.DNS.IPProtocolFallback, targetAddr, registry, logger)
 	if err != nil {

--- a/prober/dns_test.go
+++ b/prober/dns_test.go
@@ -170,7 +170,7 @@ func TestRecursiveDNSResponse(t *testing.T) {
 
 			testCTX, cancel := context.WithTimeout(context.Background(), 10*time.Second)
 			defer cancel()
-			result := ProbeDNS(testCTX, addr.String(), config.Module{Timeout: time.Second, DNS: test.Probe}, registry, log.NewNopLogger())
+			result := ProbeDNS(testCTX, probeOpts{target: addr.String()}, config.Module{Timeout: time.Second, DNS: test.Probe}, registry, log.NewNopLogger())
 			if result != test.ShouldSucceed {
 				t.Fatalf("Test %d had unexpected result: %v", i, result)
 			}
@@ -374,7 +374,7 @@ func TestAuthoritativeDNSResponse(t *testing.T) {
 			registry := prometheus.NewRegistry()
 			testCTX, cancel := context.WithTimeout(context.Background(), 10*time.Second)
 			defer cancel()
-			result := ProbeDNS(testCTX, addr.String(), config.Module{Timeout: time.Second, DNS: test.Probe}, registry, log.NewNopLogger())
+			result := ProbeDNS(testCTX, probeOpts{target: addr.String()}, config.Module{Timeout: time.Second, DNS: test.Probe}, registry, log.NewNopLogger())
 			if result != test.ShouldSucceed {
 				t.Fatalf("Test %d had unexpected result: %v", i, result)
 			}
@@ -449,7 +449,7 @@ func TestServfailDNSResponse(t *testing.T) {
 			registry := prometheus.NewRegistry()
 			testCTX, cancel := context.WithTimeout(context.Background(), 10*time.Second)
 			defer cancel()
-			result := ProbeDNS(testCTX, addr.String(), config.Module{Timeout: time.Second, DNS: test.Probe}, registry, log.NewNopLogger())
+			result := ProbeDNS(testCTX, probeOpts{target: addr.String()}, config.Module{Timeout: time.Second, DNS: test.Probe}, registry, log.NewNopLogger())
 			if result != test.ShouldSucceed {
 				t.Fatalf("Test %d had unexpected result: %v", i, result)
 			}
@@ -509,7 +509,7 @@ func TestDNSProtocol(t *testing.T) {
 		registry := prometheus.NewRegistry()
 		testCTX, cancel := context.WithTimeout(context.Background(), 10*time.Second)
 		defer cancel()
-		result := ProbeDNS(testCTX, net.JoinHostPort("localhost", port), module, registry, log.NewNopLogger())
+		result := ProbeDNS(testCTX, probeOpts{target: net.JoinHostPort("localhost", port)}, module, registry, log.NewNopLogger())
 		if !result {
 			t.Fatalf("DNS protocol: \"%v\", preferred \"ip6\" connection test failed, expected success.", protocol)
 		}
@@ -535,7 +535,7 @@ func TestDNSProtocol(t *testing.T) {
 		registry = prometheus.NewRegistry()
 		testCTX, cancel = context.WithTimeout(context.Background(), 10*time.Second)
 		defer cancel()
-		result = ProbeDNS(testCTX, net.JoinHostPort("localhost", port), module, registry, log.NewNopLogger())
+		result = ProbeDNS(testCTX, probeOpts{target: net.JoinHostPort("localhost", port)}, module, registry, log.NewNopLogger())
 		if !result {
 			t.Fatalf("DNS protocol: \"%v\", preferred \"ip4\" connection test failed, expected success.", protocol)
 		}
@@ -561,7 +561,7 @@ func TestDNSProtocol(t *testing.T) {
 		registry = prometheus.NewRegistry()
 		testCTX, cancel = context.WithTimeout(context.Background(), 10*time.Second)
 		defer cancel()
-		result = ProbeDNS(testCTX, net.JoinHostPort("localhost", port), module, registry, log.NewNopLogger())
+		result = ProbeDNS(testCTX, probeOpts{target: net.JoinHostPort("localhost", port)}, module, registry, log.NewNopLogger())
 		if !result {
 			t.Fatalf("DNS protocol: \"%v\" connection test failed, expected success.", protocol)
 		}
@@ -586,7 +586,7 @@ func TestDNSProtocol(t *testing.T) {
 		registry = prometheus.NewRegistry()
 		testCTX, cancel = context.WithTimeout(context.Background(), 10*time.Second)
 		defer cancel()
-		result = ProbeDNS(testCTX, net.JoinHostPort("localhost", port), module, registry, log.NewNopLogger())
+		result = ProbeDNS(testCTX, probeOpts{target: net.JoinHostPort("localhost", port)}, module, registry, log.NewNopLogger())
 		if protocol == "udp" {
 			if !result {
 				t.Fatalf("DNS test connection with protocol %s failed, expected success.", protocol)
@@ -629,7 +629,7 @@ func TestDNSMetrics(t *testing.T) {
 	registry := prometheus.NewRegistry()
 	testCTX, cancel := context.WithTimeout(context.Background(), 10*time.Second)
 	defer cancel()
-	result := ProbeDNS(testCTX, net.JoinHostPort("localhost", port), module, registry, log.NewNopLogger())
+	result := ProbeDNS(testCTX, probeOpts{target: net.JoinHostPort("localhost", port)}, module, registry, log.NewNopLogger())
 	if !result {
 		t.Fatalf("DNS test connection failed, expected success.")
 	}

--- a/prober/grpc_test.go
+++ b/prober/grpc_test.go
@@ -63,7 +63,7 @@ func TestGRPCConnection(t *testing.T) {
 	defer cancel()
 	registry := prometheus.NewRegistry()
 
-	result := ProbeGRPC(testCTX, "localhost:"+port,
+	result := ProbeGRPC(testCTX, probeOpts{target: "localhost:" + port},
 		config.Module{Timeout: time.Second, GRPC: config.GRPCProbe{
 			IPProtocolFallback: false,
 		},
@@ -129,7 +129,7 @@ func TestMultipleGRPCservices(t *testing.T) {
 	defer cancel()
 	registryService1 := prometheus.NewRegistry()
 
-	resultService1 := ProbeGRPC(testCTX, "localhost:"+port,
+	resultService1 := ProbeGRPC(testCTX, probeOpts{target: "localhost:" + port},
 		config.Module{Timeout: time.Second, GRPC: config.GRPCProbe{
 			IPProtocolFallback: false,
 			Service:            "service1",
@@ -141,7 +141,7 @@ func TestMultipleGRPCservices(t *testing.T) {
 	}
 
 	registryService2 := prometheus.NewRegistry()
-	resultService2 := ProbeGRPC(testCTX, "localhost:"+port,
+	resultService2 := ProbeGRPC(testCTX, probeOpts{target: "localhost:" + port},
 		config.Module{Timeout: time.Second, GRPC: config.GRPCProbe{
 			IPProtocolFallback: false,
 			Service:            "service2",
@@ -153,7 +153,7 @@ func TestMultipleGRPCservices(t *testing.T) {
 	}
 
 	registryService3 := prometheus.NewRegistry()
-	resultService3 := ProbeGRPC(testCTX, "localhost:"+port,
+	resultService3 := ProbeGRPC(testCTX, probeOpts{target: "localhost:" + port},
 		config.Module{Timeout: time.Second, GRPC: config.GRPCProbe{
 			IPProtocolFallback: false,
 			Service:            "service3",
@@ -225,7 +225,7 @@ func TestGRPCTLSConnection(t *testing.T) {
 	defer cancel()
 	registry := prometheus.NewRegistry()
 
-	result := ProbeGRPC(testCTX, "localhost:"+port,
+	result := ProbeGRPC(testCTX, probeOpts{target: "localhost:" + port},
 		config.Module{Timeout: time.Second, GRPC: config.GRPCProbe{
 			TLS:                true,
 			TLSConfig:          pconfig.TLSConfig{InsecureSkipVerify: true},
@@ -286,7 +286,7 @@ func TestNoTLSConnection(t *testing.T) {
 	defer cancel()
 	registry := prometheus.NewRegistry()
 
-	result := ProbeGRPC(testCTX, "localhost:"+port,
+	result := ProbeGRPC(testCTX, probeOpts{target: "localhost:" + port},
 		config.Module{Timeout: time.Second, GRPC: config.GRPCProbe{
 			TLS:                true,
 			TLSConfig:          pconfig.TLSConfig{InsecureSkipVerify: true},
@@ -341,7 +341,7 @@ func TestGRPCServiceNotFound(t *testing.T) {
 	defer cancel()
 	registry := prometheus.NewRegistry()
 
-	result := ProbeGRPC(testCTX, "localhost:"+port,
+	result := ProbeGRPC(testCTX, probeOpts{target: "localhost:" + port},
 		config.Module{Timeout: time.Second, GRPC: config.GRPCProbe{
 			IPProtocolFallback: false,
 			Service:            "NonExistingService",
@@ -391,7 +391,7 @@ func TestGRPCHealthCheckUnimplemented(t *testing.T) {
 	defer cancel()
 	registry := prometheus.NewRegistry()
 
-	result := ProbeGRPC(testCTX, "localhost:"+port,
+	result := ProbeGRPC(testCTX, probeOpts{target: "localhost:" + port},
 		config.Module{Timeout: time.Second, GRPC: config.GRPCProbe{
 			IPProtocolFallback: false,
 			Service:            "NonExistingService",

--- a/prober/handler.go
+++ b/prober/handler.go
@@ -116,7 +116,9 @@ func Handler(w http.ResponseWriter, r *http.Request, c *config.Config, logger lo
 	registry := prometheus.NewRegistry()
 	registry.MustRegister(probeSuccessGauge)
 	registry.MustRegister(probeDurationGauge)
-	success := prober(ctx, target, module, registry, sl)
+	success := prober(ctx,
+		probeOpts{target: target, sourceIPAddress: params.Get("sourceIPAddress")},
+		module, registry, sl)
 	duration := time.Since(start).Seconds()
 	probeDurationGauge.Set(duration)
 	if success {

--- a/prober/http.go
+++ b/prober/http.go
@@ -235,7 +235,7 @@ func (bc *byteCounter) Read(p []byte) (int, error) {
 
 var userAgentDefaultHeader = fmt.Sprintf("Blackbox Exporter/%s", version.Version)
 
-func ProbeHTTP(ctx context.Context, target string, module config.Module, registry *prometheus.Registry, logger log.Logger) (success bool) {
+func ProbeHTTP(ctx context.Context, opts probeOpts, module config.Module, registry *prometheus.Registry, logger log.Logger) (success bool) {
 	var redirects int
 	var (
 		durationGaugeVec = prometheus.NewGaugeVec(prometheus.GaugeOpts{
@@ -314,11 +314,11 @@ func ProbeHTTP(ctx context.Context, target string, module config.Module, registr
 
 	httpConfig := module.HTTP
 
-	if !strings.HasPrefix(target, "http://") && !strings.HasPrefix(target, "https://") {
-		target = "http://" + target
+	if !strings.HasPrefix(opts.target, "http://") && !strings.HasPrefix(opts.target, "https://") {
+		opts.target = "http://" + opts.target
 	}
 
-	targetURL, err := url.Parse(target)
+	targetURL, err := url.Parse(opts.target)
 	if err != nil {
 		level.Error(logger).Log("msg", "Could not parse target URL", "err", err)
 		return false

--- a/prober/http_test.go
+++ b/prober/http_test.go
@@ -68,7 +68,7 @@ func TestHTTPStatusCodes(t *testing.T) {
 		recorder := httptest.NewRecorder()
 		testCTX, cancel := context.WithTimeout(context.Background(), 10*time.Second)
 		defer cancel()
-		result := ProbeHTTP(testCTX, ts.URL,
+		result := ProbeHTTP(testCTX, probeOpts{target: ts.URL},
 			config.Module{Timeout: time.Second, HTTP: config.HTTPProbe{IPProtocolFallback: true, ValidStatusCodes: test.ValidStatusCodes}}, registry, log.NewNopLogger())
 		body := recorder.Body.String()
 		if result != test.ShouldSucceed {
@@ -93,7 +93,7 @@ func TestValidHTTPVersion(t *testing.T) {
 		defer ts.Close()
 		recorder := httptest.NewRecorder()
 		registry := prometheus.NewRegistry()
-		result := ProbeHTTP(context.Background(), ts.URL,
+		result := ProbeHTTP(context.Background(), probeOpts{target: ts.URL},
 			config.Module{Timeout: time.Second, HTTP: config.HTTPProbe{
 				IPProtocolFallback: true,
 				ValidHTTPVersions:  test.ValidHTTPVersions,
@@ -235,7 +235,7 @@ func TestContentLength(t *testing.T) {
 			registry := prometheus.NewRegistry()
 			var logbuf bytes.Buffer
 			result := ProbeHTTP(testCTX,
-				ts.URL,
+				probeOpts{target: ts.URL},
 				config.Module{
 					Timeout: time.Second,
 					HTTP:    config.HTTPProbe{IPProtocolFallback: true},
@@ -489,7 +489,7 @@ func TestHandlingOfCompressionSetting(t *testing.T) {
 			registry := prometheus.NewRegistry()
 			var logbuf bytes.Buffer
 			result := ProbeHTTP(testCTX,
-				ts.URL,
+				probeOpts{target: ts.URL},
 				config.Module{
 					Timeout: time.Second,
 					HTTP:    tc.httpConfig,
@@ -605,7 +605,7 @@ func TestMaxResponseLength(t *testing.T) {
 
 			result := ProbeHTTP(
 				testCTX,
-				ts.URL+tc.target,
+				probeOpts{target: ts.URL + tc.target},
 				config.Module{
 					Timeout: time.Second,
 					HTTP: config.HTTPProbe{
@@ -649,7 +649,8 @@ func TestRedirectFollowed(t *testing.T) {
 	registry := prometheus.NewRegistry()
 	testCTX, cancel := context.WithTimeout(context.Background(), 10*time.Second)
 	defer cancel()
-	result := ProbeHTTP(testCTX, ts.URL, config.Module{Timeout: time.Second, HTTP: config.HTTPProbe{IPProtocolFallback: true, HTTPClientConfig: pconfig.DefaultHTTPClientConfig}}, registry, log.NewNopLogger())
+
+	result := ProbeHTTP(testCTX, probeOpts{target: ts.URL}, config.Module{Timeout: time.Second, HTTP: config.HTTPProbe{IPProtocolFallback: true, HTTPClientConfig: pconfig.DefaultHTTPClientConfig}}, registry, log.NewNopLogger())
 	body := recorder.Body.String()
 	if !result {
 		t.Fatalf("Redirect test failed unexpectedly, got %s", body)
@@ -676,7 +677,7 @@ func TestRedirectNotFollowed(t *testing.T) {
 	registry := prometheus.NewRegistry()
 	testCTX, cancel := context.WithTimeout(context.Background(), 10*time.Second)
 	defer cancel()
-	result := ProbeHTTP(testCTX, ts.URL,
+	result := ProbeHTTP(testCTX, probeOpts{target: ts.URL},
 		config.Module{Timeout: time.Second, HTTP: config.HTTPProbe{IPProtocolFallback: true, HTTPClientConfig: pconfig.HTTPClientConfig{FollowRedirects: false}, ValidStatusCodes: []int{302}}}, registry, log.NewNopLogger())
 	body := recorder.Body.String()
 	if !result {
@@ -723,7 +724,7 @@ func TestRedirectionLimit(t *testing.T) {
 
 	result := ProbeHTTP(
 		testCTX,
-		ts.URL,
+		probeOpts{target: ts.URL},
 		config.Module{Timeout: time.Second, HTTP: config.HTTPProbe{IPProtocolFallback: true, HTTPClientConfig: pconfig.DefaultHTTPClientConfig}},
 		registry,
 		log.NewNopLogger())
@@ -759,7 +760,7 @@ func TestPost(t *testing.T) {
 	registry := prometheus.NewRegistry()
 	testCTX, cancel := context.WithTimeout(context.Background(), 10*time.Second)
 	defer cancel()
-	result := ProbeHTTP(testCTX, ts.URL,
+	result := ProbeHTTP(testCTX, probeOpts{target: ts.URL},
 		config.Module{Timeout: time.Second, HTTP: config.HTTPProbe{IPProtocolFallback: true, Method: "POST"}}, registry, log.NewNopLogger())
 	body := recorder.Body.String()
 	if !result {
@@ -776,7 +777,7 @@ func TestBasicAuth(t *testing.T) {
 	registry := prometheus.NewRegistry()
 	testCTX, cancel := context.WithTimeout(context.Background(), 10*time.Second)
 	defer cancel()
-	result := ProbeHTTP(testCTX, ts.URL,
+	result := ProbeHTTP(testCTX, probeOpts{target: ts.URL},
 		config.Module{Timeout: time.Second, HTTP: config.HTTPProbe{
 			IPProtocolFallback: true,
 			HTTPClientConfig: pconfig.HTTPClientConfig{
@@ -799,7 +800,7 @@ func TestBearerToken(t *testing.T) {
 	registry := prometheus.NewRegistry()
 	testCTX, cancel := context.WithTimeout(context.Background(), 10*time.Second)
 	defer cancel()
-	result := ProbeHTTP(testCTX, ts.URL,
+	result := ProbeHTTP(testCTX, probeOpts{target: ts.URL},
 		config.Module{Timeout: time.Second, HTTP: config.HTTPProbe{
 			IPProtocolFallback: true,
 			HTTPClientConfig: pconfig.HTTPClientConfig{
@@ -821,7 +822,7 @@ func TestFailIfNotSSL(t *testing.T) {
 	registry := prometheus.NewRegistry()
 	testCTX, cancel := context.WithTimeout(context.Background(), 10*time.Second)
 	defer cancel()
-	result := ProbeHTTP(testCTX, ts.URL,
+	result := ProbeHTTP(testCTX, probeOpts{target: ts.URL},
 		config.Module{Timeout: time.Second, HTTP: config.HTTPProbe{IPProtocolFallback: true, FailIfNotSSL: true}}, registry, log.NewNopLogger())
 	body := recorder.Body.String()
 	if result {
@@ -915,7 +916,7 @@ func TestFailIfNotSSLLogMsg(t *testing.T) {
 			testCTX, cancel := context.WithTimeout(context.Background(), Timeout)
 			defer cancel()
 
-			result := ProbeHTTP(testCTX, tc.URL, tc.Config, registry, &recorder)
+			result := ProbeHTTP(testCTX, probeOpts{target: tc.URL}, tc.Config, registry, &recorder)
 			if result != tc.Success {
 				t.Fatalf("Expected success=%v, got=%v", tc.Success, result)
 			}
@@ -968,7 +969,7 @@ func TestFailIfBodyMatchesRegexp(t *testing.T) {
 			registry := prometheus.NewRegistry()
 			testCTX, cancel := context.WithTimeout(context.Background(), 10*time.Second)
 			defer cancel()
-			result := ProbeHTTP(testCTX, ts.URL, config.Module{Timeout: time.Second, HTTP: config.HTTPProbe{IPProtocolFallback: true, FailIfBodyMatchesRegexp: testcase.regexps}}, registry, log.NewNopLogger())
+			result := ProbeHTTP(testCTX, probeOpts{target: ts.URL}, config.Module{Timeout: time.Second, HTTP: config.HTTPProbe{IPProtocolFallback: true, FailIfBodyMatchesRegexp: testcase.regexps}}, registry, log.NewNopLogger())
 			if testcase.expectedResult && !result {
 				t.Fatalf("Regexp test failed unexpectedly, got %s", recorder.Body.String())
 			} else if !testcase.expectedResult && result {
@@ -1004,7 +1005,7 @@ func TestFailIfBodyNotMatchesRegexp(t *testing.T) {
 	registry := prometheus.NewRegistry()
 	testCTX, cancel := context.WithTimeout(context.Background(), 10*time.Second)
 	defer cancel()
-	result := ProbeHTTP(testCTX, ts.URL,
+	result := ProbeHTTP(testCTX, probeOpts{target: ts.URL},
 		config.Module{Timeout: time.Second, HTTP: config.HTTPProbe{IPProtocolFallback: true, FailIfBodyNotMatchesRegexp: []config.Regexp{config.MustNewRegexp("Download the latest version here")}}}, registry, log.NewNopLogger())
 	body := recorder.Body.String()
 	if result {
@@ -1018,7 +1019,7 @@ func TestFailIfBodyNotMatchesRegexp(t *testing.T) {
 
 	recorder = httptest.NewRecorder()
 	registry = prometheus.NewRegistry()
-	result = ProbeHTTP(testCTX, ts.URL,
+	result = ProbeHTTP(testCTX, probeOpts{target: ts.URL},
 		config.Module{Timeout: time.Second, HTTP: config.HTTPProbe{IPProtocolFallback: true, FailIfBodyNotMatchesRegexp: []config.Regexp{config.MustNewRegexp("Download the latest version here")}}}, registry, log.NewNopLogger())
 	body = recorder.Body.String()
 	if !result {
@@ -1034,7 +1035,7 @@ func TestFailIfBodyNotMatchesRegexp(t *testing.T) {
 
 	recorder = httptest.NewRecorder()
 	registry = prometheus.NewRegistry()
-	result = ProbeHTTP(testCTX, ts.URL,
+	result = ProbeHTTP(testCTX, probeOpts{target: ts.URL},
 		config.Module{Timeout: time.Second, HTTP: config.HTTPProbe{IPProtocolFallback: true, FailIfBodyNotMatchesRegexp: []config.Regexp{config.MustNewRegexp("Download the latest version here"), config.MustNewRegexp("Copyright 2015")}}}, registry, log.NewNopLogger())
 	body = recorder.Body.String()
 	if result {
@@ -1048,7 +1049,7 @@ func TestFailIfBodyNotMatchesRegexp(t *testing.T) {
 
 	recorder = httptest.NewRecorder()
 	registry = prometheus.NewRegistry()
-	result = ProbeHTTP(testCTX, ts.URL,
+	result = ProbeHTTP(testCTX, probeOpts{target: ts.URL},
 		config.Module{Timeout: time.Second, HTTP: config.HTTPProbe{IPProtocolFallback: true, FailIfBodyNotMatchesRegexp: []config.Regexp{config.MustNewRegexp("Download the latest version here"), config.MustNewRegexp("Copyright 2015")}}}, registry, log.NewNopLogger())
 	body = recorder.Body.String()
 	if !result {
@@ -1084,7 +1085,7 @@ func TestFailIfHeaderMatchesRegexp(t *testing.T) {
 		testCTX, cancel := context.WithTimeout(context.Background(), 10*time.Second)
 		defer cancel()
 
-		result := ProbeHTTP(testCTX, ts.URL, config.Module{Timeout: time.Second, HTTP: config.HTTPProbe{IPProtocolFallback: true, FailIfHeaderMatchesRegexp: []config.HeaderMatch{test.Rule}}}, registry, log.NewNopLogger())
+		result := ProbeHTTP(testCTX, probeOpts{target: ts.URL}, config.Module{Timeout: time.Second, HTTP: config.HTTPProbe{IPProtocolFallback: true, FailIfHeaderMatchesRegexp: []config.HeaderMatch{test.Rule}}}, registry, log.NewNopLogger())
 		if result != test.ShouldSucceed {
 			t.Fatalf("Test %d had unexpected result: succeeded: %t, expected: %+v", i, result, test)
 		}
@@ -1132,7 +1133,7 @@ func TestFailIfHeaderNotMatchesRegexp(t *testing.T) {
 		testCTX, cancel := context.WithTimeout(context.Background(), 10*time.Second)
 		defer cancel()
 
-		result := ProbeHTTP(testCTX, ts.URL, config.Module{Timeout: time.Second, HTTP: config.HTTPProbe{IPProtocolFallback: true, FailIfHeaderNotMatchesRegexp: []config.HeaderMatch{test.Rule}}}, registry, log.NewNopLogger())
+		result := ProbeHTTP(testCTX, probeOpts{target: ts.URL}, config.Module{Timeout: time.Second, HTTP: config.HTTPProbe{IPProtocolFallback: true, FailIfHeaderNotMatchesRegexp: []config.HeaderMatch{test.Rule}}}, registry, log.NewNopLogger())
 		if result != test.ShouldSucceed {
 			t.Fatalf("Test %d had unexpected result: succeeded: %t, expected: %+v", i, result, test)
 		}
@@ -1177,7 +1178,7 @@ func TestHTTPHeaders(t *testing.T) {
 	registry := prometheus.NewRegistry()
 	testCTX, cancel := context.WithTimeout(context.Background(), 10*time.Second)
 	defer cancel()
-	result := ProbeHTTP(testCTX, ts.URL, config.Module{Timeout: time.Second, HTTP: config.HTTPProbe{
+	result := ProbeHTTP(testCTX, probeOpts{target: ts.URL}, config.Module{Timeout: time.Second, HTTP: config.HTTPProbe{
 		IPProtocolFallback: true,
 		Headers:            headers,
 	}}, registry, log.NewNopLogger())
@@ -1195,7 +1196,7 @@ func TestFailIfSelfSignedCA(t *testing.T) {
 	registry := prometheus.NewRegistry()
 	testCTX, cancel := context.WithTimeout(context.Background(), 10*time.Second)
 	defer cancel()
-	result := ProbeHTTP(testCTX, ts.URL,
+	result := ProbeHTTP(testCTX, probeOpts{target: ts.URL},
 		config.Module{Timeout: time.Second, HTTP: config.HTTPProbe{
 			IPProtocolFallback: true,
 			HTTPClientConfig: pconfig.HTTPClientConfig{
@@ -1225,7 +1226,7 @@ func TestSucceedIfSelfSignedCA(t *testing.T) {
 	registry := prometheus.NewRegistry()
 	testCTX, cancel := context.WithTimeout(context.Background(), 10*time.Second)
 	defer cancel()
-	result := ProbeHTTP(testCTX, ts.URL,
+	result := ProbeHTTP(testCTX, probeOpts{target: ts.URL},
 		config.Module{Timeout: time.Second, HTTP: config.HTTPProbe{
 			IPProtocolFallback: true,
 			HTTPClientConfig: pconfig.HTTPClientConfig{
@@ -1255,7 +1256,7 @@ func TestTLSConfigIsIgnoredForPlainHTTP(t *testing.T) {
 	registry := prometheus.NewRegistry()
 	testCTX, cancel := context.WithTimeout(context.Background(), 10*time.Second)
 	defer cancel()
-	result := ProbeHTTP(testCTX, ts.URL,
+	result := ProbeHTTP(testCTX, probeOpts{target: ts.URL},
 		config.Module{Timeout: time.Second, HTTP: config.HTTPProbe{
 			IPProtocolFallback: true,
 			HTTPClientConfig: pconfig.HTTPClientConfig{
@@ -1328,7 +1329,7 @@ func TestHTTPUsesTargetAsTLSServerName(t *testing.T) {
 	url := strings.Replace(ts.URL, "127.0.0.1", "localhost", -1)
 	url = strings.Replace(url, "[::1]", "localhost", -1)
 
-	result := ProbeHTTP(context.Background(), url, module, registry, log.NewNopLogger())
+	result := ProbeHTTP(context.Background(), probeOpts{target: url}, module, registry, log.NewNopLogger())
 	if !result {
 		t.Fatalf("TLS probe failed unexpectedly")
 	}
@@ -1347,7 +1348,8 @@ func TestRedirectToTLSHostWorks(t *testing.T) {
 	registry := prometheus.NewRegistry()
 	testCTX, cancel := context.WithTimeout(context.Background(), 10*time.Second)
 	defer cancel()
-	result := ProbeHTTP(testCTX, ts.URL,
+
+	result := ProbeHTTP(testCTX, probeOpts{target: ts.URL},
 		config.Module{Timeout: time.Second, HTTP: config.HTTPProbe{IPProtocolFallback: true, HTTPClientConfig: pconfig.DefaultHTTPClientConfig}}, registry, log.NewNopLogger())
 	if !result {
 		t.Fatalf("Redirect test failed unexpectedly")
@@ -1366,7 +1368,7 @@ func TestHTTPPhases(t *testing.T) {
 	testCTX, cancel := context.WithTimeout(context.Background(), 10*time.Second)
 	defer cancel()
 
-	result := ProbeHTTP(testCTX, ts.URL, config.Module{Timeout: time.Second, HTTP: config.HTTPProbe{
+	result := ProbeHTTP(testCTX, probeOpts{target: ts.URL}, config.Module{Timeout: time.Second, HTTP: config.HTTPProbe{
 		IPProtocolFallback: true,
 		HTTPClientConfig: pconfig.HTTPClientConfig{
 			TLSConfig: pconfig.TLSConfig{InsecureSkipVerify: true},
@@ -1421,7 +1423,7 @@ func TestCookieJar(t *testing.T) {
 	registry := prometheus.NewRegistry()
 	testCTX, cancel := context.WithTimeout(context.Background(), 10*time.Second)
 	defer cancel()
-	result := ProbeHTTP(testCTX, ts.URL, config.Module{Timeout: time.Second, HTTP: config.HTTPProbe{IPProtocolFallback: true, HTTPClientConfig: pconfig.DefaultHTTPClientConfig}}, registry, log.NewNopLogger())
+	result := ProbeHTTP(testCTX, probeOpts{target: ts.URL}, config.Module{Timeout: time.Second, HTTP: config.HTTPProbe{IPProtocolFallback: true, HTTPClientConfig: pconfig.DefaultHTTPClientConfig}}, registry, log.NewNopLogger())
 	body := recorder.Body.String()
 	if !result {
 		t.Fatalf("Redirect test failed unexpectedly, got %s", body)
@@ -1441,7 +1443,7 @@ func TestSkipResolvePhase(t *testing.T) {
 		registry := prometheus.NewRegistry()
 		testCTX, cancel := context.WithTimeout(context.Background(), 10*time.Second)
 		defer cancel()
-		result := ProbeHTTP(testCTX, ts.URL,
+		result := ProbeHTTP(testCTX, probeOpts{target: ts.URL},
 			config.Module{Timeout: time.Second, HTTP: config.HTTPProbe{IPProtocolFallback: true, HTTPClientConfig: pconfig.DefaultHTTPClientConfig, SkipResolvePhaseWithProxy: true}}, registry, log.NewNopLogger())
 		if !result {
 			t.Fatalf("Probe unsuccessful")
@@ -1476,7 +1478,7 @@ func TestSkipResolvePhase(t *testing.T) {
 		httpCfg.ProxyURL = pconfig.URL{
 			URL: u,
 		}
-		ProbeHTTP(testCTX, ts.URL,
+		ProbeHTTP(testCTX, probeOpts{target: ts.URL},
 			config.Module{Timeout: time.Second, HTTP: config.HTTPProbe{IPProtocolFallback: true, HTTPClientConfig: httpCfg, SkipResolvePhaseWithProxy: true}}, registry, log.NewNopLogger())
 		mfs, err := registry.Gather()
 		if err != nil {
@@ -1532,7 +1534,7 @@ func TestBody(t *testing.T) {
 		defer cancel()
 		result := ProbeHTTP(
 			testCTX,
-			ts.URL,
+			probeOpts{target: ts.URL},
 			config.Module{
 				Timeout: time.Second,
 				HTTP:    test},

--- a/prober/prober.go
+++ b/prober/prober.go
@@ -22,7 +22,12 @@ import (
 	"github.com/prometheus/blackbox_exporter/config"
 )
 
-type ProbeFn func(ctx context.Context, target string, config config.Module, registry *prometheus.Registry, logger log.Logger) bool
+type probeOpts struct {
+	target          string
+	sourceIPAddress string
+}
+
+type ProbeFn func(ctx context.Context, opts probeOpts, config config.Module, registry *prometheus.Registry, logger log.Logger) bool
 
 const (
 	helpSSLEarliestCertExpiry     = "Returns last SSL chain expiry in unixtime"

--- a/prober/utils.go
+++ b/prober/utils.go
@@ -142,3 +142,13 @@ func ipHash(ip net.IP) float64 {
 	}
 	return float64(h.Sum32())
 }
+
+// return first non empty string
+func coalesce(strs ...string) string {
+	for _, str := range strs {
+		if len(str) > 0 {
+			return str
+		}
+	}
+	return ""
+}


### PR DESCRIPTION
I have a use case which is to send icmp ping and tcp ping via different network interfaces in a machine with multiple network cards. Although the source ip can be configured through blackbox.yaml, I think it would be more fixable if we can control the source ip of the probeFn through remote parameters of Prometheus request. 

To do so, I suggest we create a probeOpts struct. Instead of passing the target to probeFn, we can pass the struct with target value inside to probeFn. This change also allow different ProbeFn to have different parameters in the future.

