### PR TITLE
prober/unix: return the TLS-config error instead of a nil error

### DIFF
--- a/prober/unix.go
+++ b/prober/unix.go
@@ -41,8 +41,8 @@ func dialUnix(ctx context.Context, target string, module config.Module, _ *prome
 	} else {
 		tlsConfig, tlsErr := pconfig.NewTLSConfig(&module.Unix.TLSConfig)
 		if tlsErr != nil {
-			logger.Error("Error creating TLS configuration", "err", err)
-			return nil, err
+			logger.Error("Error creating TLS configuration", "err", tlsErr)
+			return nil, tlsErr
 		}
 
 		timeoutDeadline, _ := ctx.Deadline()


### PR DESCRIPTION
In the unix prober's `dialUnix`, a TLS-configuration failure is silently swallowed:

```go
tlsConfig, tlsErr := pconfig.NewTLSConfig(&module.Unix.TLSConfig)
if tlsErr != nil {
    logger.Error("Error creating TLS configuration", "err", err) // logs err (nil), not tlsErr
    return nil, err                                              // returns nil, nil
}
```

`err` is the outer variable, unassigned (nil) at this point — so on a bad TLS
config `dialUnix` returns `(nil, nil)`. The caller sees no error and proceeds
with a nil connection instead of surfacing the misconfiguration.

Return (and log) `tlsErr`.

`go build` and `go test ./...` pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)