### PR TITLE
fix: use correct error variable in unix TLS error path

### DIFF
--- a/prober/unix.go
+++ b/prober/unix.go
@@ -41,8 +41,8 @@ func dialUnix(ctx context.Context, target string, module config.Module, registry
 	} else {
 		tlsConfig, tlsErr := pconfig.NewTLSConfig(&module.Unix.TLSConfig)
 		if tlsErr != nil {
-			logger.Error("Error creating TLS configuration", "err", err)
-			return nil, err
+			logger.Error("Error creating TLS configuration", "err", tlsErr)
+			return nil, tlsErr
 		}
 
 		timeoutDeadline, _ := ctx.Deadline()


### PR DESCRIPTION
The error path logged and returned 'err' (nil) instead of 'tlsErr',
silently swallowing TLS configuration failures and causing the caller
to proceed with a nil connection.

Signed-off-by: Aprazors <Aprazors@gmail.com>