### PR TITLE
http: add accept_any_response option to treat any HTTP status as success

### DIFF
--- a/CONFIGURATION.md
+++ b/CONFIGURATION.md
@@ -50,6 +50,9 @@ modules:
   # Accepted status codes for this probe. List between square brackets. Defaults to 2xx.
   [ valid_status_codes: [<int>, ...] | default = 2xx ]
 
+  # Consider any HTTP status code (1xx–5xx) as a successful probe before applying other checks.
+  [ accept_any_response: <boolean> | default = false ]
+
   # Accepted HTTP versions for this probe.
   [ valid_http_versions: <string>, ... ]
 

--- a/config/config.go
+++ b/config/config.go
@@ -314,6 +314,8 @@ type HTTPProbe struct {
 	Compression                  string                  `yaml:"compression,omitempty"`
 	BodySizeLimit                units.Base2Bytes        `yaml:"body_size_limit,omitempty"`
 	UseHTTP3                     bool                    `yaml:"enable_http3,omitempty"`
+    // When true, any HTTP status code (1xx-5xx) is considered successful prior to further validations.
+    AcceptAnyResponse            bool                    `yaml:"accept_any_response,omitempty"`
 }
 
 type GRPCProbe struct {

--- a/example.yml
+++ b/example.yml
@@ -48,6 +48,13 @@ modules:
       headers:
         Content-Type: application/json
       body: '{}'
+  http_any_response_example:
+    prober: http
+    timeout: 5s
+    http:
+      # Treat any HTTP status code as success prior to body/header checks
+      accept_any_response: true
+      method: GET
   http_post_body_file:
     prober: http
     timeout: 5s

--- a/prober/http.go
+++ b/prober/http.go
@@ -587,8 +587,11 @@ func ProbeHTTP(ctx context.Context, target string, module config.Module, registr
 	} else {
 		requestErrored := (err != nil)
 
-		logger.Debug("Received HTTP response", "status_code", resp.StatusCode)
-		if len(httpConfig.ValidStatusCodes) != 0 {
+        logger.Debug("Received HTTP response", "status_code", resp.StatusCode)
+        if httpConfig.AcceptAnyResponse {
+            success = true
+            logger.Debug("Accepting any HTTP response due to accept_any_response setting", "status_code", resp.StatusCode)
+        } else if len(httpConfig.ValidStatusCodes) != 0 {
 			for _, code := range httpConfig.ValidStatusCodes {
 				if resp.StatusCode == code {
 					success = true


### PR DESCRIPTION
Introduces new optional boolean http.accept_any_response. When enabled any HTTP status (1xx-5xx) is treated as success before header body CEL checks. Rationale: reduce false negatives when non-2xx are acceptable. Changes: add field to HTTPProbe, update prober/http.go, docs and example. Backward compatibility: opt in only. Tests: cover non-2xx with flag on and keep validations.