### PR TITLE
chore: ignore .idea folder created by JetBrains IDEs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -28,3 +28,6 @@ dependencies-stamp
 .deps
 *.tar.gz
 /vendor
+
+# JetBrains IDEs
+.idea/


### PR DESCRIPTION
.idea folder is created by JetBrains IDEs and should be ignored. 

I was using JetBrains GoLand, and saw that it's not ignored yet.