### PR TITLE
logs: label 'target' cannot be used at it is already defined by default. Renaming it in 'name'

### DIFF
--- a/prober/dns.go
+++ b/prober/dns.go
@@ -258,7 +258,7 @@ func ProbeDNS(ctx context.Context, target string, module config.Module, registry
 	msg.Question = make([]dns.Question, 1)
 	msg.Question[0] = dns.Question{Name: dns.Fqdn(module.DNS.QueryName), Qtype: qt, Qclass: qc}
 
-	logger.Debug("Making DNS query", "target", targetIP, "dial_protocol", dialProtocol, "query", module.DNS.QueryName, "type", qt, "class", qc)
+	logger.Debug("Making DNS query", "name", targetIP, "dial_protocol", dialProtocol, "query", module.DNS.QueryName, "type", qt, "class", qc)
 	timeoutDeadline, _ := ctx.Deadline()
 	client.Timeout = time.Until(timeoutDeadline)
 	requestStart := time.Now()

--- a/prober/utils.go
+++ b/prober/utils.go
@@ -58,7 +58,7 @@ func chooseProtocol(ctx context.Context, IPProtocol string, fallbackIPProtocol b
 		fallbackProtocol = "ip6"
 	}
 
-	logger.Debug("Resolving target address", "target", target, "ip_protocol", IPProtocol)
+	logger.Debug("Resolving target address", "name", target, "ip_protocol", IPProtocol)
 	resolveStart := time.Now()
 
 	defer func() {
@@ -71,19 +71,19 @@ func chooseProtocol(ctx context.Context, IPProtocol string, fallbackIPProtocol b
 		ips, err := resolver.LookupIP(ctx, IPProtocol, target)
 		if err == nil {
 			for _, ip := range ips {
-				logger.Debug("Resolved target address", "target", target, "ip", ip.String())
+				logger.Debug("Resolved target address", "name", target, "ip", ip.String())
 				probeIPProtocolGauge.Set(protocolToGauge[IPProtocol])
 				probeIPAddrHash.Set(ipHash(ip))
 				return &net.IPAddr{IP: ip}, lookupTime, nil
 			}
 		}
-		logger.Error("Resolution with IP protocol failed", "target", target, "ip_protocol", IPProtocol, "err", err)
+		logger.Error("Resolution with IP protocol failed", "name", target, "ip_protocol", IPProtocol, "err", err)
 		return nil, 0.0, err
 	}
 
 	ips, err := resolver.LookupIPAddr(ctx, target)
 	if err != nil {
-		logger.Error("Resolution with IP protocol failed", "target", target, "err", err)
+		logger.Error("Resolution with IP protocol failed", "name", target, "err", err)
 		return nil, 0.0, err
 	}
 
@@ -93,7 +93,7 @@ func chooseProtocol(ctx context.Context, IPProtocol string, fallbackIPProtocol b
 		switch IPProtocol {
 		case "ip4":
 			if ip.IP.To4() != nil {
-				logger.Debug("Resolved target address", "target", target, "ip", ip.String())
+				logger.Debug("Resolved target address", "name", target, "ip", ip.String())
 				probeIPProtocolGauge.Set(4)
 				probeIPAddrHash.Set(ipHash(ip.IP))
 				return &ip, lookupTime, nil
@@ -104,7 +104,7 @@ func chooseProtocol(ctx context.Context, IPProtocol string, fallbackIPProtocol b
 
 		case "ip6":
 			if ip.IP.To4() == nil {
-				logger.Debug("Resolved target address", "target", target, "ip", ip.String())
+				logger.Debug("Resolved target address", "name", target, "ip", ip.String())
 				probeIPProtocolGauge.Set(6)
 				probeIPAddrHash.Set(ipHash(ip.IP))
 				return &ip, lookupTime, nil
@@ -127,7 +127,7 @@ func chooseProtocol(ctx context.Context, IPProtocol string, fallbackIPProtocol b
 		probeIPProtocolGauge.Set(6)
 	}
 	probeIPAddrHash.Set(ipHash(fallback.IP))
-	logger.Debug("Resolved target address", "target", target, "ip", fallback.String())
+	logger.Debug("Resolved target address", "name", target, "ip", fallback.String())
 	return fallback, lookupTime, nil
 }
 


### PR DESCRIPTION

#### What this PR does / Which issue(s) does the PR fix:

The prober logger contains by default a label 'module' and a label 'target', which contains contextual information related to the current module/target.
Some logs related to dns explicitly specifies a label 'target', and consequently overrides the content of the default label 'target' and make log correlation difficult.
The aim of this PR if to fix this: using another label name, the label 'target' will have a consistant value and simplify log correlation.

##### example

before the fix:
```
time=2026-01-08T10:19:33.736Z level=INFO source=handler.go:123 msg="Beginning probe" module=http-xxx target=https://www.example.com/api/health probe=http timeout_seconds=5
time=2026-01-08T10:19:33.737Z level=INFO source=utils.go:61 msg="Resolving target address" module=http-xxx target=www.example.com ip_protocol=ip4
time=2026-01-08T10:19:33.739Z level=INFO source=utils.go:74 msg="Resolved target address" module=http-xxx target=www.example.com ip=104.18.26.120
time=2026-01-08T10:19:33.740Z level=INFO source=http.go:207 msg="Making HTTP request" module=http-xxx target=https://www.example.com/api/health url=https://104.18.26.120/api/health host=www.example.com
time=2026-01-08T10:19:33.749Z level=INFO source=http.go:542 msg="Received HTTP response" module=http-xxx target=https://www.example.com/api/health status_code=200
time=2026-01-08T10:19:33.749Z level=INFO source=http.go:673 msg="Response timings for roundtrip" module=http-xxx target=https://www.example.com/api/health roundtrip=0 start=2026-01-08T10:19:33.740Z dnsDone=2026-01-08T10:19:33.740Z connectDone=2026-01-08T10:19:33.741Z gotConn=2026-01-08T10:19:33.745Z responseStart=2026-01-08T10:19:33.749Z tlsStart=2026-01-08T10:19:33.741Z tlsDone=2026-01-08T10:19:33.745Z end=2026-01-08T10:19:33.749Z
time=2026-01-08T10:19:33.749Z level=INFO source=handler.go:134 msg="Probe succeeded" module=http-xxx target=https://www.example.com/api/health duration_seconds=0.012727658
```

->
the logs generated by the prober have target=https://www.example.com/api/health
the logs produced by utils.go have target=www.example.com
->
label target is not consistant.
it is hard to correlate logs.


after the fix:
```
time=2026-01-08T10:19:33.736Z level=INFO source=handler.go:123 msg="Beginning probe" module=http-xxx target=https://www.example.com/api/health probe=http timeout_seconds=5
time=2026-01-08T10:19:33.737Z level=INFO source=utils.go:61 msg="Resolving target address" module=http-xxx target=https://www.example.com/api/health name=www.example.com ip_protocol=ip4
time=2026-01-08T10:19:33.739Z level=INFO source=utils.go:74 msg="Resolved target address" module=http-xxx target=https://www.example.com/api/health name=www.example.com ip=104.18.26.120
time=2026-01-08T10:19:33.740Z level=INFO source=http.go:207 msg="Making HTTP request" module=http-xxx target=https://www.example.com/api/health url=https://104.18.26.120/api/health host=www.example.com
time=2026-01-08T10:19:33.749Z level=INFO source=http.go:542 msg="Received HTTP response" module=http-xxx target=https://www.example.com/api/health status_code=200
time=2026-01-08T10:19:33.749Z level=INFO source=http.go:673 msg="Response timings for roundtrip" module=http-xxx target=https://www.example.com/api/health roundtrip=0 start=2026-01-08T10:19:33.740Z dnsDone=2026-01-08T10:19:33.740Z connectDone=2026-01-08T10:19:33.741Z gotConn=2026-01-08T10:19:33.745Z responseStart=2026-01-08T10:19:33.749Z tlsStart=2026-01-08T10:19:33.741Z tlsDone=2026-01-08T10:19:33.745Z end=2026-01-08T10:19:33.749Z
time=2026-01-08T10:19:33.749Z level=INFO source=handler.go:134 msg="Probe succeeded" module=http-xxx target=https://www.example.com/api/health duration_seconds=0.012727658
```
->
the logs generated by the prober have target=https://www.example.com/api/health
the logs produced by utils.go have target=https://www.example.com/api/health (and name=www.example.com)
->
label target is consistant.
it is simple to correlate logs.


#### Does this PR introduce a user-facing change?
not at all

**Checklist**
- [ ] Tests updated (N/A)
- [ ] Documentation added (N/A)
- [ ] CHANGELOG added in `release-notes` section of PR Desc. (N/A)
