### PR TITLE
prober: support reject regexp in TCP/unix query_response

### DIFF
--- a/CONFIGURATION.md
+++ b/CONFIGURATION.md
@@ -234,7 +234,8 @@ regexp: <regex>,
 
 # The query sent in the TCP probe and the expected associated response.
 # "expect" matches a regular expression; it is mutually exclusive with "expect_bytes".
-# "expect_bytes" does exact byte-by-byte match; it is mutually exclusive with "expect".
+# "expect_bytes" does exact byte-by-byte match; it is mutually exclusive with "expect" and "reject".
+# "reject" matches a regular expression; if it matches a line before "expect", the probe fails immediately.
 # "labels" can define labels which will be exported on metric "probe_expect_info";
 # "send" sends some content;
 # "send" and "labels.value" can contain values matched by "expect" (such as "${1}");
@@ -242,6 +243,7 @@ regexp: <regex>,
 query_response:
   [ - [ [ expect: <string> ],
         [ expect_bytes: <string> ],
+        [ reject: <string> ],
         [ labels:
           - [ name: <string>
               value: <string>
@@ -267,6 +269,7 @@ tls_config:
 
 # The query sent in the unix socket probe and the expected associated response.
 # "expect" matches a regular expression;
+# "reject" matches a regular expression and fails the probe immediately if matched before expect;
 # "labels" can define labels which will be exported on metric "probe_expect_info";
 # "send" sends some content;
 # "send" and "labels.value" can contain values matched by "expect" (such as "${1}");

--- a/config/config.go
+++ b/config/config.go
@@ -354,6 +354,7 @@ type Label struct {
 type QueryResponse struct {
 	Expect      Regexp  `yaml:"expect,omitempty" json:"expect,omitzero"`
 	ExpectBytes string  `yaml:"expect_bytes,omitempty" json:"expect_bytes,omitempty"`
+	Reject      Regexp  `yaml:"reject,omitempty" json:"reject,omitzero"`
 	Labels      []Label `yaml:"labels,omitempty" json:"labels,omitempty"`
 	Send        string  `yaml:"send,omitempty" json:"send,omitempty"`
 	StartTLS    bool    `yaml:"starttls,omitempty" json:"starttls,omitempty"`
@@ -596,6 +597,9 @@ func (s *QueryResponse) UnmarshalYAML(unmarshal func(any) error) error {
 	if s.Expect.Regexp != nil && s.ExpectBytes != "" {
 		return errors.New("expect and expect_bytes are mutually exclusive")
 	}
+		if s.Reject.Regexp != nil && s.ExpectBytes != "" {
+			return errors.New("reject and expect_bytes are mutually exclusive")
+		}
 	return nil
 }
 

--- a/prober/query_response.go
+++ b/prober/query_response.go
@@ -105,30 +105,39 @@ func probeQueryResponses(ctx context.Context, target string, conn net.Conn, modu
 	for i, qr := range queryResponses {
 		logger.Debug("Processing query response entry", "entry_number", i)
 		send := qr.Send
-		if qr.Expect.Regexp != nil {
+		if qr.Expect.Regexp != nil || qr.Reject.Regexp != nil {
 			var match []int
-			// Read lines until one of them matches the configured regexp.
+			// Read lines until expect matches, or fail early if reject matches.
 			for scanner.Scan() {
 				logger.Debug("Read line", "line", scanner.Text())
-				match = qr.Expect.FindSubmatchIndex(scanner.Bytes())
-				if match != nil {
-					logger.Debug("Regexp matched", "regexp", qr.Expect.Regexp, "line", scanner.Text())
-					break
+				if qr.Reject.Regexp != nil && qr.Reject.Match(scanner.Bytes()) {
+					probeFailedDueToRegex.Set(1)
+					logger.Error("Reject regexp matched", "regexp", qr.Reject.Regexp, "line", scanner.Text())
+					return false
+				}
+				if qr.Expect.Regexp != nil {
+					match = qr.Expect.FindSubmatchIndex(scanner.Bytes())
+					if match != nil {
+						logger.Debug("Regexp matched", "regexp", qr.Expect.Regexp, "line", scanner.Text())
+						break
+					}
 				}
 			}
 			if scanner.Err() != nil {
 				logger.Error("Error reading from connection", "err", scanner.Err().Error())
 				return false
 			}
-			if match == nil {
-				probeFailedDueToRegex.Set(1)
-				logger.Error("Regexp did not match", "regexp", qr.Expect.Regexp, "line", scanner.Text())
-				return false
-			}
-			probeFailedDueToRegex.Set(0)
-			send = string(qr.Expect.Expand(nil, []byte(send), scanner.Bytes(), match))
-			if qr.Labels != nil {
-				probeExpectInfo(registry, &qr, scanner.Bytes(), match)
+			if qr.Expect.Regexp != nil {
+				if match == nil {
+					probeFailedDueToRegex.Set(1)
+					logger.Error("Regexp did not match", "regexp", qr.Expect.Regexp, "line", scanner.Text())
+					return false
+				}
+				probeFailedDueToRegex.Set(0)
+				send = string(qr.Expect.Expand(nil, []byte(send), scanner.Bytes(), match))
+				if qr.Labels != nil {
+					probeExpectInfo(registry, &qr, scanner.Bytes(), match)
+				}
 			}
 		}
 		if qr.ExpectBytes != "" {

--- a/prober/tcp_test.go
+++ b/prober/tcp_test.go
@@ -580,6 +580,52 @@ func TestTCPConnectionQueryResponseMatching(t *testing.T) {
 
 }
 
+func TestTCPConnectionQueryResponseReject(t *testing.T) {
+	ln, err := net.Listen("tcp", "localhost:0")
+	if err != nil {
+		t.Fatalf("Error listening on socket: %s", err)
+	}
+	defer ln.Close()
+
+	go func() {
+		conn, err := ln.Accept()
+		if err != nil {
+			return
+		}
+		defer conn.Close()
+		fmt.Fprintf(conn, "550 Permanent failure\n")
+	}()
+
+	registry := prometheus.NewRegistry()
+	testCTX, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+	module := config.Module{
+		Prober:  "tcp",
+		Timeout: 10 * time.Second,
+		TCP: config.TCPProbe{
+			IPProtocolFallback: true,
+			QueryResponse: []config.QueryResponse{
+				{
+					Expect: config.MustNewRegexp("^220"),
+					Reject: config.MustNewRegexp("^5[0-9]{2}"),
+				},
+			},
+		},
+	}
+	result := ProbeTCP(testCTX, ln.Addr().String(), module, registry, promslog.NewNopLogger())
+	if result {
+		t.Fatalf("TCP probe succeeded unexpectedly when reject regexp matched")
+	}
+	mfs, err := registry.Gather()
+	if err != nil {
+		t.Fatal(err)
+	}
+	expectedResults := map[string]float64{
+		"probe_failed_due_to_regex": 1,
+	}
+	checkRegistryResults(expectedResults, mfs, t)
+}
+
 func TestTCPConnectionQueryResponseByteMode(t *testing.T) {
 	ln, err := net.Listen("tcp", "localhost:0")
 	if err != nil {


### PR DESCRIPTION
For SMTP and friends you sometimes get a definitive failure line (`5xx`) and just want the probe to stop, rather than spinning until `expect` times out.

This adds an optional `reject` regex on each `query_response` step. While waiting for `expect`, if a line matches `reject` the probe fails right away (`probe_failed_due_to_regex=1`). Documented in CONFIGURATION.md; works for tcp and unix since they share the helper.

Fixes #1527