### PR TITLE
Support IDN targets via punycode conversion

### DIFF
--- a/prober/dns.go
+++ b/prober/dns.go
@@ -229,7 +229,8 @@ func ProbeDNS(ctx context.Context, target string, module config.Module, registry
 		}
 		if tlsConfig.ServerName == "" {
 			// Use target-hostname as default for TLS-servername.
-			tlsConfig.ServerName = targetAddr
+			// Convert IDN to ASCII so SNI matches certificates.
+			tlsConfig.ServerName = idnaToASCII(targetAddr)
 		}
 
 		client.TLSConfig = tlsConfig
@@ -251,13 +252,15 @@ func ProbeDNS(ctx context.Context, target string, module config.Module, registry
 		}
 	}
 
+	queryName := idnaToASCII(module.DNS.QueryName)
+
 	msg := new(dns.Msg)
 	msg.Id = dns.Id()
 	msg.RecursionDesired = module.DNS.Recursion
 	msg.Question = make([]dns.Question, 1)
-	msg.Question[0] = dns.Question{Name: dns.Fqdn(module.DNS.QueryName), Qtype: qt, Qclass: qc}
+	msg.Question[0] = dns.Question{Name: dns.Fqdn(queryName), Qtype: qt, Qclass: qc}
 
-	logger.Debug("Making DNS query", "target", targetIP, "dial_protocol", dialProtocol, "query", module.DNS.QueryName, "type", qt, "class", qc)
+	logger.Debug("Making DNS query", "target", targetIP, "dial_protocol", dialProtocol, "query", queryName, "type", qt, "class", qc)
 	timeoutDeadline, _ := ctx.Deadline()
 	client.Timeout = time.Until(timeoutDeadline)
 	requestStart := time.Now()

--- a/prober/grpc.go
+++ b/prober/grpc.go
@@ -140,6 +140,7 @@ func ProbeGRPC(ctx context.Context, target string, module config.Module, registr
 	if err != nil {
 		targetHost = targetURL.Host
 	}
+	targetHost = idnaToASCII(targetHost)
 
 	md := module.GRPC.Metadata
 

--- a/prober/http.go
+++ b/prober/http.go
@@ -392,6 +392,17 @@ func ProbeHTTP(ctx context.Context, target string, module config.Module, registr
 	targetHost := targetURL.Hostname()
 	targetPort := targetURL.Port()
 
+	// Convert IDN hostnames to ASCII (punycode) for DNS, Host header, and SNI.
+	if asciiHost := idnaToASCII(targetHost); asciiHost != targetHost {
+		logger.Debug("Converted IDN host to ASCII", "unicode", targetHost, "ascii", asciiHost)
+		targetHost = asciiHost
+		if targetPort == "" {
+			targetURL.Host = asciiHost
+		} else {
+			targetURL.Host = net.JoinHostPort(asciiHost, targetPort)
+		}
+	}
+
 	var ip *net.IPAddr
 	if shouldResolveDNSWithProxy(module.HTTP) {
 		var lookupTime float64

--- a/prober/tcp.go
+++ b/prober/tcp.go
@@ -34,6 +34,7 @@ func dialTCP(ctx context.Context, target string, module config.Module, registry 
 		logger.Error("Error splitting target address and port", "err", err)
 		return nil, err
 	}
+	targetAddress = idnaToASCII(targetAddress)
 
 	ip, _, err := chooseProtocol(ctx, module.TCP.IPProtocol, module.TCP.IPProtocolFallback, targetAddress, registry, logger)
 	if err != nil {

--- a/prober/utils.go
+++ b/prober/utils.go
@@ -22,6 +22,7 @@ import (
 	"time"
 
 	"github.com/prometheus/client_golang/prometheus"
+	"golang.org/x/net/idna"
 )
 
 var protocolToGauge = map[string]float64{
@@ -56,6 +57,13 @@ func chooseProtocol(ctx context.Context, IPProtocol string, fallbackIPProtocol b
 	} else {
 		IPProtocol = "ip4"
 		fallbackProtocol = "ip6"
+	}
+
+	// Convert internationalized domain names to ASCII (punycode) so DNS
+	// resolution works. Already-ASCII names and IP addresses are unchanged.
+	if ascii := idnaToASCII(target); ascii != target {
+		logger.Debug("Converted IDN target to ASCII", "unicode", target, "ascii", ascii)
+		target = ascii
 	}
 
 	logger.Debug("Resolving target address", "target", target, "ip_protocol", IPProtocol)
@@ -139,4 +147,18 @@ func ipHash(ip net.IP) float64 {
 		h.Write(ip.To16())
 	}
 	return float64(h.Sum32())
+}
+
+// idnaToASCII converts a hostname (or DNS name) to ASCII using IDNA/punycode.
+// IP addresses and empty strings are returned as-is. On conversion failure the
+// original value is returned so callers can surface the underlying lookup error.
+func idnaToASCII(name string) string {
+	if name == "" || net.ParseIP(name) != nil {
+		return name
+	}
+	ascii, err := idna.Lookup.ToASCII(name)
+	if err != nil || ascii == "" {
+		return name
+	}
+	return ascii
 }

--- a/prober/utils_test.go
+++ b/prober/utils_test.go
@@ -300,3 +300,56 @@ func checkAbsentMetrics(absent []string, mfs []*dto.MetricFamily, t *testing.T) 
 		}
 	}
 }
+
+func TestIdnaToASCII(t *testing.T) {
+	tests := []struct {
+		name  string
+		input string
+		want  string
+	}{
+		{
+			name:  "empty",
+			input: "",
+			want:  "",
+		},
+		{
+			name:  "ipv4",
+			input: "192.0.2.1",
+			want:  "192.0.2.1",
+		},
+		{
+			name:  "ipv6",
+			input: "2001:db8::1",
+			want:  "2001:db8::1",
+		},
+		{
+			name:  "ascii domain",
+			input: "example.com",
+			want:  "example.com",
+		},
+		{
+			name:  "unicode domain",
+			input: "www.académie-française.fr",
+			want:  "www.xn--acadmie-franaise-npb1a.fr",
+		},
+		{
+			name:  "already punycode",
+			input: "www.xn--acadmie-franaise-npb1a.fr",
+			want:  "www.xn--acadmie-franaise-npb1a.fr",
+		},
+		{
+			name:  "cyrillic domain",
+			input: "мтр24.рф",
+			want:  "xn--24-7lcqj.xn--p1ai",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := idnaToASCII(tt.input)
+			if got != tt.want {
+				t.Errorf("idnaToASCII(%q) = %q, want %q", tt.input, got, tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
### Description

Unicode hostnames such as `http://мтр24.рф` fail DNS with `no such host`, while the punycode form works. Blackbox resolves hosts itself, so IDN never reaches Go's net/http IDNA handling.

Convert hostnames to ASCII with `golang.org/x/net/idna` (already a dependency via `x/net`) before:

- DNS resolution (`chooseProtocol` — covers HTTP/TCP/ICMP/DNS/gRPC targets)
- HTTP Host / default TLS SNI
- DNS `query_name` and DoT SNI
- TCP / gRPC default SNI

ASCII names and IP addresses are left unchanged. Logs keep the original target label; only the resolved name is rewritten.

### How to verify

```bash
go test ./prober/ -run TestIdnaToASCII -count=1
go test ./prober/ -short -count=1

# optional: probe an IDN target
# curl 'http://localhost:9115/probe?module=http_2xx&target=http://мтр24.рф&debug=true'
```

```release-notes
[ENHANCEMENT] Convert IDN hostnames to punycode so HTTP/DNS/TCP/ICMP/gRPC probes resolve Unicode targets #626
```

Fixes #626