### PR TITLE
Set ReadHeaderTimeout on the HTTP server

### DIFF
--- a/main.go
+++ b/main.go
@@ -69,6 +69,18 @@ func init() {
 	prometheus.MustRegister(versioncollector.NewCollector("blackbox_exporter"))
 }
 
+// serverReadHeaderTimeout bounds how long the server waits to read request
+// headers, mitigating Slowloris-style connection exhaustion. It covers only
+// header reading, not the probe handler, so a generous value is safe. It is a
+// package var so tests can shorten it.
+var serverReadHeaderTimeout = time.Minute
+
+// newServer builds the exporter's HTTP server with the hardening options the
+// exporter-toolkit does not set itself.
+func newServer() *http.Server {
+	return &http.Server{ReadHeaderTimeout: serverReadHeaderTimeout}
+}
+
 func main() {
 	os.Exit(run())
 }
@@ -290,7 +302,7 @@ func run() int {
 		w.Write(c)
 	})
 
-	srv := &http.Server{}
+	srv := newServer()
 	srvc := make(chan struct{})
 	term := make(chan os.Signal, 1)
 	signal.Notify(term, os.Interrupt, syscall.SIGTERM)

--- a/server_test.go
+++ b/server_test.go
@@ -1,0 +1,78 @@
+// Copyright 2016 The Prometheus Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+import (
+	"net"
+	"net/http"
+	"testing"
+	"time"
+)
+
+// TestServerReadHeaderTimeout verifies that the server built by newServer closes
+// a connection whose request headers never complete — i.e. ReadHeaderTimeout is
+// set and effective. Without it, such a connection would be held open
+// indefinitely (a Slowloris vector). A well-formed request must still succeed.
+func TestServerReadHeaderTimeout(t *testing.T) {
+	// Shorten the production timeout for the test; newServer reads this var.
+	orig := serverReadHeaderTimeout
+	serverReadHeaderTimeout = 250 * time.Millisecond
+	t.Cleanup(func() { serverReadHeaderTimeout = orig })
+
+	srv := newServer()
+	srv.Handler = http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	})
+
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("listen: %v", err)
+	}
+	t.Cleanup(func() { _ = ln.Close() })
+	go func() { _ = srv.Serve(ln) }()
+	t.Cleanup(func() { _ = srv.Close() })
+
+	// Sanity: a well-formed request still succeeds.
+	resp, err := http.Get("http://" + ln.Addr().String() + "/")
+	if err != nil {
+		t.Fatalf("well-formed request failed: %v", err)
+	}
+	_ = resp.Body.Close()
+
+	// A client that starts the request headers but never terminates them (no
+	// final CRLF), holding the connection open.
+	conn, err := net.Dial("tcp", ln.Addr().String())
+	if err != nil {
+		t.Fatalf("dial: %v", err)
+	}
+	t.Cleanup(func() { _ = conn.Close() })
+	if _, err := conn.Write([]byte("GET / HTTP/1.1\r\nHost: localhost\r\n")); err != nil {
+		t.Fatalf("write partial request: %v", err)
+	}
+
+	// The server must close the connection once ReadHeaderTimeout elapses. Read
+	// in a goroutine so the test never hangs if the timeout is not enforced.
+	done := make(chan struct{})
+	go func() {
+		_, _ = conn.Read(make([]byte, 1)) // returns on server close (EOF or 408)
+		close(done)
+	}()
+
+	select {
+	case <-done:
+		// Server closed the stalled connection: ReadHeaderTimeout is effective.
+	case <-time.After(5 * time.Second):
+		t.Fatal("server did not close the stalled connection within 5s; ReadHeaderTimeout not effective")
+	}
+}


### PR DESCRIPTION
## Security: bound HTTP request-header reads (Slowloris / gosec G112)

The `&http.Server{}` handed to `web.ListenAndServe` left `ReadHeaderTimeout`
unset, so request-header reads were **unbounded** — a Slowloris-style
connection-exhaustion denial-of-service vector, and why `gosec` flags G112 here.
The exporter-toolkit does not set any server timeouts either, so nothing else
bounds it.

Set `ReadHeaderTimeout` to one minute via a small `newServer` constructor. It
bounds only header reading, **not** the probe handler, so legitimate probe
requests (which can run for the full scrape timeout) are unaffected. This closes
the DoS vector and lowers the exporter's network-facing attack surface. Happy to
adjust the value if a different bound is preferred.

A regression test drives a stalled-header client at the server and asserts the
connection is closed once the timeout elapses, while a well-formed request still
succeeds.

`go build`, `go vet`, `go test ./...` pass; `gosec` G112 clears.

🤖 Generated with [Claude Code](https://claude.com/claude-code)