### PR TITLE
prober: add subjectkeyid label to probe_ssl_last_chain_info

### DIFF
--- a/prober/grpc.go
+++ b/prober/grpc.go
@@ -112,7 +112,7 @@ func ProbeGRPC(ctx context.Context, target string, module config.Module, registr
 				Name: "probe_ssl_last_chain_info",
 				Help: "Contains SSL leaf certificate information",
 			},
-			[]string{"fingerprint_sha256", "subject", "issuer", "subjectalternative", "serialnumber"},
+			[]string{"fingerprint_sha256", "subject", "issuer", "subjectalternative", "serialnumber", "subjectkeyid"},
 		)
 	)
 
@@ -209,7 +209,7 @@ func ProbeGRPC(ctx context.Context, target string, module config.Module, registr
 			isSSLGauge.Set(float64(1))
 			probeSSLEarliestCertExpiryGauge.Set(float64(getEarliestCertExpiry(&tlsInfo.State).Unix()))
 			probeTLSVersion.WithLabelValues(getTLSVersion(&tlsInfo.State)).Set(1)
-			probeSSLLastInformation.WithLabelValues(getFingerprint(&tlsInfo.State), getSubject(&tlsInfo.State), getIssuer(&tlsInfo.State), getDNSNames(&tlsInfo.State), getSerialNumber(&tlsInfo.State)).Set(1)
+			probeSSLLastInformation.WithLabelValues(getFingerprint(&tlsInfo.State), getSubject(&tlsInfo.State), getIssuer(&tlsInfo.State), getDNSNames(&tlsInfo.State), getSerialNumber(&tlsInfo.State), getSubjectKeyId(&tlsInfo.State)).Set(1)
 		} else {
 			isSSLGauge.Set(float64(0))
 		}

--- a/prober/http.go
+++ b/prober/http.go
@@ -323,7 +323,7 @@ func ProbeHTTP(ctx context.Context, target string, module config.Module, registr
 				Name: "probe_ssl_last_chain_info",
 				Help: "Contains SSL leaf certificate information",
 			},
-			[]string{"fingerprint_sha256", "subject", "issuer", "subjectalternative", "serialnumber"},
+			[]string{"fingerprint_sha256", "subject", "issuer", "subjectalternative", "serialnumber", "subjectkeyid"},
 		)
 
 		probeTLSVersion = prometheus.NewGaugeVec(
@@ -750,7 +750,7 @@ func ProbeHTTP(ctx context.Context, target string, module config.Module, registr
 		probeTLSVersion.WithLabelValues(getTLSVersion(resp.TLS)).Set(1)
 		probeTLSCipher.WithLabelValues(getTLSCipher(resp.TLS)).Set(1)
 		probeSSLLastChainExpiryTimestampSeconds.Set(float64(getLastChainExpiry(resp.TLS).Unix()))
-		probeSSLLastInformation.WithLabelValues(getFingerprint(resp.TLS), getSubject(resp.TLS), getIssuer(resp.TLS), getDNSNames(resp.TLS), getSerialNumber(resp.TLS)).Set(1)
+		probeSSLLastInformation.WithLabelValues(getFingerprint(resp.TLS), getSubject(resp.TLS), getIssuer(resp.TLS), getDNSNames(resp.TLS), getSerialNumber(resp.TLS), getSubjectKeyId(resp.TLS)).Set(1)
 		if httpConfig.FailIfSSL {
 			logger.Error("Final request was over SSL")
 			success = false

--- a/prober/query_response.go
+++ b/prober/query_response.go
@@ -54,7 +54,7 @@ func probeQueryResponses(ctx context.Context, target string, conn net.Conn, modu
 			Name: "probe_ssl_last_chain_info",
 			Help: "Contains SSL leaf certificate information",
 		},
-		[]string{"fingerprint_sha256", "subject", "issuer", "subjectalternative", "serialnumber"},
+		[]string{"fingerprint_sha256", "subject", "issuer", "subjectalternative", "serialnumber", "subjectkeyid"},
 	)
 	probeTLSVersion := prometheus.NewGaugeVec(
 		probeTLSInfoGaugeOpts,
@@ -98,7 +98,7 @@ func probeQueryResponses(ctx context.Context, target string, conn net.Conn, modu
 		probeSSLEarliestCertExpiry.Set(float64(getEarliestCertExpiry(&state).Unix()))
 		probeTLSVersion.WithLabelValues(getTLSVersion(&state)).Set(1)
 		probeSSLLastChainExpiryTimestampSeconds.Set(float64(getLastChainExpiry(&state).Unix()))
-		probeSSLLastInformation.WithLabelValues(getFingerprint(&state), getSubject(&state), getIssuer(&state), getDNSNames(&state), getSerialNumber(&state)).Set(1)
+		probeSSLLastInformation.WithLabelValues(getFingerprint(&state), getSubject(&state), getIssuer(&state), getDNSNames(&state), getSerialNumber(&state), getSubjectKeyId(&state)).Set(1)
 	}
 
 	scanner := bufio.NewScanner(conn)
@@ -195,7 +195,7 @@ func probeQueryResponses(ctx context.Context, target string, conn net.Conn, modu
 			probeSSLEarliestCertExpiry.Set(float64(getEarliestCertExpiry(&state).Unix()))
 			probeTLSVersion.WithLabelValues(getTLSVersion(&state)).Set(1)
 			probeSSLLastChainExpiryTimestampSeconds.Set(float64(getLastChainExpiry(&state).Unix()))
-			probeSSLLastInformation.WithLabelValues(getFingerprint(&state), getSubject(&state), getIssuer(&state), getDNSNames(&state), getSerialNumber(&state)).Set(1)
+			probeSSLLastInformation.WithLabelValues(getFingerprint(&state), getSubject(&state), getIssuer(&state), getDNSNames(&state), getSerialNumber(&state), getSubjectKeyId(&state)).Set(1)
 		}
 	}
 	return true

--- a/prober/tls.go
+++ b/prober/tls.go
@@ -78,6 +78,15 @@ func getSerialNumber(state *tls.ConnectionState) string {
 	return fmt.Sprintf("%x", cert.SerialNumber.Bytes())
 }
 
+
+func getSubjectKeyId(state *tls.ConnectionState) string {
+	cert := state.PeerCertificates[0]
+	if len(cert.SubjectKeyId) == 0 {
+		return ""
+	}
+	return hex.EncodeToString(cert.SubjectKeyId)
+}
+
 func getTLSVersion(state *tls.ConnectionState) string {
 	switch state.Version {
 	case tls.VersionTLS10:

--- a/prober/utils_test.go
+++ b/prober/utils_test.go
@@ -292,6 +292,21 @@ func TestGetSerialNumber(t *testing.T) {
 	}
 }
 
+func TestGetSubjectKeyId(t *testing.T) {
+	ski := []byte{0x01, 0x02, 0xab, 0xcd}
+	cert := &x509.Certificate{SubjectKeyId: ski}
+	state := &tls.ConnectionState{PeerCertificates: []*x509.Certificate{cert}}
+	if got := getSubjectKeyId(state); got != "0102abcd" {
+		t.Fatalf("getSubjectKeyId() = %q, want %q", got, "0102abcd")
+	}
+	empty := &tls.ConnectionState{PeerCertificates: []*x509.Certificate{{}}}
+	if got := getSubjectKeyId(empty); got != "" {
+		t.Fatalf("getSubjectKeyId() empty = %q, want empty", got)
+	}
+}
+
+
+
 func checkAbsentMetrics(absent []string, mfs []*dto.MetricFamily, t *testing.T) {
 	for _, v := range mfs {
 		name := v.GetName()


### PR DESCRIPTION
Leaf cert fingerprint and serial change every reissue (often every 90 days with ACME). The Subject Key Identifier only moves when the key changes, so it is a better long-lived join key for cert inventory-style dashboards.

Adds a `subjectkeyid` label (hex of `SubjectKeyId`, empty if the extension is missing) on `probe_ssl_last_chain_info` for HTTP, TCP/unix, and gRPC probes.

Leaving fingerprint/serial as-is for now so existing rules keep working; happy to follow up with knobs to drop them if that is still useful.

Fixes #1581