### PR TITLE
Make default HTTP User-Agent compliant with RFC9110

### DIFF
--- a/prober/http.go
+++ b/prober/http.go
@@ -292,7 +292,7 @@ func (bc *byteCounter) Read(p []byte) (int, error) {
 	return n, err
 }
 
-var userAgentDefaultHeader = fmt.Sprintf("Blackbox Exporter/%s", version.Version)
+var userAgentDefaultHeader = fmt.Sprintf("Blackbox-Exporter/%s", version.Version)
 
 func ProbeHTTP(ctx context.Context, target string, module config.Module, registry *prometheus.Registry, logger *slog.Logger) (success bool) {
 	var redirects int

--- a/prober/http_test.go
+++ b/prober/http_test.go
@@ -1393,7 +1393,7 @@ func TestFailIfHeaderNotMatchesRegexp(t *testing.T) {
 func TestHTTPHeaders(t *testing.T) {
 	headers := map[string]string{
 		"Host":            "my-secret-vhost.com",
-		"User-Agent":      "unsuspicious user",
+		"User-Agent":      "unsuspicious-user",
 		"Accept-Language": "en-US",
 	}
 	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {


### PR DESCRIPTION
Looking at an NGINX access log I noticed that the default user-agent doesn't follow HTTP Semantics (RFC9110)

RFC9110 section 10.1.5 (User-Agent) defines that a user-agent consists of tokens (section 5.6.2). The space character is not part of the product token, but reserved for other cases, therefore changing the user-agent to `Blackbox-Exporter/<product-version>`,
 Example: `Blackbox-Exporter/0.27.0`.