### PR TITLE
fix: prevent panic with multiple labels in tcp query_response

### DIFF
--- a/prober/query_response.go
+++ b/prober/query_response.go
@@ -28,21 +28,15 @@ import (
 	"github.com/prometheus/blackbox_exporter/config"
 )
 
-func probeExpectInfo(registry *prometheus.Registry, qr *config.QueryResponse, bytes []byte, match []int) {
-	var names []string
-	var values []string
+func probeExpectInfo(metric *prometheus.GaugeVec, allLabelNames []string, qr *config.QueryResponse, content []byte, match []int) {
+	labelValues := make(map[string]string)
 	for _, s := range qr.Labels {
-		names = append(names, s.Name)
-		values = append(values, string(qr.Expect.Expand(nil, []byte(s.Value), bytes, match)))
+		labelValues[s.Name] = string(qr.Expect.Expand(nil, []byte(s.Value), content, match))
 	}
-	metric := prometheus.NewGaugeVec(
-		prometheus.GaugeOpts{
-			Name: "probe_expect_info",
-			Help: "Explicit content matched",
-		},
-		names,
-	)
-	registry.MustRegister(metric)
+	var values []string
+	for _, name := range allLabelNames {
+		values = append(values, labelValues[name])
+	}
 	metric.WithLabelValues(values...).Set(1)
 }
 
@@ -101,6 +95,29 @@ func probeQueryResponses(ctx context.Context, target string, conn net.Conn, modu
 		probeSSLLastInformation.WithLabelValues(getFingerprint(&state), getSubject(&state), getIssuer(&state), getDNSNames(&state), getSerialNumber(&state)).Set(1)
 	}
 
+	// Collect all unique label names from query_response entries that have labels.
+	var allLabelNames []string
+	seen := make(map[string]bool)
+	for _, qr := range queryResponses {
+		for _, l := range qr.Labels {
+			if !seen[l.Name] {
+				seen[l.Name] = true
+				allLabelNames = append(allLabelNames, l.Name)
+			}
+		}
+	}
+	var probeExpectInfoMetric *prometheus.GaugeVec
+	if len(allLabelNames) > 0 {
+		probeExpectInfoMetric = prometheus.NewGaugeVec(
+			prometheus.GaugeOpts{
+				Name: "probe_expect_info",
+				Help: "Explicit content matched",
+			},
+			allLabelNames,
+		)
+		registry.MustRegister(probeExpectInfoMetric)
+	}
+
 	scanner := bufio.NewScanner(conn)
 	for i, qr := range queryResponses {
 		logger.Debug("Processing query response entry", "entry_number", i)
@@ -128,7 +145,7 @@ func probeQueryResponses(ctx context.Context, target string, conn net.Conn, modu
 			probeFailedDueToRegex.Set(0)
 			send = string(qr.Expect.Expand(nil, []byte(send), scanner.Bytes(), match))
 			if qr.Labels != nil {
-				probeExpectInfo(registry, &qr, scanner.Bytes(), match)
+				probeExpectInfo(probeExpectInfoMetric, allLabelNames, &qr, scanner.Bytes(), match)
 			}
 		}
 		if qr.ExpectBytes != "" {

--- a/prober/tcp_test.go
+++ b/prober/tcp_test.go
@@ -790,7 +790,6 @@ func TestPrometheusTimeoutTCP(t *testing.T) {
 }
 
 func TestProbeExpectInfo(t *testing.T) {
-	registry := prometheus.NewRegistry()
 	qr := config.QueryResponse{
 		Expect: config.MustNewRegexp("^SSH-2.0-([^ -]+)(?: (.*))?$"),
 		Labels: []config.Label{
@@ -804,10 +803,20 @@ func TestProbeExpectInfo(t *testing.T) {
 			},
 		},
 	}
-	bytes := []byte("SSH-2.0-OpenSSH_6.9p1 Debian-2")
-	match := qr.Expect.FindSubmatchIndex(bytes)
+	allLabelNames := []string{"label1", "label2"}
+	registry := prometheus.NewRegistry()
+	metric := prometheus.NewGaugeVec(
+		prometheus.GaugeOpts{
+			Name: "probe_expect_info",
+			Help: "Explicit content matched",
+		},
+		allLabelNames,
+	)
+	registry.MustRegister(metric)
+	content := []byte("SSH-2.0-OpenSSH_6.9p1 Debian-2")
+	match := qr.Expect.FindSubmatchIndex(content)
 
-	probeExpectInfo(registry, &qr, bytes, match)
+	probeExpectInfo(metric, allLabelNames, &qr, content, match)
 
 	mfs, err := registry.Gather()
 	if err != nil {
@@ -821,5 +830,96 @@ func TestProbeExpectInfo(t *testing.T) {
 		},
 	}
 	checkRegistryLabels(expectedLabels, mfs, t)
+}
 
+func TestTCPConnectionQueryResponseMultipleLabels(t *testing.T) {
+	ln, err := net.Listen("tcp", "localhost:0")
+	if err != nil {
+		t.Fatalf("Error listening on socket: %s", err)
+	}
+	defer ln.Close()
+
+	testCTX, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+	time.Sleep(time.Millisecond * 100)
+	module := config.Module{
+		TCP: config.TCPProbe{
+			IPProtocolFallback: true,
+			QueryResponse: []config.QueryResponse{
+				{
+					Expect: config.MustNewRegexp("^HELLO ([^ ]+)$"),
+					Send:   "ACK",
+					Labels: []config.Label{
+						{
+							Name:  "greeting_name",
+							Value: "${1}",
+						},
+					},
+				},
+				{
+					Expect: config.MustNewRegexp("^VERSION ([^ ]+)$"),
+					Send:   "BYE",
+					Labels: []config.Label{
+						{
+							Name:  "server_version",
+							Value: "${1}",
+						},
+					},
+				},
+			},
+		},
+	}
+
+	go func() {
+		conn, err := ln.Accept()
+		if err != nil {
+			panic(fmt.Sprintf("Error accepting on socket: %s", err))
+		}
+		conn.SetDeadline(time.Now().Add(5 * time.Second))
+		fmt.Fprintf(conn, "HELLO world\n")
+		buf := make([]byte, 4)
+		conn.Read(buf)
+		fmt.Fprintf(conn, "VERSION 1.2.3\n")
+		buf2 := make([]byte, 4)
+		conn.Read(buf2)
+		conn.Close()
+	}()
+
+	registry := prometheus.NewRegistry()
+	if !ProbeTCP(testCTX, ln.Addr().String(), module, registry, promslog.NewNopLogger()) {
+		t.Fatalf("TCP module failed, expected success.")
+	}
+
+	mfs, err := registry.Gather()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Both label sets should be present in probe_expect_info.
+	// The first match sets greeting_name="world", server_version="".
+	// The second match sets greeting_name="", server_version="1.2.3".
+	found := map[string]bool{}
+	for _, mf := range mfs {
+		if mf.GetName() != "probe_expect_info" {
+			continue
+		}
+		for _, m := range mf.GetMetric() {
+			labels := map[string]string{}
+			for _, lp := range m.GetLabel() {
+				labels[lp.GetName()] = lp.GetValue()
+			}
+			if labels["greeting_name"] == "world" && labels["server_version"] == "" {
+				found["first"] = true
+			}
+			if labels["greeting_name"] == "" && labels["server_version"] == "1.2.3" {
+				found["second"] = true
+			}
+		}
+	}
+	if !found["first"] {
+		t.Error("Expected probe_expect_info with greeting_name=world not found")
+	}
+	if !found["second"] {
+		t.Error("Expected probe_expect_info with server_version=1.2.3 not found")
+	}
 }


### PR DESCRIPTION
## Summary

Fixes prometheus/blackbox_exporter#1526

## Root Cause

In `prober/query_response.go`, `probeExpectInfo` created and registered a new `probe_expect_info` GaugeVec with `registry.MustRegister()` on each invocation. When multiple `query_response` entries had `labels:` blocks with **different** label names, the second call panicked because a metric with the same name but different label names was already registered.

## Fix

Pre-scan all `queryResponses` entries before the loop to collect all unique label names from entries that have `Labels`. Create the `probe_expect_info` GaugeVec **once** with all collected label names and register it once. Pass this pre-created GaugeVec into `probeExpectInfo` instead of the registry.

Inside `probeExpectInfo`, build a map of the current entry's label values and iterate over `allLabelNames` to produce the full values slice, using empty strings for labels not present in the current entry.

This is backward-compatible: single-entry configs behave identically to before.

## Testing

Added `TestTCPConnectionQueryResponseMultipleLabels` in `prober/tcp_test.go` that exercises two `query_response` entries with different label names (`greeting_name` and `server_version`). The test verifies the probe completes without panic and both label sets appear in the `probe_expect_info` metric output.