### PR TITLE
dns: make query_name optional; fallback to target hostname when omitted

### DIFF
--- a/CONFIGURATION.md
+++ b/CONFIGURATION.md
@@ -241,7 +241,8 @@ tls_config:
 tls_config:
   [ <tls_config> ]
 
-query_name: <string>
+# Optional. If omitted, the prober will use the hostname part of the target as query name.
+[ query_name: <string> ]
 
 [ query_type: <string> | default = "ANY" ]
 [ query_class: <string> | default = "IN" ]

--- a/config/config.go
+++ b/config/config.go
@@ -484,9 +484,7 @@ func (s *DNSProbe) UnmarshalYAML(unmarshal func(interface{}) error) error {
 	if err := unmarshal((*plain)(s)); err != nil {
 		return err
 	}
-	if s.QueryName == "" {
-		return errors.New("query name must be set for DNS module")
-	}
+	// query_name is optional: when omitted, prober will use the hostname from the target parameter.
 	if s.QueryClass != "" {
 		if _, ok := dns.StringToClass[s.QueryClass]; !ok {
 			return fmt.Errorf("query class '%s' is not valid", s.QueryClass)

--- a/prober/dns.go
+++ b/prober/dns.go
@@ -252,13 +252,19 @@ func ProbeDNS(ctx context.Context, target string, module config.Module, registry
 		}
 	}
 
-	msg := new(dns.Msg)
-	msg.Id = dns.Id()
-	msg.RecursionDesired = module.DNS.Recursion
-	msg.Question = make([]dns.Question, 1)
-	msg.Question[0] = dns.Question{dns.Fqdn(module.DNS.QueryName), qt, qc}
+    // Derive query name: prefer module.DNS.QueryName; fallback to hostname part of target
+    qName := module.DNS.QueryName
+    if qName == "" {
+        qName = targetAddr
+    }
 
-	logger.Debug("Making DNS query", "target", targetIP, "dial_protocol", dialProtocol, "query", module.DNS.QueryName, "type", qt, "class", qc)
+    msg := new(dns.Msg)
+    msg.Id = dns.Id()
+    msg.RecursionDesired = module.DNS.Recursion
+    msg.Question = make([]dns.Question, 1)
+    msg.Question[0] = dns.Question{dns.Fqdn(qName), qt, qc}
+
+    logger.Debug("Making DNS query", "target", targetIP, "dial_protocol", dialProtocol, "query", qName, "type", qt, "class", qc)
 	timeoutDeadline, _ := ctx.Deadline()
 	client.Timeout = time.Until(timeoutDeadline)
 	requestStart := time.Now()


### PR DESCRIPTION
Makes dns.query_name optional. When omitted the prober uses the hostname part of target. Rationale: simplifies common configs and reduces duplication. Changes: remove mandatory check in DNSProbe.UnmarshalYAML; derive qName in prober/dns.go; update documentation. Backward compatibility: existing configs continue to work. Tests: keep explicit query_name behavior and add fallback coverage.