### PR TITLE
fix: return on grpc.NewClient error and propagate probe context

### DIFF
--- a/prober/grpc.go
+++ b/prober/grpc.go
@@ -188,11 +188,12 @@ func ProbeGRPC(ctx context.Context, target string, module config.Module, registr
 
 	if err != nil {
 		logger.Error("did not connect", "err", err)
+		return false
 	}
 
 	client := NewGrpcHealthCheckClient(conn)
 	defer conn.Close()
-	ok, statusCode, serverPeer, servingStatus, err := client.Check(context.Background(), module.GRPC.Service, md)
+	ok, statusCode, serverPeer, servingStatus, err := client.Check(ctx, module.GRPC.Service, md)
 	durationGaugeVec.WithLabelValues("check").Add(time.Since(checkStart).Seconds())
 
 	for servingStatusName := range grpc_health_v1.HealthCheckResponse_ServingStatus_value {


### PR DESCRIPTION
Two fixes in ProbeGRPC:
1. When grpc.NewClient returns an error, execution continued into
   a nil conn, causing a panic. Add 'return false' after the error.
2. client.Check used context.Background() instead of the probe ctx,
   bypassing the scrape timeout. Use ctx to honor the deadline.

Signed-off-by: Aprazors <Aprazors@gmail.com>