### PR TITLE
Fix go vet ./... findings

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -438,7 +438,6 @@ func (s *Module) UnmarshalYAML(unmarshal func(interface{}) error) error {
 		// invalid
 		return fmt.Errorf("prober '%s' is not valid", s.Prober)
 	}
-	return nil
 }
 
 // UnmarshalYAML implements the yaml.Unmarshaler interface.

--- a/prober/dns.go
+++ b/prober/dns.go
@@ -256,7 +256,7 @@ func ProbeDNS(ctx context.Context, target string, module config.Module, registry
 	msg.Id = dns.Id()
 	msg.RecursionDesired = module.DNS.Recursion
 	msg.Question = make([]dns.Question, 1)
-	msg.Question[0] = dns.Question{dns.Fqdn(module.DNS.QueryName), qt, qc}
+	msg.Question[0] = dns.Question{Name: dns.Fqdn(module.DNS.QueryName), Qtype: qt, Qclass: qc}
 
 	logger.Debug("Making DNS query", "target", targetIP, "dial_protocol", dialProtocol, "query", module.DNS.QueryName, "type", qt, "class", qc)
 	timeoutDeadline, _ := ctx.Deadline()

--- a/prober/http_test.go
+++ b/prober/http_test.go
@@ -1299,15 +1299,15 @@ func TestFailIfHeaderMatchesRegexp(t *testing.T) {
 		Values        []string
 		ShouldSucceed bool
 	}{
-		{config.HeaderMatch{"Content-Type", config.MustNewRegexp("text/javascript"), false}, []string{"text/javascript"}, false},
-		{config.HeaderMatch{"Content-Type", config.MustNewRegexp("text/javascript"), false}, []string{"application/octet-stream"}, true},
-		{config.HeaderMatch{"content-type", config.MustNewRegexp("text/javascript"), false}, []string{"application/octet-stream"}, true},
-		{config.HeaderMatch{"Content-Type", config.MustNewRegexp(".*"), false}, []string{""}, false},
-		{config.HeaderMatch{"Content-Type", config.MustNewRegexp(".*"), false}, []string{}, false},
-		{config.HeaderMatch{"Content-Type", config.MustNewRegexp(".*"), true}, []string{""}, false},
-		{config.HeaderMatch{"Content-Type", config.MustNewRegexp(".*"), true}, []string{}, true},
-		{config.HeaderMatch{"Set-Cookie", config.MustNewRegexp(".*Domain=\\.example\\.com.*"), false}, []string{"gid=1; Expires=Tue, 19-Mar-2019 20:08:29 GMT; Domain=.example.com; Path=/"}, false},
-		{config.HeaderMatch{"Set-Cookie", config.MustNewRegexp(".*Domain=\\.example\\.com.*"), false}, []string{"zz=4; expires=Mon, 01-Jan-1990 00:00:00 GMT; Domain=www.example.com; Path=/", "gid=1; Expires=Tue, 19-Mar-2019 20:08:29 GMT; Domain=.example.com; Path=/"}, false},
+		{config.HeaderMatch{Header: "Content-Type", Regexp: config.MustNewRegexp("text/javascript"), AllowMissing: false}, []string{"text/javascript"}, false},
+		{config.HeaderMatch{Header: "Content-Type", Regexp: config.MustNewRegexp("text/javascript"), AllowMissing: false}, []string{"application/octet-stream"}, true},
+		{config.HeaderMatch{Header: "content-type", Regexp: config.MustNewRegexp("text/javascript"), AllowMissing: false}, []string{"application/octet-stream"}, true},
+		{config.HeaderMatch{Header: "Content-Type", Regexp: config.MustNewRegexp(".*"), AllowMissing: false}, []string{""}, false},
+		{config.HeaderMatch{Header: "Content-Type", Regexp: config.MustNewRegexp(".*"), AllowMissing: false}, []string{}, false},
+		{config.HeaderMatch{Header: "Content-Type", Regexp: config.MustNewRegexp(".*"), AllowMissing: true}, []string{""}, false},
+		{config.HeaderMatch{Header: "Content-Type", Regexp: config.MustNewRegexp(".*"), AllowMissing: true}, []string{}, true},
+		{config.HeaderMatch{Header: "Set-Cookie", Regexp: config.MustNewRegexp(".*Domain=\\.example\\.com.*"), AllowMissing: false}, []string{"gid=1; Expires=Tue, 19-Mar-2019 20:08:29 GMT; Domain=.example.com; Path=/"}, false},
+		{config.HeaderMatch{Header: "Set-Cookie", Regexp: config.MustNewRegexp(".*Domain=\\.example\\.com.*"), AllowMissing: false}, []string{"zz=4; expires=Mon, 01-Jan-1990 00:00:00 GMT; Domain=www.example.com; Path=/", "gid=1; Expires=Tue, 19-Mar-2019 20:08:29 GMT; Domain=.example.com; Path=/"}, false},
 	}
 
 	for i, test := range tests {
@@ -1348,14 +1348,14 @@ func TestFailIfHeaderNotMatchesRegexp(t *testing.T) {
 		Values        []string
 		ShouldSucceed bool
 	}{
-		{config.HeaderMatch{"Content-Type", config.MustNewRegexp("text/javascript"), false}, []string{"text/javascript"}, true},
-		{config.HeaderMatch{"content-type", config.MustNewRegexp("text/javascript"), false}, []string{"text/javascript"}, true},
-		{config.HeaderMatch{"Content-Type", config.MustNewRegexp("text/javascript"), false}, []string{"application/octet-stream"}, false},
-		{config.HeaderMatch{"Content-Type", config.MustNewRegexp(".*"), false}, []string{""}, true},
-		{config.HeaderMatch{"Content-Type", config.MustNewRegexp(".*"), false}, []string{}, false},
-		{config.HeaderMatch{"Content-Type", config.MustNewRegexp(".*"), true}, []string{}, true},
-		{config.HeaderMatch{"Set-Cookie", config.MustNewRegexp(".*Domain=\\.example\\.com.*"), false}, []string{"zz=4; expires=Mon, 01-Jan-1990 00:00:00 GMT; Domain=www.example.com; Path=/"}, false},
-		{config.HeaderMatch{"Set-Cookie", config.MustNewRegexp(".*Domain=\\.example\\.com.*"), false}, []string{"zz=4; expires=Mon, 01-Jan-1990 00:00:00 GMT; Domain=www.example.com; Path=/", "gid=1; Expires=Tue, 19-Mar-2019 20:08:29 GMT; Domain=.example.com; Path=/"}, true},
+		{config.HeaderMatch{Header: "Content-Type", Regexp: config.MustNewRegexp("text/javascript"), AllowMissing: false}, []string{"text/javascript"}, true},
+		{config.HeaderMatch{Header: "content-type", Regexp: config.MustNewRegexp("text/javascript"), AllowMissing: false}, []string{"text/javascript"}, true},
+		{config.HeaderMatch{Header: "Content-Type", Regexp: config.MustNewRegexp("text/javascript"), AllowMissing: false}, []string{"application/octet-stream"}, false},
+		{config.HeaderMatch{Header: "Content-Type", Regexp: config.MustNewRegexp(".*"), AllowMissing: false}, []string{""}, true},
+		{config.HeaderMatch{Header: "Content-Type", Regexp: config.MustNewRegexp(".*"), AllowMissing: false}, []string{}, false},
+		{config.HeaderMatch{Header: "Content-Type", Regexp: config.MustNewRegexp(".*"), AllowMissing: true}, []string{}, true},
+		{config.HeaderMatch{Header: "Set-Cookie", Regexp: config.MustNewRegexp(".*Domain=\\.example\\.com.*"), AllowMissing: false}, []string{"zz=4; expires=Mon, 01-Jan-1990 00:00:00 GMT; Domain=www.example.com; Path=/"}, false},
+		{config.HeaderMatch{Header: "Set-Cookie", Regexp: config.MustNewRegexp(".*Domain=\\.example\\.com.*"), AllowMissing: false}, []string{"zz=4; expires=Mon, 01-Jan-1990 00:00:00 GMT; Domain=www.example.com; Path=/", "gid=1; Expires=Tue, 19-Mar-2019 20:08:29 GMT; Domain=.example.com; Path=/"}, true},
 	}
 
 	for i, test := range tests {


### PR DESCRIPTION
`go test`'s built-in vet subset does not run the `composites` or `unreachable` analyzers, so these `go vet ./...` findings are not caught by the normal test pipeline:

- **config**: drop the unreachable `return nil` after the exhaustive switch in `Module.UnmarshalYAML` (both the valid case and the default already return).
- **prober/dns**: use keyed fields for the `dns.Question` composite literal, so it is robust to field reordering in `github.com/miekg/dns`.
- **prober**: use keyed fields for the `config.HeaderMatch` literals in the HTTP header-match tests (17 occurrences).

No behavior change. `go vet ./...` is clean afterwards; `go build`, `go test ./...` pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)