### PR TITLE
fix: set the timeout based on the caller to avoid strange issues

### DIFF
--- a/prober/dns.go
+++ b/prober/dns.go
@@ -259,8 +259,9 @@ func ProbeDNS(ctx context.Context, target string, module config.Module, registry
 	msg.Question[0] = dns.Question{dns.Fqdn(module.DNS.QueryName), qt, qc}
 
 	logger.Info("Making DNS query", "target", targetIP, "dial_protocol", dialProtocol, "query", module.DNS.QueryName, "type", qt, "class", qc)
-	timeoutDeadline, _ := ctx.Deadline()
-	client.Timeout = time.Until(timeoutDeadline)
+	if timeoutDeadline, ok := ctx.Deadline(); ok {
+		client.Timeout = time.Until(timeoutDeadline)
+	}
 	requestStart := time.Now()
 	response, rtt, err := client.Exchange(msg, targetIP)
 	// The rtt value returned from client.Exchange includes only the time to

--- a/prober/icmp.go
+++ b/prober/icmp.go
@@ -293,11 +293,13 @@ func ProbeICMP(ctx context.Context, target string, module config.Module, registr
 	}
 
 	rb := make([]byte, 65536)
-	deadline, _ := ctx.Deadline()
-	if icmpConn != nil {
-		err = icmpConn.SetReadDeadline(deadline)
-	} else {
-		err = v4RawConn.SetReadDeadline(deadline)
+
+	if deadline, ok := ctx.Deadline(); ok {
+		if icmpConn != nil {
+			err = icmpConn.SetReadDeadline(deadline)
+		} else {
+			err = v4RawConn.SetReadDeadline(deadline)
+		}
 	}
 	if err != nil {
 		logger.Error("Error setting socket deadline", "err", err)


### PR DESCRIPTION
although a ctx with deadline is set in most cases, but passing in context.TODO() can lead to some very strange problems.

or would it be more appropriate for the business logic to return an error indicating that the context (ctx) has no deadline if it detects the the ctx without setting deadline?