### PR TITLE
[ENHANCEMENT] Unified SSL metrics registry

### DIFF
--- a/prober/grpc.go
+++ b/prober/grpc.go
@@ -99,21 +99,6 @@ func ProbeGRPC(ctx context.Context, target string, module config.Module, registr
 			Name: "probe_grpc_healthcheck_response",
 			Help: "Response HealthCheck response",
 		}, []string{"serving_status"})
-
-		probeSSLEarliestCertExpiryGauge = prometheus.NewGauge(sslEarliestCertExpiryGaugeOpts)
-
-		probeTLSVersion = prometheus.NewGaugeVec(
-			probeTLSInfoGaugeOpts,
-			[]string{"version"},
-		)
-
-		probeSSLLastInformation = prometheus.NewGaugeVec(
-			prometheus.GaugeOpts{
-				Name: "probe_ssl_last_chain_info",
-				Help: "Contains SSL leaf certificate information",
-			},
-			[]string{"fingerprint_sha256", "subject", "issuer", "subjectalternative", "serialnumber"},
-		)
 	)
 
 	for _, lv := range []string{"resolve"} {
@@ -205,11 +190,9 @@ func ProbeGRPC(ctx context.Context, target string, module config.Module, registr
 	if serverPeer != nil {
 		tlsInfo, tlsOk := serverPeer.AuthInfo.(credentials.TLSInfo)
 		if tlsOk {
-			registry.MustRegister(probeSSLEarliestCertExpiryGauge, probeTLSVersion, probeSSLLastInformation)
 			isSSLGauge.Set(float64(1))
-			probeSSLEarliestCertExpiryGauge.Set(float64(getEarliestCertExpiry(&tlsInfo.State).Unix()))
-			probeTLSVersion.WithLabelValues(getTLSVersion(&tlsInfo.State)).Set(1)
-			probeSSLLastInformation.WithLabelValues(getFingerprint(&tlsInfo.State), getSubject(&tlsInfo.State), getIssuer(&tlsInfo.State), getDNSNames(&tlsInfo.State), getSerialNumber(&tlsInfo.State)).Set(1)
+			tlsMetrics := registerTLSMetrics(registry)
+			setTLSMetrics(&tlsInfo.State, tlsMetrics)
 		} else {
 			isSSLGauge.Set(float64(0))
 		}

--- a/prober/http.go
+++ b/prober/http.go
@@ -324,28 +324,6 @@ func ProbeHTTP(ctx context.Context, target string, module config.Module, registr
 			Help: "Response HTTP status code",
 		})
 
-		probeSSLEarliestCertExpiryGauge = prometheus.NewGauge(sslEarliestCertExpiryGaugeOpts)
-
-		probeSSLLastChainExpiryTimestampSeconds = prometheus.NewGauge(sslChainExpiryInTimeStampGaugeOpts)
-
-		probeSSLLastInformation = prometheus.NewGaugeVec(
-			prometheus.GaugeOpts{
-				Name: "probe_ssl_last_chain_info",
-				Help: "Contains SSL leaf certificate information",
-			},
-			[]string{"fingerprint_sha256", "subject", "issuer", "subjectalternative", "serialnumber"},
-		)
-
-		probeTLSVersion = prometheus.NewGaugeVec(
-			probeTLSInfoGaugeOpts,
-			[]string{"version"},
-		)
-
-		probeTLSCipher = prometheus.NewGaugeVec(
-			probeTLSCipherGaugeOpts,
-			[]string{"cipher"},
-		)
-
 		probeHTTPVersionGauge = prometheus.NewGauge(prometheus.GaugeOpts{
 			Name: "probe_http_version",
 			Help: "Returns the version of HTTP of the probe response",
@@ -764,12 +742,10 @@ func ProbeHTTP(ctx context.Context, target string, module config.Module, registr
 
 	if resp.TLS != nil {
 		isSSLGauge.Set(float64(1))
-		registry.MustRegister(probeSSLEarliestCertExpiryGauge, probeTLSVersion, probeTLSCipher, probeSSLLastChainExpiryTimestampSeconds, probeSSLLastInformation)
-		probeSSLEarliestCertExpiryGauge.Set(float64(getEarliestCertExpiry(resp.TLS).Unix()))
-		probeTLSVersion.WithLabelValues(getTLSVersion(resp.TLS)).Set(1)
-		probeTLSCipher.WithLabelValues(getTLSCipher(resp.TLS)).Set(1)
-		probeSSLLastChainExpiryTimestampSeconds.Set(float64(getLastChainExpiry(resp.TLS).Unix()))
-		probeSSLLastInformation.WithLabelValues(getFingerprint(resp.TLS), getSubject(resp.TLS), getIssuer(resp.TLS), getDNSNames(resp.TLS), getSerialNumber(resp.TLS)).Set(1)
+
+		tlsMetrics := registerTLSMetrics(registry)
+		setTLSMetrics(resp.TLS, tlsMetrics)
+
 		if httpConfig.FailIfSSL {
 			logger.Error("Final request was over SSL")
 			success = false

--- a/prober/prober.go
+++ b/prober/prober.go
@@ -29,6 +29,7 @@ const (
 	helpSSLChainExpiryInTimeStamp = "Returns last SSL chain expiry in timestamp"
 	helpProbeTLSInfo              = "Returns the TLS version used or NaN when unknown"
 	helpProbeTLSCipher            = "Returns the TLS cipher negotiated during handshake"
+	helpProbeSSLLastInformation   = "Contains SSL leaf certificate information"
 )
 
 var (
@@ -50,5 +51,9 @@ var (
 	probeTLSCipherGaugeOpts = prometheus.GaugeOpts{
 		Name: "probe_tls_cipher_info",
 		Help: helpProbeTLSCipher,
+	}
+	probeSSLLastInformationGaugeOpts = prometheus.GaugeOpts{
+		Name: "probe_ssl_last_chain_info",
+		Help: helpProbeSSLLastInformation,
 	}
 )

--- a/prober/tls.go
+++ b/prober/tls.go
@@ -33,15 +33,6 @@ type TLSMetrics struct {
 	probeTLSCipher                          *prometheus.GaugeVec
 }
 
-type TLSMetricsHelpMessages struct {
-	isTLSGauge                              string
-	probeSSLEarliestCertExpiryGauge         string
-	probeSSLLastChainExpiryTimestampSeconds string
-	probeSSLLastInformation                 string
-	probeTLSVersion                         string
-	probeTLSCipher                          string
-}
-
 func getEarliestCertExpiry(state *tls.ConnectionState) time.Time {
 	earliest := time.Time{}
 	for _, cert := range state.PeerCertificates {

--- a/prober/tls.go
+++ b/prober/tls.go
@@ -20,7 +20,27 @@ import (
 	"fmt"
 	"strings"
 	"time"
+
+	"github.com/prometheus/client_golang/prometheus"
 )
+
+type TLSMetrics struct {
+	isTLSGauge                              *prometheus.Gauge
+	probeSSLEarliestCertExpiryGauge         *prometheus.Gauge
+	probeSSLLastChainExpiryTimestampSeconds *prometheus.Gauge
+	probeSSLLastInformation                 *prometheus.GaugeVec
+	probeTLSVersion                         *prometheus.GaugeVec
+	probeTLSCipher                          *prometheus.GaugeVec
+}
+
+type TLSMetricsHelpMessages struct {
+	isTLSGauge                              string
+	probeSSLEarliestCertExpiryGauge         string
+	probeSSLLastChainExpiryTimestampSeconds string
+	probeSSLLastInformation                 string
+	probeTLSVersion                         string
+	probeTLSCipher                          string
+}
 
 func getEarliestCertExpiry(state *tls.ConnectionState) time.Time {
 	earliest := time.Time{}
@@ -95,4 +115,60 @@ func getTLSVersion(state *tls.ConnectionState) string {
 
 func getTLSCipher(state *tls.ConnectionState) string {
 	return tls.CipherSuiteName(state.CipherSuite)
+}
+
+// registerTLSMetrics registers the TLS metrics for a given registry
+func registerTLSMetrics(registry *prometheus.Registry) *TLSMetrics {
+
+	var (
+		probeSSLEarliestCertExpiryGauge         = prometheus.NewGauge(sslEarliestCertExpiryGaugeOpts)
+		probeSSLLastChainExpiryTimestampSeconds = prometheus.NewGauge(sslChainExpiryInTimeStampGaugeOpts)
+		probeSSLLastInformation                 = prometheus.NewGaugeVec(
+			probeSSLLastInformationGaugeOpts,
+			[]string{"fingerprint_sha256", "subject", "issuer", "subjectalternative", "serialnumber"},
+		)
+		probeTLSVersion = prometheus.NewGaugeVec(
+			probeTLSInfoGaugeOpts,
+			[]string{"version"},
+		)
+		probeTLSCipher = prometheus.NewGaugeVec(
+			probeTLSCipherGaugeOpts,
+			[]string{"cipher"},
+		)
+	)
+
+	tlsMetrics := &TLSMetrics{
+		probeSSLEarliestCertExpiryGauge:         &probeSSLEarliestCertExpiryGauge,
+		probeSSLLastChainExpiryTimestampSeconds: &probeSSLLastChainExpiryTimestampSeconds,
+		probeSSLLastInformation:                 probeSSLLastInformation,
+		probeTLSVersion:                         probeTLSVersion,
+		probeTLSCipher:                          probeTLSCipher,
+	}
+
+	registry.MustRegister(
+		*tlsMetrics.probeSSLEarliestCertExpiryGauge,
+		*tlsMetrics.probeSSLLastChainExpiryTimestampSeconds,
+		*tlsMetrics.probeSSLLastInformation,
+		*tlsMetrics.probeTLSVersion,
+		*tlsMetrics.probeTLSCipher,
+	)
+	return tlsMetrics
+}
+
+// setTLSMetrics sets the TLS metrics for a given TLS connection state
+func setTLSMetrics(state *tls.ConnectionState, tlsMetrics *TLSMetrics) *TLSMetrics {
+
+	(*tlsMetrics.probeSSLEarliestCertExpiryGauge).Set(float64(getEarliestCertExpiry(state).Unix()))
+	(*tlsMetrics.probeSSLLastChainExpiryTimestampSeconds).Set(float64(getLastChainExpiry(state).Unix()))
+	(*tlsMetrics.probeSSLLastInformation).WithLabelValues(
+		getFingerprint(state),
+		getSubject(state),
+		getIssuer(state),
+		getDNSNames(state),
+		getSerialNumber(state),
+	).Set(1)
+	(*tlsMetrics.probeTLSVersion).WithLabelValues(getTLSVersion(state)).Set(1)
+	(*tlsMetrics.probeTLSCipher).WithLabelValues(getTLSCipher(state)).Set(1)
+
+	return tlsMetrics
 }

--- a/prober/websocket.go
+++ b/prober/websocket.go
@@ -59,7 +59,7 @@ func ProbeWebsocket(ctx context.Context, target string, module config.Module, re
 	}, []string{"phase"})
 	isSSLGauge := prometheus.NewGauge(prometheus.GaugeOpts{
 		Name: "probe_websocket_ssl",
-		Help: "Indicates if SSL was used for the final redirect",
+		Help: "Indicates if SSL was used to make the connection",
 	})
 
 	registry.MustRegister(isConnected)
@@ -105,7 +105,10 @@ func ProbeWebsocket(ctx context.Context, target string, module config.Module, re
 
 			tlsConn := tls.Client(conn, tlsConfig)
 
-			if err := tlsConn.HandshakeContext(ctx); err != nil {
+			if err := tlsConn.HandshakeContext(ctx); err == nil {
+				state := tlsConn.ConnectionState()
+				tlsState = &state
+			} else {
 				conn.Close()
 				return nil, err
 			}

--- a/prober/websocket.go
+++ b/prober/websocket.go
@@ -15,6 +15,7 @@ package prober
 
 import (
 	"context"
+	"crypto/tls"
 	"encoding/base64"
 	"log/slog"
 	"net"
@@ -56,11 +57,16 @@ func ProbeWebsocket(ctx context.Context, target string, module config.Module, re
 		Name: "probe_websocket_duration_seconds",
 		Help: "Duration of websocket request by phase",
 	}, []string{"phase"})
+	isSSLGauge := prometheus.NewGauge(prometheus.GaugeOpts{
+		Name: "probe_websocket_ssl",
+		Help: "Indicates if SSL was used for the final redirect",
+	})
 
 	registry.MustRegister(isConnected)
 	registry.MustRegister(httpStatusCode)
 	registry.MustRegister(probeFailedDueToRegex)
 	registry.MustRegister(durationGaugeVec)
+	registry.MustRegister(isSSLGauge)
 
 	tlsConfig, err := promconfig.NewTLSConfig(&module.Websocket.HTTPClientConfig.TLSConfig)
 	if err != nil {
@@ -83,21 +89,31 @@ func ProbeWebsocket(ctx context.Context, target string, module config.Module, re
 
 	// shared variable to capture connect duration from the closure
 	var connectDuration float64
+	var tlsState *tls.ConnectionState
+
 	dialer := websocket.Dialer{
 		TLSClientConfig: tlsConfig,
 		NetDialContext: func(ctx context.Context, network, addr string) (net.Conn, error) {
-			// use chosen protocol to dial but use ip as we've resolved the address
-			_, port, err := net.SplitHostPort(addr)
+			conn, err := connectTCP(ctx, network, addr, ip, durationGaugeVec)
+			return conn, err
+		},
+		NetDialTLSContext: func(ctx context.Context, network, addr string) (net.Conn, error) {
+			conn, err := connectTCP(ctx, network, addr, ip, durationGaugeVec)
 			if err != nil {
 				return nil, err
 			}
-			start := time.Now()
-			conn, err := (&net.Dialer{}).DialContext(ctx, network, net.JoinHostPort(ip.String(), port))
-			if err == nil {
-				connectDuration = time.Since(start).Seconds()
-				durationGaugeVec.WithLabelValues("connect").Add(connectDuration)
+
+			tlsConn := tls.Client(conn, tlsConfig)
+
+			if err := tlsConn.HandshakeContext(ctx); err != nil {
+				conn.Close()
+				return nil, err
 			}
-			return conn, err
+
+			state := tlsConn.ConnectionState()
+			tlsState = &state
+
+			return tlsConn, nil
 		},
 	}
 
@@ -115,6 +131,7 @@ func ProbeWebsocket(ctx context.Context, target string, module config.Module, re
 
 	if resp != nil {
 		httpStatusCode.Set(float64(resp.StatusCode))
+		resp.TLS = tlsState
 	}
 	if err != nil {
 		logger.Error("Error dialing websocket", "err", err)
@@ -123,6 +140,14 @@ func ProbeWebsocket(ctx context.Context, target string, module config.Module, re
 	defer connection.Close()
 
 	isConnected.Set(1)
+
+	if resp.TLS != nil {
+		isSSLGauge.Set(float64(1))
+		tlsMetrics := registerTLSMetrics(registry)
+		setTLSMetrics(resp.TLS, tlsMetrics)
+	} else {
+		isSSLGauge.Set(float64(0))
+	}
 
 	if len(module.Websocket.QueryResponse) > 0 {
 		transferStart := time.Now()
@@ -247,4 +272,21 @@ func constructHeadersFromConfig(websocketConfig config.WebsocketProbe, logger *s
 		}
 	}
 	return headers
+}
+
+func connectTCP(ctx context.Context, network, addr string, ip *net.IPAddr, durationGaugeVec *prometheus.GaugeVec) (net.Conn, error) {
+	var connectDuration float64
+	// use chosen protocol to dial but use ip as we've resolved the address
+	_, port, err := net.SplitHostPort(addr)
+	if err != nil {
+		return nil, err
+	}
+
+	start := time.Now()
+	conn, err := (&net.Dialer{}).DialContext(ctx, network, net.JoinHostPort(ip.String(), port))
+	if err == nil {
+		connectDuration = time.Since(start).Seconds()
+		durationGaugeVec.WithLabelValues("connect").Add(connectDuration)
+	}
+	return conn, err
 }

--- a/prober/websocket_test.go
+++ b/prober/websocket_test.go
@@ -192,6 +192,7 @@ func TestProbeWebsocket(t *testing.T) {
 				"probe_websocket_status_code":         101,
 				"probe_websocket_connection_upgraded": 1,
 				"probe_websocket_failed_due_to_regex": 0,
+				"probe_websocket_ssl":                 0,
 			},
 			expectedSuccess: true,
 		},
@@ -215,6 +216,7 @@ func TestProbeWebsocket(t *testing.T) {
 				"probe_websocket_status_code":         101,
 				"probe_websocket_connection_upgraded": 1,
 				"probe_websocket_failed_due_to_regex": 1,
+				"probe_websocket_ssl":                 0,
 			},
 			expectedSuccess: false,
 		},
@@ -241,6 +243,7 @@ func TestProbeWebsocket(t *testing.T) {
 			expected: map[string]float64{
 				"probe_websocket_status_code":         101,
 				"probe_websocket_connection_upgraded": 1,
+				"probe_websocket_ssl":                 1,
 			},
 			expectedSuccess: true,
 		},


### PR DESCRIPTION
SSL metrics: unified way to register/populate from raw connection

This change consolidates how TLS-related Prometheus metrics are created and populated so HTTP, gRPC, and WebSocket probes share the same implementation instead of duplicating metric definitions in each prober.

What changed

- Shared TLS helpers (prober/tls.go): Added registerTLSMetrics and setTLSMetrics, backed by a TLSMetrics struct, to register and set the standard SSL/TLS gauges in one place: earliest cert expiry, last chain expiry timestamp, leaf chain info (probe_ssl_last_chain_info), TLS version, and cipher.
- HTTP and gRPC (prober/http.go, prober/grpc.go): Removed per-prober copies of those metrics and call the shared helpers when a TLS connection is present.
- Naming (prober/prober.go): Centralized options for probe_ssl_last_chain_info via probeSSLLastInformationGaugeOpts so the help text and name stay consistent.
- Added probe_websocket_ssl to indicate whether the final connection used TLS.

gRPC previously exposed only a subset of TLS metrics (e.g. no chain-expiry or cipher series in the same way as HTTP). After this refactor, gRPC uses the same setTLSMetrics path, so it now emits the full set of shared TLS metrics, including probe_ssl_last_chain_expiry_timestamp_seconds and probe_tls_cipher_info, aligned with the HTTP and WebSocket behavior. 

**Checklist**
- [x] Tests updated
- [ ] Documentation added
- [ ] CHANGELOG added in `release-notes` section of PR Desc.
