### PR TITLE
Fix Basic Auth being stripped on same-host redirects

### DIFF
--- a/prober/http.go
+++ b/prober/http.go
@@ -485,6 +485,17 @@ func ProbeHTTP(ctx context.Context, target string, module config.Module, registr
 			logger.Info("Not following redirect")
 			return errors.New("don't follow redirects")
 		}
+
+		// The request URL host is rewritten to the resolved IP below, so a
+		// redirect back to the original hostname is seen as cross-host and the
+		// credentials are dropped. Re-apply Basic Auth when the redirect stays
+		// on the same logical host.
+		if ba := httpConfig.HTTPClientConfig.BasicAuth; ba != nil {
+			rh := strings.ToLower(r.URL.Hostname())
+			if rh == strings.ToLower(targetHost) || (ip != nil && rh == strings.ToLower(ip.String())) {
+				r.SetBasicAuth(ba.Username, string(ba.Password))
+			}
+		}
 		return nil
 	}
 

--- a/prober/http_test.go
+++ b/prober/http_test.go
@@ -806,6 +806,48 @@ func TestBasicAuth(t *testing.T) {
 	}
 }
 
+func TestBasicAuthPreservedOnSameHostRedirect(t *testing.T) {
+	// Reproduces https://github.com/prometheus/blackbox_exporter/issues/1656:
+	// the probe dials the resolved IP but must keep the hostname in the request
+	// URL, otherwise a same-host redirect is classified as cross-host and the
+	// Basic Auth credentials are stripped, yielding a 401.
+	mux := http.NewServeMux()
+	ts := httptest.NewServer(mux)
+	defer ts.Close()
+
+	u, err := url.Parse(ts.URL)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	mux.HandleFunc("/old", func(w http.ResponseWriter, r *http.Request) {
+		http.Redirect(w, r, "http://localhost:"+u.Port()+"/new", http.StatusFound)
+	})
+	mux.HandleFunc("/new", func(w http.ResponseWriter, r *http.Request) {
+		user, pass, ok := r.BasicAuth()
+		if !ok || user != "username" || pass != "password" {
+			http.Error(w, "unauthorized", http.StatusUnauthorized)
+			return
+		}
+	})
+
+	registry := prometheus.NewRegistry()
+	testCTX, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+	result := ProbeHTTP(testCTX, "http://localhost:"+u.Port()+"/old",
+		config.Module{Timeout: time.Second, HTTP: config.HTTPProbe{
+			IPProtocol:         "ip4",
+			IPProtocolFallback: true,
+			HTTPClientConfig: pconfig.HTTPClientConfig{
+				FollowRedirects: true,
+				BasicAuth:       &pconfig.BasicAuth{Username: "username", Password: "password"},
+			},
+		}}, registry, promslog.NewNopLogger())
+	if !result {
+		t.Fatalf("HTTP probe failed: Basic Auth was stripped on same-host redirect")
+	}
+}
+
 func TestBearerToken(t *testing.T) {
 	ts := httptest.NewServer(http.HandlerFunc(func(_ http.ResponseWriter, _ *http.Request) {
 	}))


### PR DESCRIPTION
## What

Fixes #1656.

Blackbox rewrites the probe request URL host to the resolved IP address. When
the target then issues a same-host redirect (e.g. `https://host/old` ->
`https://host/new`), the redirect's hostname no longer matches the rewritten
IP, so the request is classified as a cross-host redirect and the Basic Auth
credentials are dropped, resulting in a 401.

## How

In `CheckRedirect`, when Basic Auth is configured and the redirect stays on the
same logical host (the original target hostname, or the IP it resolved to),
re-apply the credentials to the redirect request. Cross-host redirects still
never receive credentials, preserving the security behavior.

## Testing

Added `TestBasicAuthPreservedOnSameHostRedirect`, which fails on `master`
(401 after the redirect) and passes with this change. Existing HTTP/auth tests
are unaffected.