### PR TITLE
refactor: replace interface{} with any (Go 1.18+)

### DIFF
--- a/.github/workflows/container_description.yml
+++ b/.github/workflows/container_description.yml
@@ -18,7 +18,7 @@ jobs:
     if: github.repository_owner == 'prometheus' || github.repository_owner == 'prometheus-community' # Don't run this workflow on forks.
     steps:
       - name: git checkout
-        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           persist-credentials: false
       - name: Set docker hub repo name
@@ -42,7 +42,7 @@ jobs:
     if: github.repository_owner == 'prometheus' || github.repository_owner == 'prometheus-community' # Don't run this workflow on forks.
     steps:
       - name: git checkout
-        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           persist-credentials: false
       - name: Set quay.io org name

--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -26,7 +26,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           persist-credentials: false
       - name: Install Go
@@ -40,7 +40,7 @@ jobs:
         id: golangci-lint-version
         run: echo "version=$(make print-golangci-lint-version)" >> $GITHUB_OUTPUT
       - name: Lint
-        uses: golangci/golangci-lint-action@82606bf257cbaff209d206a39f5134f0cfbfd2ee # v9.2.1
+        uses: golangci/golangci-lint-action@1e7e51e771db61008b38414a730f564565cf7c20 # v9.2.0
         with:
           args: --verbose
           version: ${{ steps.golangci-lint-version.outputs.version }}

--- a/config/config.go
+++ b/config/config.go
@@ -215,7 +215,7 @@ func NewCELProgram(s string) (CELProgram, error) {
 }
 
 // UnmarshalYAML implements the yaml.Unmarshaler interface.
-func (c *CELProgram) UnmarshalYAML(unmarshal func(interface{}) error) error {
+func (c *CELProgram) UnmarshalYAML(unmarshal func(any) error) error {
 	var expr string
 	if err := unmarshal(&expr); err != nil {
 		return err
@@ -229,7 +229,7 @@ func (c *CELProgram) UnmarshalYAML(unmarshal func(interface{}) error) error {
 }
 
 // MarshalYAML implements the yaml.Marshaler interface.
-func (c CELProgram) MarshalYAML() (interface{}, error) {
+func (c CELProgram) MarshalYAML() (any, error) {
 	if c.Expression != "" {
 		return c.Expression, nil
 	}
@@ -262,7 +262,7 @@ func NewRegexp(s string) (Regexp, error) {
 }
 
 // UnmarshalYAML implements the yaml.Unmarshaler interface.
-func (re *Regexp) UnmarshalYAML(unmarshal func(interface{}) error) error {
+func (re *Regexp) UnmarshalYAML(unmarshal func(any) error) error {
 	var s string
 	if err := unmarshal(&s); err != nil {
 		return err
@@ -276,7 +276,7 @@ func (re *Regexp) UnmarshalYAML(unmarshal func(interface{}) error) error {
 }
 
 // MarshalYAML implements the yaml.Marshaler interface.
-func (re Regexp) MarshalYAML() (interface{}, error) {
+func (re Regexp) MarshalYAML() (any, error) {
 	if re.original != "" {
 		return re.original, nil
 	}
@@ -415,7 +415,7 @@ type WebsocketProbe struct {
 }
 
 // UnmarshalYAML implements the yaml.Unmarshaler interface.
-func (s *Config) UnmarshalYAML(unmarshal func(interface{}) error) error {
+func (s *Config) UnmarshalYAML(unmarshal func(any) error) error {
 	type plain Config
 	if err := unmarshal((*plain)(s)); err != nil {
 		return err
@@ -424,7 +424,7 @@ func (s *Config) UnmarshalYAML(unmarshal func(interface{}) error) error {
 }
 
 // UnmarshalYAML implements the yaml.Unmarshaler interface.
-func (s *Module) UnmarshalYAML(unmarshal func(interface{}) error) error {
+func (s *Module) UnmarshalYAML(unmarshal func(any) error) error {
 	*s = DefaultModule
 	type plain Module
 	if err := unmarshal((*plain)(s)); err != nil {
@@ -442,7 +442,7 @@ func (s *Module) UnmarshalYAML(unmarshal func(interface{}) error) error {
 }
 
 // UnmarshalYAML implements the yaml.Unmarshaler interface.
-func (s *HTTPProbe) UnmarshalYAML(unmarshal func(interface{}) error) error {
+func (s *HTTPProbe) UnmarshalYAML(unmarshal func(any) error) error {
 	*s = DefaultHTTPProbe
 	type plain HTTPProbe
 	if err := unmarshal((*plain)(s)); err != nil {
@@ -506,7 +506,7 @@ func (s *HTTPProbe) UnmarshalYAML(unmarshal func(interface{}) error) error {
 }
 
 // UnmarshalYAML implements the yaml.Unmarshaler interface.
-func (s *GRPCProbe) UnmarshalYAML(unmarshal func(interface{}) error) error {
+func (s *GRPCProbe) UnmarshalYAML(unmarshal func(any) error) error {
 	*s = DefaultGRPCProbe
 	type plain GRPCProbe
 	if err := unmarshal((*plain)(s)); err != nil {
@@ -516,7 +516,7 @@ func (s *GRPCProbe) UnmarshalYAML(unmarshal func(interface{}) error) error {
 }
 
 // UnmarshalYAML implements the yaml.Unmarshaler interface.
-func (s *DNSProbe) UnmarshalYAML(unmarshal func(interface{}) error) error {
+func (s *DNSProbe) UnmarshalYAML(unmarshal func(any) error) error {
 	*s = DefaultDNSProbe
 	type plain DNSProbe
 	if err := unmarshal((*plain)(s)); err != nil {
@@ -540,7 +540,7 @@ func (s *DNSProbe) UnmarshalYAML(unmarshal func(interface{}) error) error {
 }
 
 // UnmarshalYAML implements the yaml.Unmarshaler interface.
-func (s *TCPProbe) UnmarshalYAML(unmarshal func(interface{}) error) error {
+func (s *TCPProbe) UnmarshalYAML(unmarshal func(any) error) error {
 	*s = DefaultTCPProbe
 	type plain TCPProbe
 	if err := unmarshal((*plain)(s)); err != nil {
@@ -550,7 +550,7 @@ func (s *TCPProbe) UnmarshalYAML(unmarshal func(interface{}) error) error {
 }
 
 // UnmarshalYAML implements the yaml.Unmarshaler interface.
-func (s *UnixProbe) UnmarshalYAML(unmarshal func(interface{}) error) error {
+func (s *UnixProbe) UnmarshalYAML(unmarshal func(any) error) error {
 	*s = DefaultUnixProbe
 	type plain UnixProbe
 	if err := unmarshal((*plain)(s)); err != nil {
@@ -560,7 +560,7 @@ func (s *UnixProbe) UnmarshalYAML(unmarshal func(interface{}) error) error {
 }
 
 // UnmarshalYAML implements the yaml.Unmarshaler interface.
-func (s *DNSRRValidator) UnmarshalYAML(unmarshal func(interface{}) error) error {
+func (s *DNSRRValidator) UnmarshalYAML(unmarshal func(any) error) error {
 	type plain DNSRRValidator
 	if err := unmarshal((*plain)(s)); err != nil {
 		return err
@@ -569,7 +569,7 @@ func (s *DNSRRValidator) UnmarshalYAML(unmarshal func(interface{}) error) error 
 }
 
 // UnmarshalYAML implements the yaml.Unmarshaler interface.
-func (s *ICMPProbe) UnmarshalYAML(unmarshal func(interface{}) error) error {
+func (s *ICMPProbe) UnmarshalYAML(unmarshal func(any) error) error {
 	*s = DefaultICMPProbe
 	type plain ICMPProbe
 	if err := unmarshal((*plain)(s)); err != nil {
@@ -590,7 +590,7 @@ func (s *ICMPProbe) UnmarshalYAML(unmarshal func(interface{}) error) error {
 }
 
 // UnmarshalYAML implements the yaml.Unmarshaler interface.
-func (s *QueryResponse) UnmarshalYAML(unmarshal func(interface{}) error) error {
+func (s *QueryResponse) UnmarshalYAML(unmarshal func(any) error) error {
 	type plain QueryResponse
 	if err := unmarshal((*plain)(s)); err != nil {
 		return err
@@ -602,7 +602,7 @@ func (s *QueryResponse) UnmarshalYAML(unmarshal func(interface{}) error) error {
 }
 
 // UnmarshalYAML implements the yaml.Unmarshaler interface.
-func (s *HeaderMatch) UnmarshalYAML(unmarshal func(interface{}) error) error {
+func (s *HeaderMatch) UnmarshalYAML(unmarshal func(any) error) error {
 	type plain HeaderMatch
 	if err := unmarshal((*plain)(s)); err != nil {
 		return err
@@ -620,7 +620,7 @@ func (s *HeaderMatch) UnmarshalYAML(unmarshal func(interface{}) error) error {
 }
 
 // UnmarshalYAML implements the yaml.Unmarshaler interface.
-func (s *WebsocketProbe) UnmarshalYAML(unmarshal func(interface{}) error) error {
+func (s *WebsocketProbe) UnmarshalYAML(unmarshal func(any) error) error {
 	*s = DefaultWebsocketProbe
 	type plain WebsocketProbe
 	if err := unmarshal((*plain)(s)); err != nil {

--- a/prober/grpc_test.go
+++ b/prober/grpc_test.go
@@ -123,9 +123,9 @@ func TestGRPCConnectionWithMetadata(t *testing.T) {
 	}
 
 	metadataUnaryInterceptor := func(ctx context.Context,
-		req interface{},
+		req any,
 		info *grpc.UnaryServerInfo,
-		handler grpc.UnaryHandler) (interface{}, error) {
+		handler grpc.UnaryHandler) (any, error) {
 
 		h, err := handler(ctx, req)
 		md, _ := metadata.FromIncomingContext(ctx)

--- a/prober/http.go
+++ b/prober/http.go
@@ -81,7 +81,7 @@ func matchCELExpressions(ctx context.Context, reader io.Reader, httpConfig confi
 		return false
 	}
 
-	evalPayload := map[string]interface{}{
+	evalPayload := map[string]any{
 		"body": bodyJSON,
 	}
 

--- a/prober/websocket_test.go
+++ b/prober/websocket_test.go
@@ -68,7 +68,7 @@ func TestCostructHeadersFromConfig(t *testing.T) {
 			},
 		},
 	}
-	testCases := []map[string]interface{}{
+	testCases := []map[string]any{
 		{
 			"test": testConfig,
 			"expected": map[string][]string{


### PR DESCRIPTION
Replaces all remaining occurrences of `interface{}` with the `any` alias.