### PR TITLE
Add probe_dns_reply_truncated metric to the DNS prober

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ BREAKING CHANGES:
 * [CHANGE]
 * [FEATURE]
 * [ENHANCEMENT]
+* [ENHANCEMENT] DNS prober: add `probe_dns_reply_truncated` to expose the response TC (truncated) flag. #1258
 * [BUGFIX]
 * [BUGFIX] Randomize ICMP Echo ID in probes to avoid SNAT session collisions that could drop replies for some clients.
 

--- a/prober/dns.go
+++ b/prober/dns.go
@@ -145,6 +145,10 @@ func ProbeDNS(ctx context.Context, target string, module config.Module, registry
 		Name: "probe_dns_query_succeeded",
 		Help: "Displays whether or not the query was executed successfully",
 	})
+	probeDNSReplyTruncated := prometheus.NewGauge(prometheus.GaugeOpts{
+		Name: "probe_dns_reply_truncated",
+		Help: "Returns whether the DNS reply had the truncated (TC) bit set",
+	})
 
 	for _, lv := range []string{"resolve", "connect", "request"} {
 		probeDNSDurationGaugeVec.WithLabelValues(lv)
@@ -155,6 +159,7 @@ func ProbeDNS(ctx context.Context, target string, module config.Module, registry
 	registry.MustRegister(probeDNSAuthorityRRSGauge)
 	registry.MustRegister(probeDNSAdditionalRRSGauge)
 	registry.MustRegister(probeDNSQuerySucceeded)
+	registry.MustRegister(probeDNSReplyTruncated)
 
 	qc := uint16(dns.ClassINET)
 	if module.DNS.QueryClass != "" {
@@ -279,6 +284,9 @@ func ProbeDNS(ctx context.Context, target string, module config.Module, registry
 	probeDNSAuthorityRRSGauge.Set(float64(len(response.Ns)))
 	probeDNSAdditionalRRSGauge.Set(float64(len(response.Extra)))
 	probeDNSQuerySucceeded.Set(1)
+	if response.Truncated {
+		probeDNSReplyTruncated.Set(1)
+	}
 
 	if qt == dns.TypeSOA {
 		probeDNSSOAGauge = prometheus.NewGauge(prometheus.GaugeOpts{

--- a/prober/dns_test.go
+++ b/prober/dns_test.go
@@ -183,6 +183,7 @@ func TestRecursiveDNSResponse(t *testing.T) {
 				"probe_dns_authority_rrs":   0,
 				"probe_dns_additional_rrs":  0,
 				"probe_dns_query_succeeded": 1,
+				"probe_dns_reply_truncated": 0,
 			}
 			if !test.Probe.Recursion {
 				expectedResults["probe_dns_answer_rrs"] = 0
@@ -654,4 +655,47 @@ func TestDNSMetrics(t *testing.T) {
 	}
 
 	checkMetrics(expectedMetrics, mfs, t)
+}
+
+func truncatedDNSHandler(w dns.ResponseWriter, r *dns.Msg) {
+	m := new(dns.Msg)
+	m.SetReply(r)
+	m.Truncated = true
+	a, err := dns.NewRR("example.com. 3600 IN A 127.0.0.1")
+	if err != nil {
+		panic(err)
+	}
+	m.Answer = append(m.Answer, a)
+	if err := w.WriteMsg(m); err != nil {
+		panic(err)
+	}
+}
+
+func TestTruncatedDNSResponse(t *testing.T) {
+	if os.Getenv("CI") == "true" {
+		t.Skip("skipping; CI is failing on ipv6 dns requests")
+	}
+
+	server, addr := startDNSServer("udp", truncatedDNSHandler)
+	defer server.Shutdown()
+
+	registry := prometheus.NewPedanticRegistry()
+	testCTX, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	result := ProbeDNS(testCTX, addr.String(), config.Module{Timeout: time.Second, DNS: config.DNSProbe{
+		IPProtocol:         "ip4",
+		IPProtocolFallback: true,
+		QueryName:          "example.com",
+		TransportProtocol:  "udp",
+	}}, registry, promslog.NewNopLogger())
+	if !result {
+		t.Fatalf("DNS probe failed unexpectedly")
+	}
+
+	mfs, err := registry.Gather()
+	if err != nil {
+		t.Fatal(err)
+	}
+	checkRegistryResults(map[string]float64{"probe_dns_reply_truncated": 1}, mfs, t)
 }


### PR DESCRIPTION
The DNS prober exposes counts of answer/authority/additional records but no response-header flags. A truncated reply (response larger than the UDP buffer, TC bit set) currently looks like a generic failure with no diagnostic signal.

The `*dns.Msg` from `client.Exchange` already carries the `Truncated` flag, so this adds a `probe_dns_reply_truncated` gauge: 0 normally, 1 when the reply has the TC bit set. That lets you tell a truncated reply apart from a real failure.

Added `TestTruncatedDNSResponse` (asserts 1 when the server sets TC), added the not-truncated case to the existing recursive test (asserts 0), and a CHANGELOG entry.

Closes #1258