### PR TITLE
prober: randomize ICMP echo identifier to avoid SNAT session collision

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ BREAKING CHANGES:
 * [FEATURE]
 * [ENHANCEMENT]
 * [BUGFIX]
+* [BUGFIX] Randomize ICMP Echo ID in probes to avoid SNAT session collisions that could drop replies for some clients.
 
 ## 0.28.0 / 2025-12-04
 


### PR DESCRIPTION
<!--
    - Please give your PR a title in the form "area: short description".  For example "prober: adding metric to expose certificate fingerprint info"

    - Please sign CNCF's Developer Certificate of Origin and sign-off your commits by adding the -s / --signoff flag to `git commit`. See https://github.com/apps/dco for more information.

    - If the PR adds or changes a behaviour or fixes a bug of an exported API it would need a unit test.

    - Where possible use only exported APIs for tests to simplify the review and make it as close as possible to an actual library usage.

    - Performance improvements would need a benchmark test to prove it.

    - All exposed objects should have a comment. More at https://tip.golang.org/doc/comment

    - All comments should start with a capital letter and end with a full stop.
 -->

#### What this PR does / Which issue(s) does the PR fix:
This PR randomizes the ICMP Echo Identifier used by the blackbox exporter when sending ICMP probes.

In the current implementation, ICMP Echo Requests are sent with a fixed identifier. Since ICMP does not have a port concept, some SNAT implementations rely on the ICMP identifier to build session mappings.

When multiple clients behind the same SNAT send ICMP probes with the same ICMP identifier to the same destination:

- The SNAT device may create colliding sessions.

- ICMP Echo Replies from the server can be matched to the wrong client.

- One client may receive no reply, while another client may receive multiple replies and drop those with mismatched destinations.

By randomizing the ICMP Echo Identifier per probe, each ICMP flow becomes distinguishable at the SNAT layer, avoiding session collisions and ensuring that replies are correctly delivered to the originating client.

This change fixes ICMP probe failures observed in SNAT environments with multiple concurrent clients.


#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-notes block below.
Otherwise, please describe what should be mentioned in the CHANGELOG. Use the following prefixes:
[FEATURE] [ENHANCEMENT] [PERF] [BUGFIX] [SECURITY] [CHANGE]
Refer to the existing CHANGELOG for inspiration: https://github.com/prometheus/blackbox_exporter/blob/master/CHANGELOG.md
If you need help formulating your entries, consult the reviewer(s).
-->
```release-notes
[BUGFIX] Randomize ICMP Echo Identifier to avoid SNAT session collisions when multiple clients send ICMP probes concurrently.
```


<!--  Thanks for sending a pull request!  Before submitting:
1. Rebase your PR if it gets out of sync with main
2. Add tests for your changes
3. If relevant, update the docs (README.md or CONFIGURATION.md) and example in example.yml
-->

**Checklist**
- [x] Tests updated
- [x] Documentation added
- [x] CHANGELOG added in `release-notes` section of PR Desc.
