### PR TITLE
Document difference between TLS Cert expiry metrics

### DIFF
--- a/prober/prober.go
+++ b/prober/prober.go
@@ -26,7 +26,7 @@ type ProbeFn func(ctx context.Context, target string, config config.Module, regi
 
 const (
 	helpSSLEarliestCertExpiry     = "Earliest expiry time of any TLS certificate returned by the server"
-	helpSSLChainExpiryInTimeStamp = "Earliest expiry of any TLS certificate that is part of the certificate chain used for validating the servers identity"
+	helpSSLChainExpiryInTimeStamp = "Earliest expiry time in the TLS certificate chain used for validating the servers identity"
 	helpProbeTLSInfo              = "Returns the TLS version used or NaN when unknown"
 	helpProbeTLSCipher            = "Returns the TLS cipher negotiated during handshake"
 )

--- a/prober/prober.go
+++ b/prober/prober.go
@@ -25,8 +25,8 @@ import (
 type ProbeFn func(ctx context.Context, target string, config config.Module, registry *prometheus.Registry, logger *slog.Logger) bool
 
 const (
-	helpSSLEarliestCertExpiry     = "Returns the earliest expiry of any peer certificate returned by the server as an unix timestamp. This can include certificates that are not validated by TLS clients. In rare server configurations this might return a time in the past, even for valid TLS certificate chains."
-	helpSSLChainExpiryInTimeStamp = "Returns the earliest expiry of any validated TLS certificate as an unix timestamp. This indicates the time when connections will start to fail, unless a certificate is renewed."
+	helpSSLEarliestCertExpiry     = "Earliest expiry time of any TLS certificate returned by the server"
+	helpSSLChainExpiryInTimeStamp = "Earliest expiry of any TLS certificate that is part of the certificate chain used for validating the servers identity"
 	helpProbeTLSInfo              = "Returns the TLS version used or NaN when unknown"
 	helpProbeTLSCipher            = "Returns the TLS cipher negotiated during handshake"
 )

--- a/prober/prober.go
+++ b/prober/prober.go
@@ -25,8 +25,8 @@ import (
 type ProbeFn func(ctx context.Context, target string, config config.Module, registry *prometheus.Registry, logger *slog.Logger) bool
 
 const (
-	helpSSLEarliestCertExpiry     = "Returns last SSL chain expiry in unixtime"
-	helpSSLChainExpiryInTimeStamp = "Returns last SSL chain expiry in timestamp"
+	helpSSLEarliestCertExpiry     = "Returns the earliest expiry of any peer certificate returned by the server as an unix timestamp. This can include certificates that are not validated by TLS clients. In rare server configurations this might return a time in the past, even for valid TLS certificate chains."
+	helpSSLChainExpiryInTimeStamp = "Returns the earliest expiry of any validated TLS certificate as an unix timestamp. This indicates the time when connections will start to fail, unless a certificate is renewed."
 	helpProbeTLSInfo              = "Returns the TLS version used or NaN when unknown"
 	helpProbeTLSCipher            = "Returns the TLS cipher negotiated during handshake"
 )


### PR DESCRIPTION
blackbox-exporter currently offers two metrics to
measure when TLS Certificates will expire.

The difference between those is very subtle, but
using `probe_ssl_earliest_cert_expiry`
for checking whether a certificate is due to
replacement can lead to false positive alerts.

This documents the difference between those two.

Generally, `probe_ssl_last_chain_expiry_timestamp_seconds`
 seems to be what most people would want to use.