### PR TITLE
Add custom dns support.

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -297,6 +297,8 @@ type HTTPProbe struct {
 	Compression                  string                  `yaml:"compression,omitempty"`
 	BodySizeLimit                units.Base2Bytes        `yaml:"body_size_limit,omitempty"`
 	UseHTTP3                     bool                    `yaml:"enable_http3,omitempty"`
+	DNSServer                    string                  `yaml:"dns_server,omitempty"`
+	DNSTimeout                   time.Duration           `yaml:"dns_timeout,omitempty"`
 }
 
 type GRPCProbe struct {
@@ -305,6 +307,8 @@ type GRPCProbe struct {
 	TLSConfig           config.TLSConfig `yaml:"tls_config,omitempty"`
 	IPProtocolFallback  bool             `yaml:"ip_protocol_fallback,omitempty"`
 	PreferredIPProtocol string           `yaml:"preferred_ip_protocol,omitempty"`
+	DNSServer           string           `yaml:"dns_server,omitempty"`
+	DNSTimeout          time.Duration    `yaml:"dns_timeout,omitempty"`
 }
 
 type HeaderMatch struct {
@@ -332,6 +336,8 @@ type TCPProbe struct {
 	QueryResponse      []QueryResponse  `yaml:"query_response,omitempty"`
 	TLS                bool             `yaml:"tls,omitempty"`
 	TLSConfig          config.TLSConfig `yaml:"tls_config,omitempty"`
+	DNSServer          string           `yaml:"dns_server,omitempty"`
+	DNSTimeout         time.Duration    `yaml:"dns_timeout,omitempty"`
 }
 
 type ICMPProbe struct {
@@ -341,6 +347,8 @@ type ICMPProbe struct {
 	PayloadSize        int    `yaml:"payload_size,omitempty"`
 	DontFragment       bool   `yaml:"dont_fragment,omitempty"`
 	TTL                int    `yaml:"ttl,omitempty"`
+	DNSServer          string        `yaml:"dns_server,omitempty"`
+	DNSTimeout         time.Duration `yaml:"dns_timeout,omitempty"`
 }
 
 type DNSProbe struct {
@@ -358,6 +366,8 @@ type DNSProbe struct {
 	ValidateAnswer     DNSRRValidator   `yaml:"validate_answer_rrs,omitempty"`
 	ValidateAuthority  DNSRRValidator   `yaml:"validate_authority_rrs,omitempty"`
 	ValidateAdditional DNSRRValidator   `yaml:"validate_additional_rrs,omitempty"`
+	DNSServer          string           `yaml:"dns_server,omitempty"`
+	DNSTimeout         time.Duration    `yaml:"dns_timeout,omitempty"`
 }
 
 type DNSRRValidator struct {

--- a/prober/dns.go
+++ b/prober/dns.go
@@ -196,7 +196,7 @@ func ProbeDNS(ctx context.Context, target string, module config.Module, registry
 		}
 		targetAddr = target
 	}
-	ip, lookupTime, err := chooseProtocol(ctx, module.DNS.IPProtocol, module.DNS.IPProtocolFallback, targetAddr, registry, logger)
+	ip, lookupTime, err := chooseProtocol(ctx, module.DNS.IPProtocol, module.DNS.IPProtocolFallback, targetAddr, registry, logger, module.DNS.DNSServer, module.DNS.DNSTimeout)
 	if err != nil {
 		logger.Error("Error resolving address", "err", err)
 		return false

--- a/prober/grpc.go
+++ b/prober/grpc.go
@@ -144,7 +144,7 @@ func ProbeGRPC(ctx context.Context, target string, module config.Module, registr
 		return false
 	}
 
-	ip, lookupTime, err := chooseProtocol(ctx, module.GRPC.PreferredIPProtocol, module.GRPC.IPProtocolFallback, targetHost, registry, logger)
+	ip, lookupTime, err := chooseProtocol(ctx, module.GRPC.PreferredIPProtocol, module.GRPC.IPProtocolFallback, targetHost, registry, logger, module.GRPC.DNSServer, module.GRPC.DNSTimeout)
 	if err != nil {
 		logger.Error("Error resolving address", "err", err)
 		return false

--- a/prober/http.go
+++ b/prober/http.go
@@ -404,7 +404,7 @@ func ProbeHTTP(ctx context.Context, target string, module config.Module, registr
 	var ip *net.IPAddr
 	if shouldResolveDNSWithProxy(module.HTTP) {
 		var lookupTime float64
-		ip, lookupTime, err = chooseProtocol(ctx, module.HTTP.IPProtocol, module.HTTP.IPProtocolFallback, targetHost, registry, logger)
+		ip, lookupTime, err = chooseProtocol(ctx, module.HTTP.IPProtocol, module.HTTP.IPProtocolFallback, targetHost, registry, logger, module.HTTP.DNSServer, module.HTTP.DNSTimeout)
 		durationGaugeVec.WithLabelValues("resolve").Add(lookupTime)
 		if err != nil {
 			logger.Error("Error resolving address", "err", err)

--- a/prober/icmp.go
+++ b/prober/icmp.go
@@ -87,7 +87,7 @@ func ProbeICMP(ctx context.Context, target string, module config.Module, registr
 
 	registry.MustRegister(durationGaugeVec)
 
-	dstIPAddr, lookupTime, err := chooseProtocol(ctx, module.ICMP.IPProtocol, module.ICMP.IPProtocolFallback, target, registry, logger)
+	dstIPAddr, lookupTime, err := chooseProtocol(ctx, module.ICMP.IPProtocol, module.ICMP.IPProtocolFallback, target, registry, logger, module.ICMP.DNSServer, module.ICMP.DNSTimeout)
 
 	if err != nil {
 		logger.Error("Error resolving address", "err", err)

--- a/prober/tcp.go
+++ b/prober/tcp.go
@@ -36,7 +36,7 @@ func dialTCP(ctx context.Context, target string, module config.Module, registry 
 		return nil, err
 	}
 
-	ip, _, err := chooseProtocol(ctx, module.TCP.IPProtocol, module.TCP.IPProtocolFallback, targetAddress, registry, logger)
+	ip, _, err := chooseProtocol(ctx, module.TCP.IPProtocol, module.TCP.IPProtocolFallback, targetAddress, registry, logger, module.TCP.DNSServer, module.TCP.DNSTimeout)
 	if err != nil {
 		logger.Error("Error resolving address", "err", err)
 		return nil, err


### PR DESCRIPTION
Over the past year, I've observed many users requiring specific DNS configurations rather than blindly defaulting to local DNS settings:

- https://github.com/prometheus/blackbox_exporter/issues/1356 
- https://github.com/prometheus/blackbox_exporter/issues/1275
- https://github.com/prometheus/blackbox_exporter/issues/1235
- https://github.com/prometheus/blackbox_exporter/issues/960

I observe that Blackbox Exporter supports Helm chart deployment and provides container images, which enables flexible deployment in large-scale Kubernetes clusters. Real-world network probing requirements are often complex. We want certain pods to maintain the ability to resolve targets through CoreDNS, while other pods should resolve public DNS addresses or DNS servers on jump hosts. Based on these **enterprise-level** realities, we've made some modifications to the source code.

Assuming we want the following configuration (either manually written or Helm-generated):

- file: `/etc/blackbox.yaml`
- file: `metrics/data/{cluster-name}/blackbox.jumpserver.yaml`
- file: `metrics/data/{cluster-name}/blackbox.worker.yaml`
- file: `metrics/data/{cluster-name}/blackbox.master.yaml`

We have implemented the following configuration (sanitized and simplified for demonstration):

```yaml
modules:
  http_get_2xx:
    prober: http
    http:
      dns_server: 10.96.0.10:53
      dns_timeout: 10s
  tcp_connect:
    prober: tcp
    tcp:
      dns_server: 10.96.0.10:53
      dns_timeout: 10s
  grpc:
    prober: grpc
    grpc:
      dns_server: 10.96.0.10:53
      dns_timeout: 10s
```

This PR has been running stably in Kubernetes clusters spanning **hundreds to thousands of** physical machines and has operated continuously **for over a year**. The code and operational experience have undergone rigorous production-level validation.

I hope this will be helpful to others. @electron0zero , @anionDev , @RorFis , @darioef , @snaar


