### PR TITLE
add tcp and unix prober metric for tls_cipher_info

### DIFF
--- a/prober/query_response.go
+++ b/prober/query_response.go
@@ -60,6 +60,10 @@ func probeQueryResponses(ctx context.Context, target string, conn net.Conn, modu
 		probeTLSInfoGaugeOpts,
 		[]string{"version"},
 	)
+	probeTLSCipher := prometheus.NewGaugeVec(
+		probeTLSCipherGaugeOpts,
+		[]string{"cipher"},
+	)
 	probeFailedDueToRegex := prometheus.NewGauge(prometheus.GaugeOpts{
 		Name: "probe_failed_due_to_regex",
 		Help: "Indicates if probe failed due to regex",
@@ -94,9 +98,10 @@ func probeQueryResponses(ctx context.Context, target string, conn net.Conn, modu
 
 	if useTLS {
 		state := conn.(*tls.Conn).ConnectionState()
-		registry.MustRegister(probeSSLEarliestCertExpiry, probeTLSVersion, probeSSLLastChainExpiryTimestampSeconds, probeSSLLastInformation)
+		registry.MustRegister(probeSSLEarliestCertExpiry, probeTLSVersion, probeTLSCipher, probeSSLLastChainExpiryTimestampSeconds, probeSSLLastInformation)
 		probeSSLEarliestCertExpiry.Set(float64(getEarliestCertExpiry(&state).Unix()))
 		probeTLSVersion.WithLabelValues(getTLSVersion(&state)).Set(1)
+		probeTLSCipher.WithLabelValues(getTLSCipher(&state)).Set(1)
 		probeSSLLastChainExpiryTimestampSeconds.Set(float64(getLastChainExpiry(&state).Unix()))
 		probeSSLLastInformation.WithLabelValues(getFingerprint(&state), getSubject(&state), getIssuer(&state), getDNSNames(&state), getSerialNumber(&state)).Set(1)
 	}
@@ -191,9 +196,10 @@ func probeQueryResponses(ctx context.Context, target string, conn net.Conn, modu
 
 			// Get certificate expiry.
 			state := tlsConn.ConnectionState()
-			registry.MustRegister(probeSSLEarliestCertExpiry, probeTLSVersion, probeSSLLastChainExpiryTimestampSeconds, probeSSLLastInformation)
+			registry.MustRegister(probeSSLEarliestCertExpiry, probeTLSVersion, probeTLSCipher, probeSSLLastChainExpiryTimestampSeconds, probeSSLLastInformation)
 			probeSSLEarliestCertExpiry.Set(float64(getEarliestCertExpiry(&state).Unix()))
 			probeTLSVersion.WithLabelValues(getTLSVersion(&state)).Set(1)
+			probeTLSCipher.WithLabelValues(getTLSCipher(&state)).Set(1)
 			probeSSLLastChainExpiryTimestampSeconds.Set(float64(getLastChainExpiry(&state).Unix()))
 			probeSSLLastInformation.WithLabelValues(getFingerprint(&state), getSubject(&state), getIssuer(&state), getDNSNames(&state), getSerialNumber(&state)).Set(1)
 		}

--- a/prober/query_response.go
+++ b/prober/query_response.go
@@ -60,6 +60,10 @@ func probeQueryResponses(ctx context.Context, target string, conn net.Conn, modu
 		probeTLSInfoGaugeOpts,
 		[]string{"version"},
 	)
+	probeTLSCipher := prometheus.NewGaugeVec(
+		probeTLSCipherGaugeOpts,
+		[]string{"cipher"},
+	)
 	probeFailedDueToRegex := prometheus.NewGauge(prometheus.GaugeOpts{
 		Name: "probe_failed_due_to_regex",
 		Help: "Indicates if probe failed due to regex",
@@ -97,9 +101,10 @@ func probeQueryResponses(ctx context.Context, target string, conn net.Conn, modu
 
 	if useTLS {
 		state := conn.(*tls.Conn).ConnectionState()
-		registry.MustRegister(probeSSLEarliestCertExpiry, probeTLSVersion, probeSSLLastChainExpiryTimestampSeconds, probeSSLLastInformation)
+		registry.MustRegister(probeSSLEarliestCertExpiry, probeTLSVersion, probeTLSCipher, probeSSLLastChainExpiryTimestampSeconds, probeSSLLastInformation)
 		probeSSLEarliestCertExpiry.Set(float64(getEarliestCertExpiry(&state).Unix()))
 		probeTLSVersion.WithLabelValues(getTLSVersion(&state)).Set(1)
+		probeTLSCipher.WithLabelValues(getTLSCipher(&state)).Set(1)
 		probeSSLLastChainExpiryTimestampSeconds.Set(float64(getLastChainExpiry(&state).Unix()))
 		probeSSLLastInformation.WithLabelValues(getFingerprint(&state), getSubject(&state), getIssuer(&state), getDNSNames(&state), getSerialNumber(&state)).Set(1)
 		checkCRL(ctx, &state, checkRevoked, nil, registry, logger)
@@ -195,9 +200,10 @@ func probeQueryResponses(ctx context.Context, target string, conn net.Conn, modu
 
 			// Get certificate expiry.
 			state := tlsConn.ConnectionState()
-			registry.MustRegister(probeSSLEarliestCertExpiry, probeTLSVersion, probeSSLLastChainExpiryTimestampSeconds, probeSSLLastInformation)
+			registry.MustRegister(probeSSLEarliestCertExpiry, probeTLSVersion, probeTLSCipher, probeSSLLastChainExpiryTimestampSeconds, probeSSLLastInformation)
 			probeSSLEarliestCertExpiry.Set(float64(getEarliestCertExpiry(&state).Unix()))
 			probeTLSVersion.WithLabelValues(getTLSVersion(&state)).Set(1)
+			probeTLSCipher.WithLabelValues(getTLSCipher(&state)).Set(1)
 			probeSSLLastChainExpiryTimestampSeconds.Set(float64(getLastChainExpiry(&state).Unix()))
 			probeSSLLastInformation.WithLabelValues(getFingerprint(&state), getSubject(&state), getIssuer(&state), getDNSNames(&state), getSerialNumber(&state)).Set(1)
 			checkCRL(ctx, &state, checkRevoked, nil, registry, logger)

--- a/prober/tcp_test.go
+++ b/prober/tcp_test.go
@@ -126,6 +126,7 @@ func TestTCPConnectionWithTLS(t *testing.T) {
 			Certificates: []tls.Certificate{testcert},
 			MinVersion:   tls.VersionTLS12,
 			MaxVersion:   tls.VersionTLS12,
+			CipherSuites: []uint16{tls.TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256},
 		}
 		tlsConn := tls.Server(conn, tlsConfig)
 		defer tlsConn.Close()
@@ -188,6 +189,9 @@ func TestTCPConnectionWithTLS(t *testing.T) {
 		"probe_tls_version_info": {
 			"version": "TLS 1.2",
 		},
+		"probe_tls_cipher_info": {
+			"cipher": "TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256",
+		},
 	}
 	checkRegistryLabels(expectedLabels, mfs, t)
 
@@ -196,6 +200,7 @@ func TestTCPConnectionWithTLS(t *testing.T) {
 		"probe_ssl_earliest_cert_expiry": float64(certExpiry.Unix()),
 		"probe_ssl_last_chain_info":      1,
 		"probe_tls_version_info":         1,
+		"probe_tls_cipher_info":          1,
 	}
 	checkRegistryResults(expectedResults, mfs, t)
 }
@@ -406,6 +411,9 @@ func TestTCPConnectionQueryResponseStartTLS(t *testing.T) {
 		tlsConfig := &tls.Config{
 			ServerName:   "localhost",
 			Certificates: []tls.Certificate{testcert},
+			MinVersion:   tls.VersionTLS12,
+			MaxVersion:   tls.VersionTLS12,
+			CipherSuites: []uint16{tls.TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256},
 		}
 		tlsConn := tls.Server(conn, tlsConfig)
 		if err := tlsConn.Handshake(); err != nil {
@@ -436,8 +444,16 @@ func TestTCPConnectionQueryResponseStartTLS(t *testing.T) {
 	}
 	expectedResults := map[string]float64{
 		"probe_ssl_earliest_cert_expiry": float64(certExpiry.Unix()),
+		"probe_tls_cipher_info":          1,
 	}
 	checkRegistryResults(expectedResults, mfs, t)
+
+	expectedLabels := map[string]map[string]string{
+		"probe_tls_cipher_info": {
+			"cipher": "TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256",
+		},
+	}
+	checkRegistryLabels(expectedLabels, mfs, t)
 }
 
 func TestTCPConnectionQueryResponseIRC(t *testing.T) {

--- a/prober/tcp_test.go
+++ b/prober/tcp_test.go
@@ -126,6 +126,7 @@ func TestTCPConnectionWithTLS(t *testing.T) {
 			Certificates: []tls.Certificate{testcert},
 			MinVersion:   tls.VersionTLS12,
 			MaxVersion:   tls.VersionTLS12,
+			CipherSuites: []uint16{tls.TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256},
 		}
 		tlsConn := tls.Server(conn, tlsConfig)
 		defer tlsConn.Close()
@@ -188,6 +189,9 @@ func TestTCPConnectionWithTLS(t *testing.T) {
 		"probe_tls_version_info": {
 			"version": "TLS 1.2",
 		},
+		"probe_tls_cipher_info": {
+			"cipher": "TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256",
+		},
 	}
 	checkRegistryLabels(expectedLabels, mfs, t)
 
@@ -196,6 +200,7 @@ func TestTCPConnectionWithTLS(t *testing.T) {
 		"probe_ssl_earliest_cert_expiry": float64(certExpiry.Unix()),
 		"probe_ssl_last_chain_info":      1,
 		"probe_tls_version_info":         1,
+		"probe_tls_cipher_info":          1,
 	}
 	checkRegistryResults(expectedResults, mfs, t)
 }
@@ -406,6 +411,9 @@ func TestTCPConnectionQueryResponseStartTLS(t *testing.T) {
 		tlsConfig := &tls.Config{
 			ServerName:   "localhost",
 			Certificates: []tls.Certificate{testcert},
+			MinVersion:   tls.VersionTLS12,
+			MaxVersion:   tls.VersionTLS12,
+			CipherSuites: []uint16{tls.TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256},
 		}
 		tlsConn := tls.Server(conn, tlsConfig)
 		if err := tlsConn.Handshake(); err != nil {
@@ -436,8 +444,16 @@ func TestTCPConnectionQueryResponseStartTLS(t *testing.T) {
 	}
 	expectedResults := map[string]float64{
 		"probe_ssl_earliest_cert_expiry": float64(certExpiry.Unix()),
+		"probe_tls_cipher_info":          1,
 	}
 	checkRegistryResults(expectedResults, mfs, t)
+
+	expectedLabels := map[string]map[string]string{
+		"probe_tls_cipher_info": {
+			"cipher": "TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256",
+		},
+	}
+	checkRegistryLabels(expectedLabels, mfs, t)
 }
 
 func TestTCPConnectionWithTLSAndCRL(t *testing.T) {

--- a/prober/unix_test.go
+++ b/prober/unix_test.go
@@ -94,6 +94,7 @@ func TestUnixConnectionWithTLSAndCRL(t *testing.T) {
 			Certificates: []tls.Certificate{serverTLSCert(leafKey, leaf, ca)},
 			MinVersion:   tls.VersionTLS12,
 			MaxVersion:   tls.VersionTLS12,
+			CipherSuites: []uint16{tls.TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256},
 		})
 		defer tlsConn.Close()
 		if err := tlsConn.Handshake(); err == nil {
@@ -126,6 +127,18 @@ func TestUnixConnectionWithTLSAndCRL(t *testing.T) {
 	if val, ok := getMetricWithLabels(mfs, "probe_ssl_crl_available", map[string]string{"subject": "CN=Test Leaf,O=Example Org"}); !ok || val != 1 {
 		t.Errorf("Expected probe_ssl_crl_available=1, got %v (found=%v)", val, ok)
 	}
+
+	expectedResults := map[string]float64{
+		"probe_tls_cipher_info": 1,
+	}
+	checkRegistryResults(expectedResults, mfs, t)
+
+	expectedLabels := map[string]map[string]string{
+		"probe_tls_cipher_info": {
+			"cipher": "TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256",
+		},
+	}
+	checkRegistryLabels(expectedLabels, mfs, t)
 }
 
 func TestUnixConnectionFails(t *testing.T) {


### PR DESCRIPTION
#### What this PR does / Which issue(s) does the PR fix:
adds tls_cipher_info metric to tcp prober

#### Does this PR introduce a user-facing change?
```release-notes
[FEATURE] add tls_cipher_info metric to tcp and unix probers
```

**Checklist**
- [x] Tests updated
- [ ] Documentation added
- [x] CHANGELOG added in `release-notes` section of PR Desc.
