### PR TITLE
feat(tcp): add support for PostgreSQL SSLRequest in TCP prober

### DIFF
--- a/CONFIGURATION.md
+++ b/CONFIGURATION.md
@@ -207,6 +207,9 @@ query_response:
 
 # Whether or not TLS is used when the connection is initiated.
 [ tls: <boolean | default = false> ]
+# If set to `true`, the probe will send a PostgreSQL-specific `SSLRequest` message
+# before starting the TLS handshake.
+[ postgres_tls_request: <boolean | default = false> ]
 
 # Configuration for TLS protocol of TCP probe.
 tls_config:

--- a/config/config.go
+++ b/config/config.go
@@ -325,6 +325,7 @@ type TCPProbe struct {
 	SourceIPAddress    string           `yaml:"source_ip_address,omitempty"`
 	QueryResponse      []QueryResponse  `yaml:"query_response,omitempty"`
 	TLS                bool             `yaml:"tls,omitempty"`
+	PostgresTLSRequest bool             `yaml:"postgres_tls_request,omitempty"`
 	TLSConfig          config.TLSConfig `yaml:"tls_config,omitempty"`
 }
 

--- a/config/testdata/blackbox-good.yml
+++ b/config/testdata/blackbox-good.yml
@@ -15,6 +15,14 @@ modules:
   tcp_connect:
     prober: tcp
     timeout: 5s
+  tls_postgres:
+    prober: tcp
+    timeout: 5s
+    tcp:
+      postgres_tls_request: true
+      tls: true
+      tls_config:
+        insecure_skip_verify: false
   pop3s_banner:
     prober: tcp
     tcp:

--- a/example.yml
+++ b/example.yml
@@ -112,6 +112,15 @@ modules:
   tcp_connect_example:
     prober: tcp
     timeout: 5s
+  tls_postgres:
+    prober: tcp
+    timeout: 5s
+    tcp:
+      preferred_ip_protocol: "ip4"
+      postgres_tls_request: true
+      tls: true
+      tls_config:
+        insecure_skip_verify: false
   imap_starttls:
     prober: tcp
     timeout: 5s


### PR DESCRIPTION
Adds a new `postgres_ssl_request` option to the TCP module configuration. When enabled, the prober sends a PostgreSQL-specific SSLRequest message before initiating a TLS handshake. This allows the TCP prober to connect to PostgreSQL servers that expect protocol negotiation prior to starting TLS.

This change enables monitoring of PostgreSQL TLS sockets using the standard `tcp` prober.

Reference: https://www.postgresql.org/docs/current/protocol-flow.html#PROTOCOL-FLOW-SSL

Fixes: #801