### PR TITLE
Enable the nilerr linter in golangci-lint

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -3,6 +3,7 @@ linters:
   default: none
   enable:
     - misspell
+    - nilerr
     - revive
     - sloglint
     - staticcheck

--- a/prober/unix.go
+++ b/prober/unix.go
@@ -41,8 +41,8 @@ func dialUnix(ctx context.Context, target string, module config.Module, _ *prome
 	} else {
 		tlsConfig, tlsErr := pconfig.NewTLSConfig(&module.Unix.TLSConfig)
 		if tlsErr != nil {
-			logger.Error("Error creating TLS configuration", "err", err)
-			return nil, err
+			logger.Error("Error creating TLS configuration", "err", tlsErr)
+			return nil, tlsErr
 		}
 
 		timeoutDeadline, _ := ctx.Deadline()


### PR DESCRIPTION
## Security: catch silently-swallowed errors (`nilerr`)

`nilerr` flags functions that check an error and then return a *different* (often
`nil`) error — silently swallowing the real one. That pattern is exactly how a
security control can fail quietly: it caught the dropped TLS-config error in the
unix prober fixed in #1629, where `dialUnix` returned `(nil, nil)` on an
**invalid TLS configuration**, so the probe would proceed as if TLS setup had
succeeded rather than failing closed. Enabling the linter guards against that
class of silent bypass recurring.

Now that #1629 has merged, this PR is just the single `nilerr` line, rebased onto
the latest master.

Verified: `go build`, `go test ./...`, and `golangci-lint run` all pass — and it
has teeth: reintroducing the unix bug makes `nilerr` fire.

Complements the `govet` linter proposed in #1631.

🤖 Generated with [Claude Code](https://claude.com/claude-code)