### PR TITLE
Add workflow that lets triagers approve CI runs

### DIFF
--- a/.github/workflows/approve-workflows.yml
+++ b/.github/workflows/approve-workflows.yml
@@ -1,0 +1,24 @@
+---
+name: Approve pending workflows
+
+on:
+  issue_comment:
+    types: [created]
+
+permissions: read-all
+
+jobs:
+  approve:
+    if: >-
+      github.event.issue.pull_request &&
+      github.event.comment.body == '/workflow-approve' &&
+      github.repository_owner == 'prometheus'
+    runs-on: ubuntu-latest
+    permissions:
+      actions: write
+      contents: read
+      pull-requests: write
+    steps:
+      - uses: prometheus/promci/approve_workflows@370e8c15dcec50043cbe66f2f34633d9efc0a190
+        with:
+          github_token: ${{ github.token }}


### PR DESCRIPTION
Based on https://github.com/prometheus/promci/pull/114