### PR TITLE
Update CA certificates in Docker image from Debian

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,14 @@
 ARG ARCH="amd64"
 ARG OS="linux"
+
+# Install a current CA bundle independently of the busybox base image rebuild
+# cycle. Blackbox probes remote TLS endpoints, so stale roots cause false
+# probe failures (see #1429, #1547).
+FROM debian:trixie-slim AS certs
+RUN apt-get update \
+	&& apt-get install -y --no-install-recommends ca-certificates \
+	&& rm -rf /var/lib/apt/lists/*
+
 FROM quay.io/prometheus/busybox-${OS}-${ARCH}:latest
 LABEL maintainer="The Prometheus Authors <prometheus-developers@googlegroups.com>"
 
@@ -17,6 +26,7 @@ ARG ARCH="amd64"
 ARG OS="linux"
 COPY .build/${OS}-${ARCH}/blackbox_exporter  /bin/blackbox_exporter
 COPY blackbox.yml       /etc/blackbox_exporter/config.yml
+COPY --from=certs /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/ca-certificates.crt
 
 EXPOSE      9115
 ENTRYPOINT  [ "/bin/blackbox_exporter" ]


### PR DESCRIPTION
### Description

The busybox base image ships `/etc/ssl/certs/ca-certificates.crt`, but that bundle can lag behind current public roots. Probes against hosts using newer CAs (for example Sectigo Public Server Authentication Root R46) fail with `x509: certificate signed by unknown authority` even when desktop clients succeed.

This multi-stage Dockerfile installs `ca-certificates` from `debian:trixie-slim` and copies a fresh `ca-certificates.crt` into the image at build time, so each blackbox image build picks up current roots without depending on a busybox base rebuild cycle.

Related: #1429

Fixes #1547

### How to verify

```bash
# After building the image:
# docker run --rm --entrypoint cat <image> /etc/ssl/certs/ca-certificates.crt | openssl storeutl -noout -text -certs /dev/stdin | grep -i 'Sectigo Public Server Authentication Root'
```

```release-notes
[BUGFIX] Refresh CA certificates in the Docker image from Debian at build time #1547
```