### PR TITLE
Log probe outcome failures at info instead of error

### DIFF
--- a/prober/dns.go
+++ b/prober/dns.go
@@ -35,11 +35,11 @@ func validRRs(rrs *[]dns.RR, v *config.DNSRRValidator, logger *slog.Logger) bool
 	// Fail the probe if there are no RRs of a given type, but a regexp match is required
 	// (i.e. FailIfNotMatchesRegexp or FailIfNoneMatchesRegexp is set).
 	if len(*rrs) == 0 && len(v.FailIfNotMatchesRegexp) > 0 {
-		logger.Error("fail_if_not_matches_regexp specified but no RRs returned")
+		logger.Info("fail_if_not_matches_regexp specified but no RRs returned")
 		return false
 	}
 	if len(*rrs) == 0 && len(v.FailIfNoneMatchesRegexp) > 0 {
-		logger.Error("fail_if_none_matches_regexp specified but no RRs returned")
+		logger.Info("fail_if_none_matches_regexp specified but no RRs returned")
 		return false
 	}
 	for _, rr := range *rrs {
@@ -47,18 +47,18 @@ func validRRs(rrs *[]dns.RR, v *config.DNSRRValidator, logger *slog.Logger) bool
 		for _, re := range v.FailIfMatchesRegexp {
 			match, err := regexp.MatchString(re, rr.String())
 			if err != nil {
-				logger.Error("Error matching regexp", "regexp", re, "err", err)
+				logger.Info("Error matching regexp", "regexp", re, "err", err)
 				return false
 			}
 			if match {
-				logger.Error("At least one RR matched regexp", "regexp", re, "rr", rr)
+				logger.Info("At least one RR matched regexp", "regexp", re, "rr", rr)
 				return false
 			}
 		}
 		for _, re := range v.FailIfAllMatchRegexp {
 			match, err := regexp.MatchString(re, rr.String())
 			if err != nil {
-				logger.Error("Error matching regexp", "regexp", re, "err", err)
+				logger.Info("Error matching regexp", "regexp", re, "err", err)
 				return false
 			}
 			if !match {
@@ -68,18 +68,18 @@ func validRRs(rrs *[]dns.RR, v *config.DNSRRValidator, logger *slog.Logger) bool
 		for _, re := range v.FailIfNotMatchesRegexp {
 			match, err := regexp.MatchString(re, rr.String())
 			if err != nil {
-				logger.Error("Error matching regexp", "regexp", re, "err", err)
+				logger.Info("Error matching regexp", "regexp", re, "err", err)
 				return false
 			}
 			if !match {
-				logger.Error("At least one RR did not match regexp", "regexp", re, "rr", rr)
+				logger.Info("At least one RR did not match regexp", "regexp", re, "rr", rr)
 				return false
 			}
 		}
 		for _, re := range v.FailIfNoneMatchesRegexp {
 			match, err := regexp.MatchString(re, rr.String())
 			if err != nil {
-				logger.Error("Error matching regexp", "regexp", re, "err", err)
+				logger.Info("Error matching regexp", "regexp", re, "err", err)
 				return false
 			}
 			if match {
@@ -88,11 +88,11 @@ func validRRs(rrs *[]dns.RR, v *config.DNSRRValidator, logger *slog.Logger) bool
 		}
 	}
 	if len(v.FailIfAllMatchRegexp) > 0 && !allMatch {
-		logger.Error("Not all RRs matched regexp")
+		logger.Info("Not all RRs matched regexp")
 		return false
 	}
 	if len(v.FailIfNoneMatchesRegexp) > 0 && !anyMatch {
-		logger.Error("None of the RRs did matched any regexp")
+		logger.Info("None of the RRs did matched any regexp")
 		return false
 	}
 	return true
@@ -118,7 +118,7 @@ func validRcode(rcode int, valid []string, logger *slog.Logger) bool {
 		logger.Debug("Rcode is valid", "rcode", rcode, "string_rcode", dns.RcodeToString[rcode])
 		return true
 	}
-	logger.Error("Rcode is not one of the valid rcodes", "rcode", rcode, "string_rcode", dns.RcodeToString[rcode], "valid_rcodes", validRcodes)
+	logger.Info("Rcode is not one of the valid rcodes", "rcode", rcode, "string_rcode", dns.RcodeToString[rcode], "valid_rcodes", validRcodes)
 	return false
 }
 
@@ -197,7 +197,7 @@ func ProbeDNS(ctx context.Context, target string, module config.Module, registry
 	}
 	ip, lookupTime, err := chooseProtocol(ctx, module.DNS.IPProtocol, module.DNS.IPProtocolFallback, targetAddr, registry, logger)
 	if err != nil {
-		logger.Error("Error resolving address", "err", err)
+		logger.Info("Error resolving address", "err", err)
 		return false
 	}
 	probeDNSDurationGaugeVec.WithLabelValues("resolve").Add(lookupTime)
@@ -269,7 +269,7 @@ func ProbeDNS(ctx context.Context, target string, module config.Module, registry
 	probeDNSDurationGaugeVec.WithLabelValues("connect").Set((time.Since(requestStart) - rtt).Seconds())
 	probeDNSDurationGaugeVec.WithLabelValues("request").Set(rtt.Seconds())
 	if err != nil {
-		logger.Error("Error while sending a DNS query", "err", err)
+		logger.Info("Error while sending a DNS query", "err", err)
 		return false
 	}
 	logger.Debug("Got response", "response", response)
@@ -298,17 +298,17 @@ func ProbeDNS(ctx context.Context, target string, module config.Module, registry
 	}
 	logger.Debug("Validating Answer RRs")
 	if !validRRs(&response.Answer, &module.DNS.ValidateAnswer, logger) {
-		logger.Error("Answer RRs validation failed")
+		logger.Info("Answer RRs validation failed")
 		return false
 	}
 	logger.Debug("Validating Authority RRs")
 	if !validRRs(&response.Ns, &module.DNS.ValidateAuthority, logger) {
-		logger.Error("Authority RRs validation failed")
+		logger.Info("Authority RRs validation failed")
 		return false
 	}
 	logger.Debug("Validating Additional RRs")
 	if !validRRs(&response.Extra, &module.DNS.ValidateAdditional, logger) {
-		logger.Error("Additional RRs validation failed")
+		logger.Info("Additional RRs validation failed")
 		return false
 	}
 	return true

--- a/prober/grpc.go
+++ b/prober/grpc.go
@@ -131,7 +131,7 @@ func ProbeGRPC(ctx context.Context, target string, module config.Module, registr
 
 	targetURL, err := url.Parse(target)
 	if err != nil {
-		logger.Error("Could not parse target URL", "err", err)
+		logger.Info("Could not parse target URL", "err", err)
 		return false
 	}
 
@@ -151,7 +151,7 @@ func ProbeGRPC(ctx context.Context, target string, module config.Module, registr
 
 	ip, lookupTime, err := chooseProtocol(ctx, module.GRPC.PreferredIPProtocol, module.GRPC.IPProtocolFallback, targetHost, registry, logger)
 	if err != nil {
-		logger.Error("Error resolving address", "err", err)
+		logger.Info("Error resolving address", "err", err)
 		return false
 	}
 	durationGaugeVec.WithLabelValues("resolve").Add(lookupTime)
@@ -187,7 +187,7 @@ func ProbeGRPC(ctx context.Context, target string, module config.Module, registr
 	conn, err := grpc.NewClient(target, opts...)
 
 	if err != nil {
-		logger.Error("did not connect", "err", err)
+		logger.Info("did not connect", "err", err)
 	}
 
 	client := NewGrpcHealthCheckClient(conn)
@@ -217,7 +217,7 @@ func ProbeGRPC(ctx context.Context, target string, module config.Module, registr
 	statusCodeGauge.Set(float64(statusCode))
 
 	if !ok || err != nil {
-		logger.Error("can't connect grpc server:", "err", err)
+		logger.Info("can't connect grpc server:", "err", err)
 		success = false
 	} else {
 		logger.Debug("connect the grpc server successfully")

--- a/prober/grpc.go
+++ b/prober/grpc.go
@@ -131,7 +131,7 @@ func ProbeGRPC(ctx context.Context, target string, module config.Module, registr
 
 	targetURL, err := url.Parse(target)
 	if err != nil {
-		logger.Error("Could not parse target URL", "err", err)
+		logger.Info("Could not parse target URL", "err", err)
 		return false
 	}
 
@@ -151,7 +151,7 @@ func ProbeGRPC(ctx context.Context, target string, module config.Module, registr
 
 	ip, lookupTime, err := chooseProtocol(ctx, module.GRPC.PreferredIPProtocol, module.GRPC.IPProtocolFallback, targetHost, registry, logger)
 	if err != nil {
-		logger.Error("Error resolving address", "err", err)
+		logger.Info("Error resolving address", "err", err)
 		return false
 	}
 	durationGaugeVec.WithLabelValues("resolve").Add(lookupTime)
@@ -187,7 +187,7 @@ func ProbeGRPC(ctx context.Context, target string, module config.Module, registr
 	conn, err := grpc.NewClient(target, opts...)
 
 	if err != nil {
-		logger.Error("did not connect", "err", err)
+		logger.Info("did not connect", "err", err)
 		return false
 	}
 
@@ -219,7 +219,7 @@ func ProbeGRPC(ctx context.Context, target string, module config.Module, registr
 	statusCodeGauge.Set(float64(statusCode))
 
 	if !ok || err != nil {
-		logger.Error("can't connect grpc server:", "err", err)
+		logger.Info("can't connect grpc server:", "err", err)
 		success = false
 	} else {
 		logger.Debug("connect the grpc server successfully")

--- a/prober/handler.go
+++ b/prober/handler.go
@@ -138,7 +138,7 @@ func Handler(w http.ResponseWriter, r *http.Request, c *config.Config, logger *s
 		probeSuccessGauge.Set(1)
 		slLogger.Debug("Probe succeeded", "duration_seconds", duration)
 	} else {
-		slLogger.Error("Probe failed", "duration_seconds", duration)
+		slLogger.Info("Probe failed", "duration_seconds", duration)
 	}
 
 	debugOutput := DebugOutput(&module, sl.buffer, registry)

--- a/prober/http.go
+++ b/prober/http.go
@@ -51,18 +51,18 @@ import (
 func matchRegularExpressions(reader io.Reader, httpConfig config.HTTPProbe, logger *slog.Logger) bool {
 	body, err := io.ReadAll(reader)
 	if err != nil {
-		logger.Error("Error reading HTTP body", "err", err)
+		logger.Info("Error reading HTTP body", "err", err)
 		return false
 	}
 	for _, expression := range httpConfig.FailIfBodyMatchesRegexp {
 		if expression.Match(body) {
-			logger.Error("Body matched regular expression", "regexp", expression)
+			logger.Info("Body matched regular expression", "regexp", expression)
 			return false
 		}
 	}
 	for _, expression := range httpConfig.FailIfBodyNotMatchesRegexp {
 		if !expression.Match(body) {
-			logger.Error("Body did not match regular expression", "regexp", expression)
+			logger.Info("Body did not match regular expression", "regexp", expression)
 			return false
 		}
 	}
@@ -72,13 +72,13 @@ func matchRegularExpressions(reader io.Reader, httpConfig config.HTTPProbe, logg
 func matchCELExpressions(ctx context.Context, reader io.Reader, httpConfig config.HTTPProbe, logger *slog.Logger) bool {
 	body, err := io.ReadAll(reader)
 	if err != nil {
-		logger.Error("Error reading HTTP body", "err", err)
+		logger.Info("Error reading HTTP body", "err", err)
 		return false
 	}
 
 	var bodyJSON any
 	if err := json.Unmarshal(body, &bodyJSON); err != nil {
-		logger.Error("Error unmarshalling HTTP body to JSON", "err", err)
+		logger.Info("Error unmarshalling HTTP body to JSON", "err", err)
 		return false
 	}
 
@@ -89,15 +89,15 @@ func matchCELExpressions(ctx context.Context, reader io.Reader, httpConfig confi
 	if httpConfig.FailIfBodyJSONMatchesCEL != nil {
 		result, details, err := httpConfig.FailIfBodyJSONMatchesCEL.ContextEval(ctx, evalPayload)
 		if err != nil {
-			logger.Error("Error evaluating CEL expression", "err", err)
+			logger.Info("Error evaluating CEL expression", "err", err)
 			return false
 		}
 		if result.Type() != cel.BoolType {
-			logger.Error("CEL evaluation result is not a boolean", "details", details)
+			logger.Info("CEL evaluation result is not a boolean", "details", details)
 			return false
 		}
 		if result.Type() == cel.BoolType && result.Value().(bool) {
-			logger.Error("Body matched CEL expression", "expression", httpConfig.FailIfBodyJSONMatchesCEL.Expression)
+			logger.Info("Body matched CEL expression", "expression", httpConfig.FailIfBodyJSONMatchesCEL.Expression)
 			return false
 		}
 	}
@@ -105,15 +105,15 @@ func matchCELExpressions(ctx context.Context, reader io.Reader, httpConfig confi
 	if httpConfig.FailIfBodyJSONNotMatchesCEL != nil {
 		result, details, err := httpConfig.FailIfBodyJSONNotMatchesCEL.ContextEval(ctx, evalPayload)
 		if err != nil {
-			logger.Error("Error evaluating CEL expression", "err", err)
+			logger.Info("Error evaluating CEL expression", "err", err)
 			return false
 		}
 		if result.Type() != cel.BoolType {
-			logger.Error("CEL evaluation result is not a boolean", "details", details)
+			logger.Info("CEL evaluation result is not a boolean", "details", details)
 			return false
 		}
 		if result.Type() == cel.BoolType && !result.Value().(bool) {
-			logger.Error("Body did not match CEL expression", "expression", httpConfig.FailIfBodyJSONNotMatchesCEL.Expression)
+			logger.Info("Body did not match CEL expression", "expression", httpConfig.FailIfBodyJSONNotMatchesCEL.Expression)
 			return false
 		}
 	}
@@ -126,14 +126,14 @@ func matchRegularExpressionsOnHeaders(header http.Header, httpConfig config.HTTP
 		values := header[textproto.CanonicalMIMEHeaderKey(headerMatchSpec.Header)]
 		if len(values) == 0 {
 			if !headerMatchSpec.AllowMissing {
-				logger.Error("Missing required header", "header", headerMatchSpec.Header)
+				logger.Info("Missing required header", "header", headerMatchSpec.Header)
 				return false
 			}
 			continue // No need to match any regex on missing headers.
 		}
 
 		if slices.ContainsFunc(values, headerMatchSpec.Regexp.MatchString) {
-			logger.Error("Header matched regular expression", "header", headerMatchSpec.Header,
+			logger.Info("Header matched regular expression", "header", headerMatchSpec.Header,
 				"regexp", headerMatchSpec.Regexp, "value_count", len(values))
 			return false
 		}
@@ -142,7 +142,7 @@ func matchRegularExpressionsOnHeaders(header http.Header, httpConfig config.HTTP
 		values := header[textproto.CanonicalMIMEHeaderKey(headerMatchSpec.Header)]
 		if len(values) == 0 {
 			if !headerMatchSpec.AllowMissing {
-				logger.Error("Missing required header", "header", headerMatchSpec.Header)
+				logger.Info("Missing required header", "header", headerMatchSpec.Header)
 				return false
 			}
 			continue // No need to match any regex on missing headers.
@@ -151,7 +151,7 @@ func matchRegularExpressionsOnHeaders(header http.Header, httpConfig config.HTTP
 		anyHeaderValueMatched := slices.ContainsFunc(values, headerMatchSpec.Regexp.MatchString)
 
 		if !anyHeaderValueMatched {
-			logger.Error("Header did not match regular expression", "header", headerMatchSpec.Header,
+			logger.Info("Header did not match regular expression", "header", headerMatchSpec.Header,
 				"regexp", headerMatchSpec.Regexp, "value_count", len(values))
 			return false
 		}
@@ -385,7 +385,7 @@ func ProbeHTTP(ctx context.Context, target string, module config.Module, registr
 
 	targetURL, err := url.Parse(target)
 	if err != nil {
-		logger.Error("Could not parse target URL", "err", err)
+		logger.Info("Could not parse target URL", "err", err)
 		return false
 	}
 
@@ -398,7 +398,7 @@ func ProbeHTTP(ctx context.Context, target string, module config.Module, registr
 		ip, lookupTime, err = chooseProtocol(ctx, module.HTTP.IPProtocol, module.HTTP.IPProtocolFallback, targetHost, registry, logger)
 		durationGaugeVec.WithLabelValues("resolve").Add(lookupTime)
 		if err != nil {
-			logger.Error("Error resolving address", "err", err)
+			logger.Info("Error resolving address", "err", err)
 			return false
 		}
 	}
@@ -574,7 +574,7 @@ func ProbeHTTP(ctx context.Context, target string, module config.Module, registr
 	if resp == nil {
 		resp = &http.Response{}
 		if err != nil {
-			logger.Error("Error for HTTP request", "err", err)
+			logger.Info("Error for HTTP request", "err", err)
 		}
 	} else {
 		requestErrored := (err != nil)
@@ -585,13 +585,13 @@ func ProbeHTTP(ctx context.Context, target string, module config.Module, registr
 				success = true
 			}
 			if !success {
-				logger.Error("Invalid HTTP response status code", "status_code", resp.StatusCode,
+				logger.Info("Invalid HTTP response status code", "status_code", resp.StatusCode,
 					"valid_status_codes", fmt.Sprintf("%v", httpConfig.ValidStatusCodes))
 			}
 		} else if 200 <= resp.StatusCode && resp.StatusCode < 300 {
 			success = true
 		} else {
-			logger.Error("Invalid HTTP response status code, wanted 2xx", "status_code", resp.StatusCode)
+			logger.Info("Invalid HTTP response status code, wanted 2xx", "status_code", resp.StatusCode)
 		}
 
 		if success && (len(httpConfig.FailIfHeaderMatchesRegexp) > 0 || len(httpConfig.FailIfHeaderNotMatchesRegexp) > 0) {
@@ -609,7 +609,7 @@ func ProbeHTTP(ctx context.Context, target string, module config.Module, registr
 		if httpConfig.Compression != "" {
 			dec, err := getDecompressionReader(httpConfig.Compression, resp.Body)
 			if err != nil {
-				logger.Error("Failed to get decompressor for HTTP response body", "err", err)
+				logger.Info("Failed to get decompressor for HTTP response body", "err", err)
 				success = false
 			} else if dec != nil {
 				// Since we are replacing the original resp.Body with the decoder, we need to make sure
@@ -620,7 +620,7 @@ func ProbeHTTP(ctx context.Context, target string, module config.Module, registr
 					if err != nil {
 						// At this point we cannot really do anything with this error, but log
 						// it in case it contains useful information as to what's the problem.
-						logger.Error("Error while closing response from server", "err", err)
+						logger.Info("Error while closing response from server", "err", err)
 					}
 				}(resp.Body)
 
@@ -659,7 +659,7 @@ func ProbeHTTP(ctx context.Context, target string, module config.Module, registr
 		if !requestErrored {
 			_, err = io.Copy(io.Discard, byteCounter)
 			if err != nil {
-				logger.Error("Failed to read HTTP response body", "err", err)
+				logger.Info("Failed to read HTTP response body", "err", err)
 				success = false
 			}
 
@@ -669,7 +669,7 @@ func ProbeHTTP(ctx context.Context, target string, module config.Module, registr
 				// We have already read everything we could from the server, maybe even uncompressed the
 				// body. The error here might be either a decompression error or a TCP error. Log it in
 				// case it contains useful information as to what's the problem.
-				logger.Error("Error while closing response from server", "error", err.Error())
+				logger.Info("Error while closing response from server", "error", err.Error())
 			}
 		}
 
@@ -685,14 +685,14 @@ func ProbeHTTP(ctx context.Context, target string, module config.Module, registr
 		var httpVersionNumber float64
 		httpVersionNumber, err = strconv.ParseFloat(strings.TrimPrefix(resp.Proto, "HTTP/"), 64)
 		if err != nil {
-			logger.Error("Error parsing version number from HTTP version", "err", err)
+			logger.Info("Error parsing version number from HTTP version", "err", err)
 		}
 		probeHTTPVersionGauge.Set(httpVersionNumber)
 
 		if len(httpConfig.ValidHTTPVersions) != 0 {
 			found := slices.Contains(httpConfig.ValidHTTPVersions, resp.Proto)
 			if !found {
-				logger.Error("Invalid HTTP version number", "version", resp.Proto)
+				logger.Info("Invalid HTTP version number", "version", resp.Proto)
 				success = false
 			}
 		}
@@ -752,11 +752,11 @@ func ProbeHTTP(ctx context.Context, target string, module config.Module, registr
 		probeSSLLastChainExpiryTimestampSeconds.Set(float64(getLastChainExpiry(resp.TLS).Unix()))
 		probeSSLLastInformation.WithLabelValues(getFingerprint(resp.TLS), getSubject(resp.TLS), getIssuer(resp.TLS), getDNSNames(resp.TLS), getSerialNumber(resp.TLS)).Set(1)
 		if httpConfig.FailIfSSL {
-			logger.Error("Final request was over SSL")
+			logger.Info("Final request was over SSL")
 			success = false
 		}
 	} else if httpConfig.FailIfNotSSL && success {
-		logger.Error("Final request was not over SSL")
+		logger.Info("Final request was not over SSL")
 		success = false
 	}
 

--- a/prober/http.go
+++ b/prober/http.go
@@ -51,18 +51,18 @@ import (
 func matchRegularExpressions(reader io.Reader, httpConfig config.HTTPProbe, logger *slog.Logger) bool {
 	body, err := io.ReadAll(reader)
 	if err != nil {
-		logger.Error("Error reading HTTP body", "err", err)
+		logger.Info("Error reading HTTP body", "err", err)
 		return false
 	}
 	for _, expression := range httpConfig.FailIfBodyMatchesRegexp {
 		if expression.Match(body) {
-			logger.Error("Body matched regular expression", "regexp", expression)
+			logger.Info("Body matched regular expression", "regexp", expression)
 			return false
 		}
 	}
 	for _, expression := range httpConfig.FailIfBodyNotMatchesRegexp {
 		if !expression.Match(body) {
-			logger.Error("Body did not match regular expression", "regexp", expression)
+			logger.Info("Body did not match regular expression", "regexp", expression)
 			return false
 		}
 	}
@@ -72,13 +72,13 @@ func matchRegularExpressions(reader io.Reader, httpConfig config.HTTPProbe, logg
 func matchCELExpressions(ctx context.Context, reader io.Reader, httpConfig config.HTTPProbe, logger *slog.Logger) bool {
 	body, err := io.ReadAll(reader)
 	if err != nil {
-		logger.Error("Error reading HTTP body", "err", err)
+		logger.Info("Error reading HTTP body", "err", err)
 		return false
 	}
 
 	var bodyJSON any
 	if err := json.Unmarshal(body, &bodyJSON); err != nil {
-		logger.Error("Error unmarshalling HTTP body to JSON", "err", err)
+		logger.Info("Error unmarshalling HTTP body to JSON", "err", err)
 		return false
 	}
 
@@ -89,15 +89,15 @@ func matchCELExpressions(ctx context.Context, reader io.Reader, httpConfig confi
 	if httpConfig.FailIfBodyJSONMatchesCEL != nil {
 		result, details, err := httpConfig.FailIfBodyJSONMatchesCEL.ContextEval(ctx, evalPayload)
 		if err != nil {
-			logger.Error("Error evaluating CEL expression", "err", err)
+			logger.Info("Error evaluating CEL expression", "err", err)
 			return false
 		}
 		if result.Type() != cel.BoolType {
-			logger.Error("CEL evaluation result is not a boolean", "details", details)
+			logger.Info("CEL evaluation result is not a boolean", "details", details)
 			return false
 		}
 		if result.Type() == cel.BoolType && result.Value().(bool) {
-			logger.Error("Body matched CEL expression", "expression", httpConfig.FailIfBodyJSONMatchesCEL.Expression)
+			logger.Info("Body matched CEL expression", "expression", httpConfig.FailIfBodyJSONMatchesCEL.Expression)
 			return false
 		}
 	}
@@ -105,15 +105,15 @@ func matchCELExpressions(ctx context.Context, reader io.Reader, httpConfig confi
 	if httpConfig.FailIfBodyJSONNotMatchesCEL != nil {
 		result, details, err := httpConfig.FailIfBodyJSONNotMatchesCEL.ContextEval(ctx, evalPayload)
 		if err != nil {
-			logger.Error("Error evaluating CEL expression", "err", err)
+			logger.Info("Error evaluating CEL expression", "err", err)
 			return false
 		}
 		if result.Type() != cel.BoolType {
-			logger.Error("CEL evaluation result is not a boolean", "details", details)
+			logger.Info("CEL evaluation result is not a boolean", "details", details)
 			return false
 		}
 		if result.Type() == cel.BoolType && !result.Value().(bool) {
-			logger.Error("Body did not match CEL expression", "expression", httpConfig.FailIfBodyJSONNotMatchesCEL.Expression)
+			logger.Info("Body did not match CEL expression", "expression", httpConfig.FailIfBodyJSONNotMatchesCEL.Expression)
 			return false
 		}
 	}
@@ -126,14 +126,14 @@ func matchRegularExpressionsOnHeaders(header http.Header, httpConfig config.HTTP
 		values := header[textproto.CanonicalMIMEHeaderKey(headerMatchSpec.Header)]
 		if len(values) == 0 {
 			if !headerMatchSpec.AllowMissing {
-				logger.Error("Missing required header", "header", headerMatchSpec.Header)
+				logger.Info("Missing required header", "header", headerMatchSpec.Header)
 				return false
 			}
 			continue // No need to match any regex on missing headers.
 		}
 
 		if slices.ContainsFunc(values, headerMatchSpec.Regexp.MatchString) {
-			logger.Error("Header matched regular expression", "header", headerMatchSpec.Header,
+			logger.Info("Header matched regular expression", "header", headerMatchSpec.Header,
 				"regexp", headerMatchSpec.Regexp, "value_count", len(values))
 			return false
 		}
@@ -142,7 +142,7 @@ func matchRegularExpressionsOnHeaders(header http.Header, httpConfig config.HTTP
 		values := header[textproto.CanonicalMIMEHeaderKey(headerMatchSpec.Header)]
 		if len(values) == 0 {
 			if !headerMatchSpec.AllowMissing {
-				logger.Error("Missing required header", "header", headerMatchSpec.Header)
+				logger.Info("Missing required header", "header", headerMatchSpec.Header)
 				return false
 			}
 			continue // No need to match any regex on missing headers.
@@ -151,7 +151,7 @@ func matchRegularExpressionsOnHeaders(header http.Header, httpConfig config.HTTP
 		anyHeaderValueMatched := slices.ContainsFunc(values, headerMatchSpec.Regexp.MatchString)
 
 		if !anyHeaderValueMatched {
-			logger.Error("Header did not match regular expression", "header", headerMatchSpec.Header,
+			logger.Info("Header did not match regular expression", "header", headerMatchSpec.Header,
 				"regexp", headerMatchSpec.Regexp, "value_count", len(values))
 			return false
 		}
@@ -385,7 +385,7 @@ func ProbeHTTP(ctx context.Context, target string, module config.Module, registr
 
 	targetURL, err := url.Parse(target)
 	if err != nil {
-		logger.Error("Could not parse target URL", "err", err)
+		logger.Info("Could not parse target URL", "err", err)
 		return false
 	}
 
@@ -398,7 +398,7 @@ func ProbeHTTP(ctx context.Context, target string, module config.Module, registr
 		ip, lookupTime, err = chooseProtocol(ctx, module.HTTP.IPProtocol, module.HTTP.IPProtocolFallback, targetHost, registry, logger)
 		durationGaugeVec.WithLabelValues("resolve").Add(lookupTime)
 		if err != nil {
-			logger.Error("Error resolving address", "err", err)
+			logger.Info("Error resolving address", "err", err)
 			return false
 		}
 	}
@@ -574,7 +574,7 @@ func ProbeHTTP(ctx context.Context, target string, module config.Module, registr
 	if resp == nil {
 		resp = &http.Response{}
 		if err != nil {
-			logger.Error("Error for HTTP request", "err", err)
+			logger.Info("Error for HTTP request", "err", err)
 		}
 	} else {
 		requestErrored := (err != nil)
@@ -585,13 +585,13 @@ func ProbeHTTP(ctx context.Context, target string, module config.Module, registr
 				success = true
 			}
 			if !success {
-				logger.Error("Invalid HTTP response status code", "status_code", resp.StatusCode,
+				logger.Info("Invalid HTTP response status code", "status_code", resp.StatusCode,
 					"valid_status_codes", fmt.Sprintf("%v", httpConfig.ValidStatusCodes))
 			}
 		} else if 200 <= resp.StatusCode && resp.StatusCode < 300 {
 			success = true
 		} else {
-			logger.Error("Invalid HTTP response status code, wanted 2xx", "status_code", resp.StatusCode)
+			logger.Info("Invalid HTTP response status code, wanted 2xx", "status_code", resp.StatusCode)
 		}
 
 		if success && (len(httpConfig.FailIfHeaderMatchesRegexp) > 0 || len(httpConfig.FailIfHeaderNotMatchesRegexp) > 0) {
@@ -609,7 +609,7 @@ func ProbeHTTP(ctx context.Context, target string, module config.Module, registr
 		if httpConfig.Compression != "" {
 			dec, err := getDecompressionReader(httpConfig.Compression, resp.Body)
 			if err != nil {
-				logger.Error("Failed to get decompressor for HTTP response body", "err", err)
+				logger.Info("Failed to get decompressor for HTTP response body", "err", err)
 				success = false
 			} else if dec != nil {
 				// Since we are replacing the original resp.Body with the decoder, we need to make sure
@@ -620,7 +620,7 @@ func ProbeHTTP(ctx context.Context, target string, module config.Module, registr
 					if err != nil {
 						// At this point we cannot really do anything with this error, but log
 						// it in case it contains useful information as to what's the problem.
-						logger.Error("Error while closing response from server", "err", err)
+						logger.Info("Error while closing response from server", "err", err)
 					}
 				}(resp.Body)
 
@@ -659,7 +659,7 @@ func ProbeHTTP(ctx context.Context, target string, module config.Module, registr
 		if !requestErrored {
 			_, err = io.Copy(io.Discard, byteCounter)
 			if err != nil {
-				logger.Error("Failed to read HTTP response body", "err", err)
+				logger.Info("Failed to read HTTP response body", "err", err)
 				success = false
 			}
 
@@ -669,7 +669,7 @@ func ProbeHTTP(ctx context.Context, target string, module config.Module, registr
 				// We have already read everything we could from the server, maybe even uncompressed the
 				// body. The error here might be either a decompression error or a TCP error. Log it in
 				// case it contains useful information as to what's the problem.
-				logger.Error("Error while closing response from server", "error", err.Error())
+				logger.Info("Error while closing response from server", "error", err.Error())
 			}
 		}
 
@@ -685,14 +685,14 @@ func ProbeHTTP(ctx context.Context, target string, module config.Module, registr
 		var httpVersionNumber float64
 		httpVersionNumber, err = strconv.ParseFloat(strings.TrimPrefix(resp.Proto, "HTTP/"), 64)
 		if err != nil {
-			logger.Error("Error parsing version number from HTTP version", "err", err)
+			logger.Info("Error parsing version number from HTTP version", "err", err)
 		}
 		probeHTTPVersionGauge.Set(httpVersionNumber)
 
 		if len(httpConfig.ValidHTTPVersions) != 0 {
 			found := slices.Contains(httpConfig.ValidHTTPVersions, resp.Proto)
 			if !found {
-				logger.Error("Invalid HTTP version number", "version", resp.Proto)
+				logger.Info("Invalid HTTP version number", "version", resp.Proto)
 				success = false
 			}
 		}
@@ -753,11 +753,11 @@ func ProbeHTTP(ctx context.Context, target string, module config.Module, registr
 		probeSSLLastInformation.WithLabelValues(getFingerprint(resp.TLS), getSubject(resp.TLS), getIssuer(resp.TLS), getDNSNames(resp.TLS), getSerialNumber(resp.TLS)).Set(1)
 		checkCRL(ctx, resp.TLS, module.HTTP.CheckRevoked, &module.HTTP.HTTPClientConfig.ProxyConfig, registry, logger)
 		if httpConfig.FailIfSSL {
-			logger.Error("Final request was over SSL")
+			logger.Info("Final request was over SSL")
 			success = false
 		}
 	} else if httpConfig.FailIfNotSSL && success {
-		logger.Error("Final request was not over SSL")
+		logger.Info("Final request was not over SSL")
 		success = false
 	}
 

--- a/prober/icmp.go
+++ b/prober/icmp.go
@@ -85,7 +85,7 @@ func ProbeICMP(ctx context.Context, target string, module config.Module, registr
 
 	dstIPAddr, lookupTime, err := chooseProtocol(ctx, module.ICMP.IPProtocol, module.ICMP.IPProtocolFallback, target, registry, logger)
 	if err != nil {
-		logger.Error("Error resolving address", "err", err)
+		logger.Info("Error resolving address", "err", err)
 		return false
 	}
 	durationGaugeVec.WithLabelValues("resolve").Add(lookupTime)
@@ -340,7 +340,7 @@ func ProbeICMP(ctx context.Context, target string, module config.Module, registr
 				logger.Warn("Timeout reading from socket", "err", err)
 				return
 			}
-			logger.Error("Error reading from socket", "err", err)
+			logger.Info("Error reading from socket", "err", err)
 			continue
 		}
 		if peer.String() != dst.String() {

--- a/prober/query_response.go
+++ b/prober/query_response.go
@@ -88,7 +88,7 @@ func probeQueryResponses(ctx context.Context, target string, conn net.Conn, modu
 
 	deadline, _ := ctx.Deadline()
 	if err := conn.SetDeadline(deadline); err != nil {
-		logger.Error("Error setting deadline", "err", err)
+		logger.Info("Error setting deadline", "err", err)
 		return false
 	}
 
@@ -117,12 +117,12 @@ func probeQueryResponses(ctx context.Context, target string, conn net.Conn, modu
 				}
 			}
 			if scanner.Err() != nil {
-				logger.Error("Error reading from connection", "err", scanner.Err().Error())
+				logger.Info("Error reading from connection", "err", scanner.Err().Error())
 				return false
 			}
 			if match == nil {
 				probeFailedDueToRegex.Set(1)
-				logger.Error("Regexp did not match", "regexp", qr.Expect.Regexp, "line", scanner.Text())
+				logger.Info("Regexp did not match", "regexp", qr.Expect.Regexp, "line", scanner.Text())
 				return false
 			}
 			probeFailedDueToRegex.Set(0)
@@ -138,20 +138,20 @@ func probeQueryResponses(ctx context.Context, target string, conn net.Conn, modu
 			data := make([]byte, len(expectBytes))
 			n, err := conn.Read(data)
 			if err != nil {
-				logger.Error("Error reading from connection", "err", err)
+				logger.Info("Error reading from connection", "err", err)
 				return false
 			}
 
 			logger.Debug("Read bytes", "bytes", data)
 
 			if n < len(expectBytes) {
-				logger.Error("Read less data than expected", "expected", expectBytes, "bytes", data)
+				logger.Info("Read less data than expected", "expected", expectBytes, "bytes", data)
 				return false
 			}
 
 			if !bytes.Equal(expectBytes, data) {
 				probeFailedDueToBytes.Set(1)
-				logger.Error("Bytes did not match", "expected", expectBytes, "bytes", data)
+				logger.Info("Bytes did not match", "expected", expectBytes, "bytes", data)
 				return false
 			}
 			logger.Debug("Bytes matched", "expected", expectBytes, "bytes", data)
@@ -160,7 +160,7 @@ func probeQueryResponses(ctx context.Context, target string, conn net.Conn, modu
 		if send != "" {
 			logger.Debug("Sending line", "line", send)
 			if _, err := fmt.Fprintf(conn, "%s\n", send); err != nil {
-				logger.Error("Failed to send", "err", err)
+				logger.Info("Failed to send", "err", err)
 				return false
 			}
 		}
@@ -182,7 +182,7 @@ func probeQueryResponses(ctx context.Context, target string, conn net.Conn, modu
 
 			// Initiate TLS handshake (required here to get TLS state).
 			if err := tlsConn.Handshake(); err != nil {
-				logger.Error("TLS Handshake (client) failed", "err", err)
+				logger.Info("TLS Handshake (client) failed", "err", err)
 				return false
 			}
 			logger.Debug("TLS Handshake (client) succeeded.")

--- a/prober/query_response.go
+++ b/prober/query_response.go
@@ -91,7 +91,7 @@ func probeQueryResponses(ctx context.Context, target string, conn net.Conn, modu
 
 	deadline, _ := ctx.Deadline()
 	if err := conn.SetDeadline(deadline); err != nil {
-		logger.Error("Error setting deadline", "err", err)
+		logger.Info("Error setting deadline", "err", err)
 		return false
 	}
 
@@ -121,12 +121,12 @@ func probeQueryResponses(ctx context.Context, target string, conn net.Conn, modu
 				}
 			}
 			if scanner.Err() != nil {
-				logger.Error("Error reading from connection", "err", scanner.Err().Error())
+				logger.Info("Error reading from connection", "err", scanner.Err().Error())
 				return false
 			}
 			if match == nil {
 				probeFailedDueToRegex.Set(1)
-				logger.Error("Regexp did not match", "regexp", qr.Expect.Regexp, "line", scanner.Text())
+				logger.Info("Regexp did not match", "regexp", qr.Expect.Regexp, "line", scanner.Text())
 				return false
 			}
 			probeFailedDueToRegex.Set(0)
@@ -142,20 +142,20 @@ func probeQueryResponses(ctx context.Context, target string, conn net.Conn, modu
 			data := make([]byte, len(expectBytes))
 			n, err := conn.Read(data)
 			if err != nil {
-				logger.Error("Error reading from connection", "err", err)
+				logger.Info("Error reading from connection", "err", err)
 				return false
 			}
 
 			logger.Debug("Read bytes", "bytes", data)
 
 			if n < len(expectBytes) {
-				logger.Error("Read less data than expected", "expected", expectBytes, "bytes", data)
+				logger.Info("Read less data than expected", "expected", expectBytes, "bytes", data)
 				return false
 			}
 
 			if !bytes.Equal(expectBytes, data) {
 				probeFailedDueToBytes.Set(1)
-				logger.Error("Bytes did not match", "expected", expectBytes, "bytes", data)
+				logger.Info("Bytes did not match", "expected", expectBytes, "bytes", data)
 				return false
 			}
 			logger.Debug("Bytes matched", "expected", expectBytes, "bytes", data)
@@ -164,7 +164,7 @@ func probeQueryResponses(ctx context.Context, target string, conn net.Conn, modu
 		if send != "" {
 			logger.Debug("Sending line", "line", send)
 			if _, err := fmt.Fprintf(conn, "%s\n", send); err != nil {
-				logger.Error("Failed to send", "err", err)
+				logger.Info("Failed to send", "err", err)
 				return false
 			}
 		}
@@ -186,7 +186,7 @@ func probeQueryResponses(ctx context.Context, target string, conn net.Conn, modu
 
 			// Initiate TLS handshake (required here to get TLS state).
 			if err := tlsConn.Handshake(); err != nil {
-				logger.Error("TLS Handshake (client) failed", "err", err)
+				logger.Info("TLS Handshake (client) failed", "err", err)
 				return false
 			}
 			logger.Debug("TLS Handshake (client) succeeded.")

--- a/prober/tcp.go
+++ b/prober/tcp.go
@@ -31,13 +31,13 @@ func dialTCP(ctx context.Context, target string, module config.Module, registry 
 	dialer := &net.Dialer{}
 	targetAddress, port, err := net.SplitHostPort(target)
 	if err != nil {
-		logger.Error("Error splitting target address and port", "err", err)
+		logger.Info("Error splitting target address and port", "err", err)
 		return nil, err
 	}
 
 	ip, _, err := chooseProtocol(ctx, module.TCP.IPProtocol, module.TCP.IPProtocolFallback, targetAddress, registry, logger)
 	if err != nil {
-		logger.Error("Error resolving address", "err", err)
+		logger.Info("Error resolving address", "err", err)
 		return nil, err
 	}
 
@@ -89,7 +89,7 @@ func dialTCP(ctx context.Context, target string, module config.Module, registry 
 func ProbeTCP(ctx context.Context, target string, module config.Module, registry *prometheus.Registry, logger *slog.Logger) bool {
 	conn, err := dialTCP(ctx, target, module, registry, logger)
 	if err != nil {
-		logger.Error("Error dialing TCP", "err", err)
+		logger.Info("Error dialing TCP", "err", err)
 		return false
 	}
 	defer conn.Close()

--- a/prober/unix.go
+++ b/prober/unix.go
@@ -69,7 +69,7 @@ func dialUnix(ctx context.Context, target string, module config.Module, _ *prome
 func ProbeUnix(ctx context.Context, target string, module config.Module, registry *prometheus.Registry, logger *slog.Logger) bool {
 	conn, err := dialUnix(ctx, target, module, registry, logger)
 	if err != nil {
-		logger.Error("Error dialing unix", "err", err)
+		logger.Info("Error dialing unix", "err", err)
 		return false
 	}
 	defer conn.Close()

--- a/prober/utils.go
+++ b/prober/utils.go
@@ -77,13 +77,13 @@ func chooseProtocol(ctx context.Context, IPProtocol string, fallbackIPProtocol b
 				return &net.IPAddr{IP: ip}, lookupTime, nil
 			}
 		}
-		logger.Error("Resolution with IP protocol failed", "target", target, "ip_protocol", IPProtocol, "err", err)
+		logger.Info("Resolution with IP protocol failed", "target", target, "ip_protocol", IPProtocol, "err", err)
 		return nil, 0.0, err
 	}
 
 	ips, err := resolver.LookupIPAddr(ctx, target)
 	if err != nil {
-		logger.Error("Resolution with IP protocol failed", "target", target, "err", err)
+		logger.Info("Resolution with IP protocol failed", "target", target, "err", err)
 		return nil, 0.0, err
 	}
 

--- a/prober/websocket.go
+++ b/prober/websocket.go
@@ -34,7 +34,7 @@ func ProbeWebsocket(ctx context.Context, target string, module config.Module, re
 
 	targetURL, err := url.Parse(target)
 	if err != nil {
-		logger.Error("Could not parse target URL", "err", err)
+		logger.Info("Could not parse target URL", "err", err)
 		return false
 	}
 
@@ -70,7 +70,7 @@ func ProbeWebsocket(ctx context.Context, target string, module config.Module, re
 
 	ip, lookupTime, err := chooseProtocol(ctx, module.Websocket.IPProtocol, module.Websocket.IPProtocolFallback, targetURL.Hostname(), registry, logger)
 	if err != nil {
-		logger.Error("Error resolving address", "err", err)
+		logger.Info("Error resolving address", "err", err)
 		return false
 	}
 	durationGaugeVec.WithLabelValues("resolve").Add(lookupTime)
@@ -117,7 +117,7 @@ func ProbeWebsocket(ctx context.Context, target string, module config.Module, re
 		httpStatusCode.Set(float64(resp.StatusCode))
 	}
 	if err != nil {
-		logger.Error("Error dialing websocket", "err", err)
+		logger.Info("Error dialing websocket", "err", err)
 		return false
 	}
 	defer connection.Close()
@@ -146,7 +146,7 @@ func matchQueryResponse(qr config.QueryResponse, conn *websocket.Conn, logger *s
 	if qr.Expect.Regexp != nil {
 		_, message, err = conn.ReadMessage()
 		if err != nil {
-			logger.Error("Error reading message", "err", err)
+			logger.Info("Error reading message", "err", err)
 			return false
 		}
 	}
@@ -159,7 +159,7 @@ func matchQueryResponse(qr config.QueryResponse, conn *websocket.Conn, logger *s
 	if send != "" {
 		err = conn.WriteMessage(websocket.TextMessage, []byte(send))
 		if err != nil {
-			logger.Error("Error sending message", "err", err)
+			logger.Info("Error sending message", "err", err)
 			return false
 		}
 	}
@@ -172,7 +172,7 @@ func processWebsocketQueryRegexp(qr *config.QueryResponse, message []byte, logge
 	if qr.Expect.Regexp != nil {
 		match := qr.Expect.FindSubmatchIndex(message)
 		if match == nil {
-			logger.Error("Regexp did not match", "regexp", qr.Expect.Regexp, "line", message)
+			logger.Info("Regexp did not match", "regexp", qr.Expect.Regexp, "line", message)
 			return "", false
 		}
 


### PR DESCRIPTION
### Description

Since v0.28.0, failed probes are logged at `error`, which can't be filtered with `--log.prober` (highest filter is still `error`). That turns routine probe outcomes — timeouts, refused connections, expected-fail TCP modules, regex mismatches — into the same severity as real exporter problems.

This demotes probe *outcome* failures to `info`. Configuration / local setup failures stay at `error`.

Operators who want quiet probe logs can use `--log.prober=warn` or `--log.prober=error`.

Fixes #1510

### How to verify

```bash
go test ./...

# optional smoke:
# run blackbox with a module that fails (e.g. tcp to a closed port),
# confirm "Probe failed" / dial errors are level=INFO
# and disappear with --log.prober=error
```

```release-notes
[BUGFIX] Log probe outcome failures at info instead of error so they can be filtered with --log.prober #1510
```