### PR TITLE
Add a way to export labels with content matched by the probe

### DIFF
--- a/CONFIGURATION.md
+++ b/CONFIGURATION.md
@@ -182,9 +182,18 @@ regexp: <regex>,
 [ source_ip_address: <string> ]
 
 # The query sent in the TCP probe and the expected associated response.
-# starttls upgrades TCP connection to TLS.
+# "expect" matches a regular expression;
+# "labels" can define labels which will be exported on metric "probe_expect_info";
+# "send" sends some content;
+# "send" and "labels.value" can contain values matched by "expect" (such as "${1}");
+# "starttls" upgrades TCP connection to TLS.
 query_response:
   [ - [ [ expect: <string> ],
+        [ labels:
+          - [ name: <string>
+              value: <string>
+            ], ...
+        ],
         [ send: <string> ],
         [ starttls: <boolean | default = false> ]
       ], ...

--- a/blackbox.yml
+++ b/blackbox.yml
@@ -33,6 +33,17 @@ modules:
       query_response:
       - expect: "^SSH-2.0-"
       - send: "SSH-2.0-blackbox-ssh-check"
+  ssh_banner_extract:
+    prober: tcp
+    timeout: 5s
+    tcp:
+      query_response:
+      - expect: "^SSH-2.0-([^ -]+)(?: (.*))?$"
+        labels:
+        - name: ssh_version
+          value: "${1}"
+        - name: ssh_comments
+          value: "${2}"
   irc_banner:
     prober: tcp
     tcp:

--- a/config/config.go
+++ b/config/config.go
@@ -239,10 +239,16 @@ type HeaderMatch struct {
 	AllowMissing bool   `yaml:"allow_missing,omitempty"`
 }
 
+type Label struct {
+	Name  string `yaml:"name,omitempty"`
+	Value string `yaml:"value,omitempty"`
+}
+
 type QueryResponse struct {
-	Expect   Regexp `yaml:"expect,omitempty"`
-	Send     string `yaml:"send,omitempty"`
-	StartTLS bool   `yaml:"starttls,omitempty"`
+	Expect   Regexp  `yaml:"expect,omitempty"`
+	Labels   []Label `yaml:"labels,omitempty"`
+	Send     string  `yaml:"send,omitempty"`
+	StartTLS bool    `yaml:"starttls,omitempty"`
 }
 
 type TCPProbe struct {

--- a/prober/tcp.go
+++ b/prober/tcp.go
@@ -165,15 +165,15 @@ func ProbeTCP(ctx context.Context, target string, module config.Module, registry
 					names = append(names, s.Name)
 					values = append(values, string(qr.Expect.Regexp.Expand(nil, []byte(s.Value), scanner.Bytes(), match)))
 				}
-				probeContent := prometheus.NewGaugeVec(
+				probeExpectInfo := prometheus.NewGaugeVec(
 					prometheus.GaugeOpts{
-						Name: "probe_content",
+						Name: "probe_expect_info",
 						Help: "Explicit content matched",
 					},
 					names,
 				)
-				registry.MustRegister(probeContent)
-				probeContent.WithLabelValues(values...).Set(1)
+				registry.MustRegister(probeExpectInfo)
+				probeExpectInfo.WithLabelValues(values...).Set(1)
 			}
 		}
 		if send != "" {

--- a/prober/tcp.go
+++ b/prober/tcp.go
@@ -88,12 +88,12 @@ func dialTCP(ctx context.Context, target string, module config.Module, registry 
 	return tls.DialWithDialer(dialer, dialProtocol, dialTarget, tlsConfig)
 }
 
-func probeExpectInfo(registry *prometheus.Registry, qr *config.QueryResponse, scanner *bufio.Scanner, match []int) {
+func probeExpectInfo(registry *prometheus.Registry, qr *config.QueryResponse, bytes []byte, match []int) {
 	var names []string
 	var values []string
 	for _, s := range qr.Labels {
 		names = append(names, s.Name)
-		values = append(values, string(qr.Expect.Regexp.Expand(nil, []byte(s.Value), scanner.Bytes(), match)))
+		values = append(values, string(qr.Expect.Regexp.Expand(nil, []byte(s.Value), bytes, match)))
 	}
 	metric := prometheus.NewGaugeVec(
 		prometheus.GaugeOpts{
@@ -177,7 +177,7 @@ func ProbeTCP(ctx context.Context, target string, module config.Module, registry
 			probeFailedDueToRegex.Set(0)
 			send = string(qr.Expect.Regexp.Expand(nil, []byte(send), scanner.Bytes(), match))
 			if qr.Labels != nil {
-				probeExpectInfo(registry, &qr, scanner, match)
+				probeExpectInfo(registry, &qr, scanner.Bytes(), match)
 			}
 		}
 		if send != "" {

--- a/prober/tcp_test.go
+++ b/prober/tcp_test.go
@@ -525,8 +525,18 @@ func TestTCPConnectionQueryResponseMatching(t *testing.T) {
 			IPProtocolFallback: true,
 			QueryResponse: []config.QueryResponse{
 				{
-					Expect: config.MustNewRegexp("SSH-2.0-(OpenSSH_6.9p1) Debian-2"),
+					Expect: config.MustNewRegexp("^SSH-2.0-([^ -]+)(?: (.*))?$"),
 					Send:   "CONFIRM ${1}",
+					Labels: []config.Label{
+						{
+							Name:  "ssh_version",
+							Value: "${1}",
+						},
+						{
+							Name:  "ssh_comments",
+							Value: "${2}",
+						},
+					},
 				},
 			},
 		},
@@ -560,6 +570,14 @@ func TestTCPConnectionQueryResponseMatching(t *testing.T) {
 		"probe_failed_due_to_regex": 0,
 	}
 	checkRegistryResults(expectedResults, mfs, t)
+	// Check labels
+	expectedLabels := map[string]map[string]string{
+		"probe_expect_info": {
+			"ssh_version":  "OpenSSH_6.9p1",
+			"ssh_comments": "Debian-2",
+		},
+	}
+	checkRegistryLabels(expectedLabels, mfs, t)
 
 }
 


### PR DESCRIPTION
I wanted to create an exporter to check if all my hosts had an updated `sshd` (due to recent CVEs) then I resorted to using blackbock exporter by matching the "fixed" version and the timeout:

```yaml
  ssh_freebsd_secure:
    prober: tcp
    timeout: 5s
    tcp:
      query_response:
      - expect: "^SSH-2.0-OpenSSH_[0-9.]+ FreeBSD-20240806$"
```

but then again I'd prefer to capture the value as a label and do my checks by coloring the value in Grafana table later on or in alertmanager rules so I did this change instead.

I tried to do it in a generic way so that it can be used also for very different cases when matching part of the protocol chat is useful.

This produces scraping values like these:

```
# HELP probe_content Explicit content matched
# TYPE probe_content gauge
probe_content{ssh_comments="FreeBSD-20240806",ssh_version="OpenSSH_9.7"} 1
```

BTW: I know no Go, except a advent-of-code example, these are the first Go lines that I wrote.

Feel free to close if uninteresting for the project (though I hope it isn't, to avoid the need to always compile my branch) or suggest what I should change in the PR to have it accepted. Thanks!