### PR TITLE
Add RabbitMQ probe example

### DIFF
--- a/example.yml
+++ b/example.yml
@@ -141,6 +141,34 @@ modules:
         - expect: "PING :([^ ]+)"
           send: "PONG ${1}"
         - expect: "^:[^ ]+ 001"
+  rabbitmq:
+    prober: tcp
+    timeout: 30s
+    tcp:
+      query_response:
+        - send: "HELO\r"
+        - send: "\r"
+        - send: "\r"
+        - send: "\r"
+        - expect: "AMQP"
+      tls: true
+      tls_config:
+        insecure_skip_verify: false
+        ca_file: "/etc/blackbox_exporter/CA_cert.crt"
+  rabbitmq_insecure:
+    prober: tcp
+    timeout: 30s
+    tcp:
+      query_response:
+        - send: "HELO\r"
+        - send: "\r"
+        - send: "\r"
+        - send: "\r"
+        - expect: "AMQP"
+      tls: true
+      tls_config:
+        insecure_skip_verify: true
+        ca_file: "/etc/blackbox_exporter/CA_cert.crt"
   icmp_example:
     prober: icmp
     timeout: 5s


### PR DESCRIPTION
Adding the RabbitMQ probe example shared by @victorpablosceruelo in https://github.com/prometheus/blackbox_exporter/issues/1074

thanks @victorpablosceruelo for the RabbitMQ probe config example.

Fixed https://github.com/prometheus/blackbox_exporter/issues/1074