### PR TITLE
Skip failing IPv6 tests in test CI Pipeline

### DIFF
--- a/prober/grpc_test.go
+++ b/prober/grpc_test.go
@@ -35,6 +35,9 @@ import (
 )
 
 func TestGRPCConnection(t *testing.T) {
+	if os.Getenv("CI") == "true" {
+		t.Skip("skipping; CI is failing on ipv6 dns requests")
+	}
 
 	ln, err := net.Listen("tcp", "localhost:0")
 	if err != nil {
@@ -100,6 +103,9 @@ func TestGRPCConnection(t *testing.T) {
 }
 
 func TestMultipleGRPCservices(t *testing.T) {
+	if os.Getenv("CI") == "true" {
+		t.Skip("skipping; CI is failing on ipv6 dns requests")
+	}
 
 	ln, err := net.Listen("tcp", "localhost:0")
 	if err != nil {
@@ -166,6 +172,9 @@ func TestMultipleGRPCservices(t *testing.T) {
 }
 
 func TestGRPCTLSConnection(t *testing.T) {
+	if os.Getenv("CI") == "true" {
+		t.Skip("skipping; CI is failing on ipv6 dns requests")
+	}
 
 	certExpiry := time.Now().AddDate(0, 0, 1)
 	testCertTmpl := generateCertificateTemplate(certExpiry, false)
@@ -258,6 +267,9 @@ func TestGRPCTLSConnection(t *testing.T) {
 }
 
 func TestNoTLSConnection(t *testing.T) {
+	if os.Getenv("CI") == "true" {
+		t.Skip("skipping; CI is failing on ipv6 dns requests")
+	}
 
 	ln, err := net.Listen("tcp", "localhost:0")
 	if err != nil {
@@ -305,7 +317,7 @@ func TestNoTLSConnection(t *testing.T) {
 
 	expectedResults := map[string]float64{
 		"probe_grpc_ssl":         0,
-		"probe_grpc_status_code": 14, //UNAVAILABLE
+		"probe_grpc_status_code": 14, // UNAVAILABLE
 	}
 
 	checkRegistryResults(expectedResults, mfs, t)
@@ -313,6 +325,9 @@ func TestNoTLSConnection(t *testing.T) {
 }
 
 func TestGRPCServiceNotFound(t *testing.T) {
+	if os.Getenv("CI") == "true" {
+		t.Skip("skipping; CI is failing on ipv6 dns requests")
+	}
 
 	ln, err := net.Listen("tcp", "localhost:0")
 	if err != nil {
@@ -359,13 +374,16 @@ func TestGRPCServiceNotFound(t *testing.T) {
 
 	expectedResults := map[string]float64{
 		"probe_grpc_ssl":         0,
-		"probe_grpc_status_code": 5, //NOT_FOUND
+		"probe_grpc_status_code": 5, // NOT_FOUND
 	}
 
 	checkRegistryResults(expectedResults, mfs, t)
 }
 
 func TestGRPCHealthCheckUnimplemented(t *testing.T) {
+	if os.Getenv("CI") == "true" {
+		t.Skip("skipping; CI is failing on ipv6 dns requests")
+	}
 
 	ln, err := net.Listen("tcp", "localhost:0")
 	if err != nil {
@@ -409,7 +427,7 @@ func TestGRPCHealthCheckUnimplemented(t *testing.T) {
 
 	expectedResults := map[string]float64{
 		"probe_grpc_ssl":         0,
-		"probe_grpc_status_code": 12, //UNIMPLEMENTED
+		"probe_grpc_status_code": 12, // UNIMPLEMENTED
 	}
 
 	checkRegistryResults(expectedResults, mfs, t)


### PR DESCRIPTION
These tests have been failing on the `test` pipeline CI for a while, but they run fine locally on the systems that support ipv4 and ipv6

Since we have `test-ipv6` pipeline that runs full test suite in a docker image with IPv6 enabled,
we should be okay to skip these Tests on the `test` pipeline.

The reason these tests are failing is because they are using `net.Listen("tcp", "localhost:0")`,
the use of `tcp` network expects both IPv4 and IPv6.

If we don't want to skip these tests, we can split these tests into a table test with `tcp4` and `tcp6`, and only skip `tcp6` on the `test` pipeline.

this was the first approach that came to my mind, and I am open to other approaches as well. if you can think of something better, please suggest other approaches as well.