### PR TITLE
feat: http 'source_interface' parameter

### DIFF
--- a/README.md
+++ b/README.md
@@ -238,6 +238,21 @@ scrape_configs:
         target_label: vhost  # and store it in 'vhost' label
 ```
 
+HTTP probes can also limit themselves to a particular
+interface with the `source_interface` parameter. This
+feature works only for 'regular' (non-HTTP3) HTTP
+probes, is likely Linux-specific and may require you
+to disable return-path (rp) filtering in the network
+configuration of the host on which blackbox runs:
+
+```
+modules:
+  http_2xx:
+    prober: http
+    http:
+      source_interface: wlan0
+```
+
 ## Permissions
 
 The ICMP probe requires elevated privileges to function:

--- a/config/config.go
+++ b/config/config.go
@@ -303,6 +303,7 @@ type HTTPProbe struct {
 	ValidHTTPVersions            []string                `yaml:"valid_http_versions,omitempty"`
 	IPProtocol                   string                  `yaml:"preferred_ip_protocol,omitempty"`
 	IPProtocolFallback           bool                    `yaml:"ip_protocol_fallback,omitempty"`
+	SourceInterface              string                  `yaml:"source_interface,omitempty"`
 	SkipResolvePhaseWithProxy    bool                    `yaml:"skip_resolve_phase_with_proxy,omitempty"`
 	NoFollowRedirects            *bool                   `yaml:"no_follow_redirects,omitempty"`
 	FailIfSSL                    bool                    `yaml:"fail_if_ssl,omitempty"`

--- a/config/testdata/blackbox-good.yml
+++ b/config/testdata/blackbox-good.yml
@@ -3,6 +3,7 @@ modules:
     prober: http
     timeout: 5s
     http:
+      source_interface: wlan0
   http_post_2xx:
     prober: http
     timeout: 5s

--- a/prober/http.go
+++ b/prober/http.go
@@ -427,6 +427,7 @@ func ProbeHTTP(ctx context.Context, target string, module config.Module, registr
 			}
 		}
 	}
+
 	var client *http.Client
 	var noServerName http.RoundTripper
 
@@ -455,7 +456,15 @@ func ProbeHTTP(ctx context.Context, target string, module config.Module, registr
 
 	} else {
 		// For standard HTTP/HTTPS, create client from config
-		client, err = pconfig.NewClientFromConfig(httpClientConfig, "http_probe", pconfig.WithKeepAlivesDisabled())
+		httpClientOptions := []pconfig.HTTPClientOption{
+			pconfig.WithKeepAlivesDisabled(),
+		}
+
+		if len(module.HTTP.SourceInterface) > 0 {
+			httpClientOptions = BindToInterface(httpClientOptions, module.HTTP.SourceInterface, logger)
+		}
+
+		client, err = pconfig.NewClientFromConfig(httpClientConfig, "http_probe", httpClientOptions...)
 		if err != nil {
 			logger.Error("Error generating HTTP client", "err", err)
 			return false
@@ -466,7 +475,7 @@ func ProbeHTTP(ctx context.Context, target string, module config.Module, registr
 		serverNamelessConfig := httpClientConfig
 		serverNamelessConfig.TLSConfig.ServerName = ""
 
-		noServerName, err = pconfig.NewRoundTripperFromConfig(serverNamelessConfig, "http_probe", pconfig.WithKeepAlivesDisabled())
+		noServerName, err = pconfig.NewRoundTripperFromConfig(serverNamelessConfig, "http_probe", httpClientOptions...)
 		if err != nil {
 			logger.Error("Error generating HTTP client without ServerName", "err", err)
 			return false

--- a/prober/http_linux.go
+++ b/prober/http_linux.go
@@ -1,0 +1,41 @@
+// Copyright 2025 The Prometheus Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//go:build linux
+
+package prober
+
+import (
+	pconfig "github.com/prometheus/common/config"
+	"log/slog"
+	"net"
+	"syscall"
+)
+
+func BindToInterface(options []pconfig.HTTPClientOption, sourceInterface string, _ *slog.Logger) []pconfig.HTTPClientOption {
+	return append(options,
+		pconfig.WithDialContextFunc((&net.Dialer{
+			Control: func(network, address string, c syscall.RawConn) error {
+				var err error
+				c.Control(func(fd uintptr) {
+					err = syscall.SetsockoptString(
+						int(fd),
+						syscall.SOL_SOCKET,
+						syscall.SO_BINDTODEVICE,
+						sourceInterface,
+					)
+				})
+				return err
+			},
+		}).DialContext))
+}

--- a/prober/http_nonlinux.go
+++ b/prober/http_nonlinux.go
@@ -1,0 +1,26 @@
+// Copyright 2025 The Prometheus Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//go:build !linux
+
+package prober
+
+import (
+	pconfig "github.com/prometheus/common/config"
+	"log/slog"
+)
+
+func BindToInterface(options []pconfig.HTTPClientOption, _ string, logger *slog.Logger) []pconfig.HTTPClientOption {
+	logger.Error("Binding to a specific interface is only supported on Linux")
+	return options
+}


### PR DESCRIPTION
#### What this PR does / Which issue(s) does the PR fix:

Add a 'source_interface' parameter to the 'http' probe

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-notes block below.
Otherwise, please describe what should be mentioned in the CHANGELOG. Use the following prefixes:
[FEATURE] [ENHANCEMENT] [PERF] [BUGFIX] [SECURITY] [CHANGE]
Refer to the existing CHANGELOG for inspiration: https://github.com/prometheus/blackbox_exporter/blob/master/CHANGELOG.md
If you need help formulating your entries, consult the reviewer(s).
-->
```release-notes
[FEATURE] allow restricting the HTTP probe to a given network interface
```

Sadly I didn't see a clear way to meaningfully test this feature.

**Checklist**
- [ ] Tests updated
- [x] Documentation added
- [x] CHANGELOG added in `release-notes` section of PR Desc.
