### PR TITLE
Enable govet and additional correctness linters in golangci-lint

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -2,10 +2,24 @@ version: "2"
 linters:
   default: none
   enable:
+    - copyloopvar
+    - durationcheck
+    - govet
+    - ineffassign
+    - makezero
     - misspell
     - revive
     - sloglint
     - staticcheck
+    - unconvert
+    - wastedassign
+  settings:
+    govet:
+      # Enable the composites analyzer (unkeyed struct literals) on top of the
+      # default vet analyzers (which include unreachable). Neither is part of
+      # `go test`'s built-in vet subset, so they otherwise go uncaught in CI.
+      enable:
+        - composites
   exclusions:
     generated: lax
     presets:

--- a/main.go
+++ b/main.go
@@ -258,7 +258,7 @@ func run() int {
 			http.Error(w, "Probe module filter only works in conjunction with target parameter", http.StatusBadRequest)
 			return
 		}
-		result := new(prober.Result)
+		var result *prober.Result
 		if target != "" {
 			result = rh.GetByTargetAndModule(target, module)
 			if result == nil {

--- a/prober/http_test.go
+++ b/prober/http_test.go
@@ -186,7 +186,7 @@ func TestContentLength(t *testing.T) {
 			msg := testmsg
 			var buf bytes.Buffer
 			fw := brotli.NewWriter(&buf)
-			fw.Write([]byte(msg))
+			fw.Write(msg)
 			fw.Close()
 			return testdata{
 				msg:                    msg,
@@ -206,7 +206,7 @@ func TestContentLength(t *testing.T) {
 			var buf bytes.Buffer
 			// the only error path is an invalid compression level
 			fw, _ := flate.NewWriter(&buf, flate.DefaultCompression)
-			fw.Write([]byte(msg))
+			fw.Write(msg)
 			fw.Close()
 			return testdata{
 				msg:                    msg,
@@ -225,7 +225,7 @@ func TestContentLength(t *testing.T) {
 			msg := testmsg
 			var buf bytes.Buffer
 			gw := gzip.NewWriter(&buf)
-			gw.Write([]byte(msg))
+			gw.Write(msg)
 			gw.Close()
 			return testdata{
 				msg:                    msg,


### PR DESCRIPTION
Follow-up to #1624. As noted there — "I think I will followup with some
additional linters in our golangci-lint config" — here is a proposed set.

### Why

The config runs only `misspell`, `revive`, `sloglint` and `staticcheck`.
`govet` is not enabled, and `go test`'s built-in vet subset skips the
`composites` and `unreachable` analyzers — which is exactly why the findings
fixed in #1624 were not caught by CI. (Verified: reintroducing those issues
makes this config flag both `unreachable` and `composites`.)

### What

Enable `govet` (with the `composites` analyzer) plus a curated, low-noise
correctness set: `copyloopvar`, `durationcheck`, `ineffassign`, `makezero`,
`unconvert`, `wastedassign`. The `wastedassign` (main) and `unconvert`
(http_test) findings these surface are fixed in the first commit.

`go build`, `go test ./...`, and `golangci-lint run` (pinned v2.11.4) all pass.

Happy to trim/extend the set to your preference. A follow-up will add `nilerr`
(it depends on a separate dropped-error fix, #1629).

🤖 Generated with [Claude Code](https://claude.com/claude-code)