### PR TITLE
DNS: Make query_name module attribute optional

### DIFF
--- a/CONFIGURATION.md
+++ b/CONFIGURATION.md
@@ -312,7 +312,10 @@ tls_config:
 tls_config:
   [ <tls_config> ]
 
-query_name: <string>
+# Question to ask the DNS server. If empty, scrapers can provide
+# their own value via the *hostname* parameter, otherwise the
+# target hostname is used as default.
+[ query_name: <string> ]
 
 [ query_type: <string> | default = "ANY" ]
 [ query_class: <string> | default = "IN" ]

--- a/config/config.go
+++ b/config/config.go
@@ -520,9 +520,6 @@ func (s *DNSProbe) UnmarshalYAML(unmarshal func(any) error) error {
 	if err := unmarshal((*plain)(s)); err != nil {
 		return err
 	}
-	if s.QueryName == "" {
-		return errors.New("query name must be set for DNS module")
-	}
 	if s.QueryClass != "" {
 		if _, ok := dns.StringToClass[s.QueryClass]; !ok {
 			return fmt.Errorf("query class '%s' is not valid", s.QueryClass)

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -49,10 +49,6 @@ func TestLoadBadConfigs(t *testing.T) {
 			want:  "error parsing config file: prober 'invalid' is not valid",
 		},
 		{
-			input: "testdata/invalid-dns-module.yml",
-			want:  "error parsing config file: query name must be set for DNS module",
-		},
-		{
 			input: "testdata/invalid-dns-class.yml",
 			want:  "error parsing config file: query class 'X' is not valid",
 		},

--- a/config/testdata/blackbox-good.yml
+++ b/config/testdata/blackbox-good.yml
@@ -67,6 +67,17 @@ modules:
       ip_protocol_fallback: false
       validate_answer_rrs:
         fail_if_matches_regexp: [test]
+  dns_self_v6:
+    prober: dns
+    timeout: 5s
+    dns:
+      preferred_ip_protocol: ip6
+      query_type: AAAA
+      query_class: ANY
+      recursion_desired: false
+      valid_rcodes:
+      - NOERROR
+      - NXDOMAIN
   http_header_match_origin:
     prober: http
     timeout: 5s

--- a/config/testdata/invalid-dns-module.yml
+++ b/config/testdata/invalid-dns-module.yml
@@ -1,8 +1,0 @@
-modules:
-  dns_test:
-    prober: dns
-    timeout: 5s
-    dns:
-      preferred_ip_protocol: ip6
-      validate_answer_rrs:
-        fail_if_matches_regexp: [test]

--- a/example.yml
+++ b/example.yml
@@ -212,6 +212,12 @@ modules:
     dns:
       query_name: "prometheus.io"
       query_type: "SOA"
+  dns_scraper_host:
+    prober: dns
+    dns:
+      # uses the *hostname* parameter from the scrape request,
+      # otherwise the target hostname
+      query_name: ""
   dns_tcp_example:
     prober: dns
     dns:

--- a/prober/dns.go
+++ b/prober/dns.go
@@ -251,13 +251,18 @@ func ProbeDNS(ctx context.Context, target string, module config.Module, registry
 		}
 	}
 
+	qn := targetAddr
+	if module.DNS.QueryName != "" {
+		qn = module.DNS.QueryName
+	}
+
 	msg := new(dns.Msg)
 	msg.Id = dns.Id()
 	msg.RecursionDesired = module.DNS.Recursion
 	msg.Question = make([]dns.Question, 1)
-	msg.Question[0] = dns.Question{Name: dns.Fqdn(module.DNS.QueryName), Qtype: qt, Qclass: qc}
+	msg.Question[0] = dns.Question{Name: dns.Fqdn(qn), Qtype: qt, Qclass: qc}
 
-	logger.Debug("Making DNS query", "target", targetIP, "dial_protocol", dialProtocol, "query", module.DNS.QueryName, "type", qt, "class", qc)
+	logger.Debug("Making DNS query", "target", targetIP, "dial_protocol", dialProtocol, "query", qn, "type", qt, "class", qc)
 	timeoutDeadline, _ := ctx.Deadline()
 	client.Timeout = time.Until(timeoutDeadline)
 	requestStart := time.Now()

--- a/prober/dns_test.go
+++ b/prober/dns_test.go
@@ -110,6 +110,13 @@ func TestRecursiveDNSResponse(t *testing.T) {
 			config.DNSProbe{
 				IPProtocol:         "ip4",
 				IPProtocolFallback: true,
+				Recursion:          true,
+			}, true,
+		},
+		{
+			config.DNSProbe{
+				IPProtocol:         "ip4",
+				IPProtocolFallback: true,
 				QueryName:          "example.com",
 				Recursion:          true,
 				ValidRcodes:        []string{"SERVFAIL", "NXDOMAIN"},

--- a/prober/handler.go
+++ b/prober/handler.go
@@ -120,6 +120,14 @@ func Handler(w http.ResponseWriter, r *http.Request, c *config.Config, logger *s
 		}
 	}
 
+	if module.Prober == "dns" && hostname != "" {
+		err = setDNSHost(hostname, &module)
+		if err != nil {
+			http.Error(w, err.Error(), http.StatusBadRequest)
+			return
+		}
+	}
+
 	sl := newScrapeLogger(promslogConfig, moduleName, target)
 	slLogger := slog.New(sl)
 
@@ -168,6 +176,15 @@ func setHTTPHost(hostname string, module *config.Module) error {
 	}
 	headers["Host"] = hostname
 	module.HTTP.Headers = headers
+	return nil
+}
+
+func setDNSHost(hostname string, module *config.Module) error {
+	value := module.DNS.QueryName
+	if value != "" && value != hostname {
+		return fmt.Errorf("query name defined both in module configuration (%s) and with URL-parameter 'hostname' (%s)", value, hostname)
+	}
+	module.DNS.QueryName = hostname
 	return nil
 }
 

--- a/prober/handler_test.go
+++ b/prober/handler_test.go
@@ -309,6 +309,48 @@ func TestTCPHostnameParam(t *testing.T) {
 
 }
 
+func TestDNSHostnameParam(t *testing.T) {
+	qn := "must-be-this.example.com"
+	c := &config.Config{
+		Modules: map[string]config.Module{
+			"dns_test": {
+				Prober:  "dns",
+				Timeout: 10 * time.Second,
+				DNS: config.DNSProbe{
+					QueryName: qn,
+				},
+			},
+		},
+	}
+
+	// intentionally invalid param to trigger validation fault
+	hostname := "foo.example.com"
+
+	requrl := fmt.Sprintf("?module=dns_test&debug=true&hostname=%s&target=%s", hostname, "never-contacted.example.com:5353")
+
+	req, err := http.NewRequest("GET", requrl, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	rr := httptest.NewRecorder()
+
+	handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		Handler(w, r, c, promslog.NewNopLogger(), &ResultHistory{}, 0.5, nil, nil, &promslog.Config{})
+	})
+
+	handler.ServeHTTP(rr, req)
+
+	if status := rr.Code; status != http.StatusBadRequest {
+		t.Errorf("probe request handler returned wrong status code: %v, want %v", status, http.StatusBadRequest)
+	}
+
+	wantErr := fmt.Sprintf("query name defined both in module configuration (%s) and with URL-parameter 'hostname' (%s)", qn, hostname)
+	if body := rr.Body.String(); !strings.Contains(body, wantErr) {
+		t.Errorf("probe failed, response body: %v", body)
+	}
+}
+
 func TestURLDecoding(t *testing.T) {
 	c := &config.Config{
 		Modules: map[string]config.Module{


### PR DESCRIPTION
this is similar to the PRs below with the following differences:

* added test coverage for new logic
* the query name is *not* blindly accepted from the *hostname* parameter, but only applied if the configuration does not define one. this is similar to how the HTTP and TCP probers treat the *hostname* parameter.

Closes #1483
Closes #1105

#### What this PR does / Which issue(s) does the PR fix:

Operators can provide a DNS probe module config without an explicit `query_name` for the probe. This allows scrapers/consumer to provide the value via the `hostname` parameter, similar to the HTTP and TCP probers. Should no value be defined anywhere, the DNS query will use the target hostname instead.

Closes #1104

#### Does this PR introduce a user-facing change?

```release-notes
[ENHANCEMENT] Queryname for DNS probe can be provided via scrape URL parameter
```

**Checklist**
- [x] Tests updated
- [x] Documentation added
- [x] CHANGELOG added in `release-notes` section of PR Desc.
