### PR TITLE
Update CONFIGURATION.md to clarify that valid_status_codes expects a list

### DIFF
--- a/CONFIGURATION.md
+++ b/CONFIGURATION.md
@@ -47,8 +47,8 @@ modules:
 ### `<http_probe>`
 ```yml
 
-  # Accepted status codes for this probe. Defaults to 2xx.
-  [ valid_status_codes: <int>, ... | default = 2xx ]
+  # Accepted status codes for this probe. List between square brackets. Defaults to 2xx.
+  [ valid_status_codes: [<int>, ...] | default = 2xx ]
 
   # Accepted HTTP versions for this probe.
   [ valid_http_versions: <string>, ... ]


### PR DESCRIPTION
The valid_status_codes expects a list between square brackets. Without you get this error: cannot unmarshal !!str \`200, 401\` into []int