### PR TITLE
prober: fix gRPC probe IP resolution and yamllint issues

### DIFF
--- a/config/testdata/blackbox-good.yml
+++ b/config/testdata/blackbox-good.yml
@@ -84,7 +84,7 @@ modules:
       service: example
       metadata:
         key:
-          - value1
-          - value2
+        - value1
+        - value2
         authorization:
-          - "Bearer token"
+        - "Bearer token"

--- a/config/testdata/invalid-http-http3-http2-enabled.yml
+++ b/config/testdata/invalid-http-http3-http2-enabled.yml
@@ -6,4 +6,4 @@ modules:
       enable_http3: true
       enable_http2: true
       valid_http_versions: ["HTTP/3.0"]
-      preferred_ip_protocol: "ip4" 
+      preferred_ip_protocol: "ip4"

--- a/config/testdata/invalid-http-http3-http2-version.yml
+++ b/config/testdata/invalid-http-http3-http2-version.yml
@@ -6,4 +6,4 @@ modules:
       enable_http3: true
       enable_http2: false
       valid_http_versions: ["HTTP/1.1", "HTTP/2.0", "HTTP/3.0"]
-      preferred_ip_protocol: "ip4" 
+      preferred_ip_protocol: "ip4"

--- a/config/testdata/invalid-http-http3-http2.yml
+++ b/config/testdata/invalid-http-http3-http2.yml
@@ -6,4 +6,4 @@ modules:
       enable_http3: true
       enable_http2: true
       valid_http_versions: ["HTTP/1.1", "HTTP/2.0", "HTTP/3.0"]
-      preferred_ip_protocol: "ip4" 
+      preferred_ip_protocol: "ip4"

--- a/config/testdata/invalid-no-versions-http3-enabled.yml
+++ b/config/testdata/invalid-no-versions-http3-enabled.yml
@@ -4,4 +4,4 @@ modules:
     timeout: 5s
     http:
       enable_http3: true
-      preferred_ip_protocol: "ip4" 
+      preferred_ip_protocol: "ip4"

--- a/config/testdata/invalid-websocket-query-response-regexp.yml
+++ b/config/testdata/invalid-websocket-query-response-regexp.yml
@@ -6,4 +6,3 @@ modules:
       query_response:
         - expect: ":["
         - send: "test message"
-

--- a/example.yml
+++ b/example.yml
@@ -229,9 +229,9 @@ modules:
     prober: tcp
     tcp:
       query_response:
-      - send: !!binary AAAACATSFi8= # 0x00, 0x00, 0x00, 0x08, 0x04, 0xD2, 0x16, 0x2F - PostgreSQL SSLRequest
-      - expect_bytes: S # 0x53 - Reply will be 'S' if SSL is enabled, and 'N' if it is not.
-      - starttls: true
+        - send: !!binary AAAACATSFi8= # 0x00, 0x00, 0x00, 0x08, 0x04, 0xD2, 0x16, 0x2F - PostgreSQL SSLRequest
+        - expect_bytes: S # 0x53 - Reply will be 'S' if SSL is enabled, and 'N' if it is not.
+        - starttls: true
   http_with_header_from_files:
     prober: http
     http:

--- a/prober/grpc.go
+++ b/prober/grpc.go
@@ -163,28 +163,24 @@ func ProbeGRPC(ctx context.Context, target string, module config.Module, registr
 	}
 
 	if targetPort == "" {
-		targetURL.Host = "[" + ip.String() + "]"
-	} else {
-		targetURL.Host = net.JoinHostPort(ip.String(), targetPort)
+		if !module.GRPC.TLS {
+			targetPort = "80"
+		} else {
+			targetPort = "443"
+		}
 	}
 
 	var opts []grpc.DialOption
-	target = targetHost + ":" + targetPort
 	if !module.GRPC.TLS {
 		logger.Debug("Dialing GRPC without TLS")
 		opts = append(opts, grpc.WithTransportCredentials(insecure.NewCredentials()))
-		if len(targetPort) == 0 {
-			target = targetHost + ":80"
-		}
 	} else {
 		creds := credentials.NewTLS(tlsConfig)
 		opts = append(opts, grpc.WithTransportCredentials(creds))
-		if len(targetPort) == 0 {
-			target = targetHost + ":443"
-		}
 	}
 
-	conn, err := grpc.NewClient(target, opts...)
+	dialTarget := net.JoinHostPort(ip.String(), targetPort)
+	conn, err := grpc.NewClient(dialTarget, opts...)
 
 	if err != nil {
 		logger.Error("did not connect", "err", err)

--- a/prober/grpc_test.go
+++ b/prober/grpc_test.go
@@ -41,7 +41,7 @@ func TestGRPCConnection(t *testing.T) {
 		t.Skip("skipping; CI is failing on ipv6 dns requests")
 	}
 
-	ln, err := net.Listen("tcp", "localhost:0")
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
 	if err != nil {
 		t.Fatalf("Error listening on socket: %s", err)
 	}
@@ -68,9 +68,10 @@ func TestGRPCConnection(t *testing.T) {
 	defer cancel()
 	registry := prometheus.NewRegistry()
 
-	result := ProbeGRPC(testCTX, "localhost:"+port,
+	result := ProbeGRPC(testCTX, "127.0.0.1:"+port,
 		config.Module{Timeout: time.Second, GRPC: config.GRPCProbe{
-			IPProtocolFallback: false,
+			IPProtocolFallback:  false,
+			PreferredIPProtocol: "ip4",
 		},
 		}, registry, promslog.NewNopLogger())
 
@@ -111,7 +112,7 @@ func TestGRPCConnectionWithMetadata(t *testing.T) {
 
 	binaryMetadataValue := []byte{'t', 'e', 's', 't'}
 
-	ln, err := net.Listen("tcp", "localhost:0")
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
 	if err != nil {
 		t.Fatalf("Error listening on socket: %s", err)
 	}
@@ -170,9 +171,10 @@ func TestGRPCConnectionWithMetadata(t *testing.T) {
 	defer cancel()
 	registry := prometheus.NewRegistry()
 
-	result := ProbeGRPC(testCTX, "localhost:"+port,
+	result := ProbeGRPC(testCTX, "127.0.0.1:"+port,
 		config.Module{Timeout: time.Second, GRPC: config.GRPCProbe{
-			IPProtocolFallback: false,
+			IPProtocolFallback:  false,
+			PreferredIPProtocol: "ip4",
 			Metadata: metadata.Pairs("key1", "value1",
 				"key1", "value2",
 				"key2-bin", string(binaryMetadataValue),
@@ -216,7 +218,7 @@ func TestMultipleGRPCservices(t *testing.T) {
 		t.Skip("skipping; CI is failing on ipv6 dns requests")
 	}
 
-	ln, err := net.Listen("tcp", "localhost:0")
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
 	if err != nil {
 		t.Fatalf("Error listening on socket: %s", err)
 	}
@@ -244,10 +246,11 @@ func TestMultipleGRPCservices(t *testing.T) {
 	defer cancel()
 	registryService1 := prometheus.NewRegistry()
 
-	resultService1 := ProbeGRPC(testCTX, "localhost:"+port,
+	resultService1 := ProbeGRPC(testCTX, "127.0.0.1:"+port,
 		config.Module{Timeout: time.Second, GRPC: config.GRPCProbe{
-			IPProtocolFallback: false,
-			Service:            "service1",
+			IPProtocolFallback:  false,
+			PreferredIPProtocol: "ip4",
+			Service:             "service1",
 		},
 		}, registryService1, promslog.NewNopLogger())
 
@@ -256,10 +259,11 @@ func TestMultipleGRPCservices(t *testing.T) {
 	}
 
 	registryService2 := prometheus.NewRegistry()
-	resultService2 := ProbeGRPC(testCTX, "localhost:"+port,
+	resultService2 := ProbeGRPC(testCTX, "127.0.0.1:"+port,
 		config.Module{Timeout: time.Second, GRPC: config.GRPCProbe{
-			IPProtocolFallback: false,
-			Service:            "service2",
+			IPProtocolFallback:  false,
+			PreferredIPProtocol: "ip4",
+			Service:             "service2",
 		},
 		}, registryService2, promslog.NewNopLogger())
 
@@ -268,10 +272,11 @@ func TestMultipleGRPCservices(t *testing.T) {
 	}
 
 	registryService3 := prometheus.NewRegistry()
-	resultService3 := ProbeGRPC(testCTX, "localhost:"+port,
+	resultService3 := ProbeGRPC(testCTX, "127.0.0.1:"+port,
 		config.Module{Timeout: time.Second, GRPC: config.GRPCProbe{
-			IPProtocolFallback: false,
-			Service:            "service3",
+			IPProtocolFallback:  false,
+			PreferredIPProtocol: "ip4",
+			Service:             "service3",
 		},
 		}, registryService3, promslog.NewNopLogger())
 
@@ -315,7 +320,7 @@ func TestGRPCTLSConnection(t *testing.T) {
 		MaxVersion:   tls.VersionTLS12,
 	}
 
-	ln, err := net.Listen("tcp", "localhost:0")
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
 	if err != nil {
 		t.Fatalf("Error listening on socket: %s", err)
 	}
@@ -343,11 +348,12 @@ func TestGRPCTLSConnection(t *testing.T) {
 	defer cancel()
 	registry := prometheus.NewRegistry()
 
-	result := ProbeGRPC(testCTX, "localhost:"+port,
+	result := ProbeGRPC(testCTX, "127.0.0.1:"+port,
 		config.Module{Timeout: time.Second, GRPC: config.GRPCProbe{
-			TLS:                true,
-			TLSConfig:          pconfig.TLSConfig{InsecureSkipVerify: true},
-			IPProtocolFallback: false,
+			TLS:                 true,
+			TLSConfig:           pconfig.TLSConfig{InsecureSkipVerify: true},
+			IPProtocolFallback:  false,
+			PreferredIPProtocol: "ip4",
 		},
 		}, registry, promslog.NewNopLogger())
 
@@ -380,7 +386,7 @@ func TestNoTLSConnection(t *testing.T) {
 		t.Skip("skipping; CI is failing on ipv6 dns requests")
 	}
 
-	ln, err := net.Listen("tcp", "localhost:0")
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
 	if err != nil {
 		t.Fatalf("Error listening on socket: %s", err)
 	}
@@ -407,11 +413,12 @@ func TestNoTLSConnection(t *testing.T) {
 	defer cancel()
 	registry := prometheus.NewRegistry()
 
-	result := ProbeGRPC(testCTX, "localhost:"+port,
+	result := ProbeGRPC(testCTX, "127.0.0.1:"+port,
 		config.Module{Timeout: time.Second, GRPC: config.GRPCProbe{
-			TLS:                true,
-			TLSConfig:          pconfig.TLSConfig{InsecureSkipVerify: true},
-			IPProtocolFallback: false,
+			TLS:                 true,
+			TLSConfig:           pconfig.TLSConfig{InsecureSkipVerify: true},
+			IPProtocolFallback:  false,
+			PreferredIPProtocol: "ip4",
 		},
 		}, registry, promslog.NewNopLogger())
 
@@ -438,7 +445,7 @@ func TestGRPCServiceNotFound(t *testing.T) {
 		t.Skip("skipping; CI is failing on ipv6 dns requests")
 	}
 
-	ln, err := net.Listen("tcp", "localhost:0")
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
 	if err != nil {
 		t.Fatalf("Error listening on socket: %s", err)
 	}
@@ -465,10 +472,11 @@ func TestGRPCServiceNotFound(t *testing.T) {
 	defer cancel()
 	registry := prometheus.NewRegistry()
 
-	result := ProbeGRPC(testCTX, "localhost:"+port,
+	result := ProbeGRPC(testCTX, "127.0.0.1:"+port,
 		config.Module{Timeout: time.Second, GRPC: config.GRPCProbe{
-			IPProtocolFallback: false,
-			Service:            "NonExistingService",
+			IPProtocolFallback:  false,
+			PreferredIPProtocol: "ip4",
+			Service:             "NonExistingService",
 		},
 		}, registry, promslog.NewNopLogger())
 
@@ -494,7 +502,7 @@ func TestGRPCHealthCheckUnimplemented(t *testing.T) {
 		t.Skip("skipping; CI is failing on ipv6 dns requests")
 	}
 
-	ln, err := net.Listen("tcp", "localhost:0")
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
 	if err != nil {
 		t.Fatalf("Error listening on socket: %s", err)
 	}
@@ -518,10 +526,11 @@ func TestGRPCHealthCheckUnimplemented(t *testing.T) {
 	defer cancel()
 	registry := prometheus.NewRegistry()
 
-	result := ProbeGRPC(testCTX, "localhost:"+port,
+	result := ProbeGRPC(testCTX, "127.0.0.1:"+port,
 		config.Module{Timeout: time.Second, GRPC: config.GRPCProbe{
-			IPProtocolFallback: false,
-			Service:            "NonExistingService",
+			IPProtocolFallback:  false,
+			PreferredIPProtocol: "ip4",
+			Service:             "NonExistingService",
 		},
 		}, registry, promslog.NewNopLogger())
 
@@ -550,8 +559,9 @@ func TestGRPCAbsentFailedTLS(t *testing.T) {
 	// probe and invalid port to trigger TCP/TLS error
 	result := ProbeGRPC(testCTX, "localhost:0",
 		config.Module{Timeout: time.Second, GRPC: config.GRPCProbe{
-			IPProtocolFallback: false,
-			Service:            "NonExistingService",
+			IPProtocolFallback:  false,
+			PreferredIPProtocol: "ip4",
+			Service:             "NonExistingService",
 		},
 		}, registry, promslog.NewNopLogger())
 


### PR DESCRIPTION
PR title: prober: fix gRPC probe IP resolution and yamllint issues

<!--
    - Please give your PR a title in the form "area: short description".  For example "prober: adding metric to expose certificate fingerprint info"

    - Please sign CNCF's Developer Certificate of Origin and sign-off your commits by adding the -s / --signoff flag to `git commit`. See https://github.com/apps/dco for more information.

    - If the PR adds or changes a behaviour or fixes a bug of an exported API it would need a unit test.

    - Where possible use only exported APIs for tests to simplify the review and make it as close as possible to an actual library usage.

    - Performance improvements would need a benchmark test to prove it.

    - All exposed objects should have a comment. More at https://tip.golang.org/doc/comment

    - All comments should start with a capital letter and end with a full stop.
 -->

#### What this PR does / Which issue(s) does the PR fix:

Fixes `make` failures caused by yamllint errors in `example.yml` and config testdata, and gRPC probe test failures on hosts where `localhost` has no IPv6 address.

- Correct YAML indentation, trailing spaces, and extra blank lines flagged by yamllint.
- Dial the IP returned by `chooseProtocol` in `ProbeGRPC` instead of re-resolving the hostname (consistent with the TCP prober).
- Update gRPC tests to use `127.0.0.1` with `preferred_ip_protocol: ip4` when `ip_protocol_fallback` is disabled.

#### Does this PR introduce a user-facing change?

```release-notes
[BUGFIX] gRPC probes now connect to the resolved IP address instead of re-resolving the hostname.
```

<!--  Thanks for sending a pull request!  Before submitting:
1. Rebase your PR if it gets out of sync with main
2. Add tests for your changes
3. If relevant, update the docs (README.md or CONFIGURATION.md) and example in example.yml
-->

**Checklist**
- [x] Tests updated
- [ ] Documentation added
- [x] CHANGELOG added in `release-notes` section of PR Desc.
