### PR TITLE
fix: replace time.Tick with time.NewTicker to prevent goroutine leak

### DIFF
--- a/main.go
+++ b/main.go
@@ -143,6 +143,8 @@ func run() int {
 	reloadCh := make(chan chan error)
 	signal.Notify(hup, syscall.SIGHUP)
 	go func() {
+		autoReloadTicker := time.NewTicker(time.Duration(*autoReloadInterval) * time.Second)
+		defer autoReloadTicker.Stop()
 		for {
 			select {
 			case <-hup:
@@ -159,7 +161,7 @@ func run() int {
 					logger.Info("Reloaded config file")
 					rc <- nil
 				}
-			case <-time.Tick(time.Duration(*autoReloadInterval) * time.Second):
+			case <-autoReloadTicker.C:
 				if !*enableAutoReload {
 					continue
 				}


### PR DESCRIPTION
time.Tick inside a select creates a new ticker on every loop iteration
that is never stopped. Replace with a single NewTicker created before
the loop with defer Stop() for proper cleanup.

Signed-off-by: Aprazors <Aprazors@gmail.com>