### PR TITLE
Expose the negotiated TLS group for HTTPS probes

### DIFF
--- a/prober/http.go
+++ b/prober/http.go
@@ -336,6 +336,11 @@ func ProbeHTTP(ctx context.Context, target string, module config.Module, registr
 			[]string{"cipher"},
 		)
 
+		probeTLSGroup = prometheus.NewGaugeVec(
+			probeTLSGroupGaugeOpts,
+			[]string{"group", "id"},
+		)
+
 		probeHTTPVersionGauge = prometheus.NewGauge(prometheus.GaugeOpts{
 			Name: "probe_http_version",
 			Help: "Returns the version of HTTP of the probe response",
@@ -745,10 +750,14 @@ func ProbeHTTP(ctx context.Context, target string, module config.Module, registr
 
 	if resp.TLS != nil {
 		isSSLGauge.Set(float64(1))
-		registry.MustRegister(probeSSLEarliestCertExpiryGauge, probeTLSVersion, probeTLSCipher, probeSSLLastChainExpiryTimestampSeconds, probeSSLLastInformation)
+		registry.MustRegister(probeSSLEarliestCertExpiryGauge, probeTLSVersion, probeTLSCipher, probeTLSGroup, probeSSLLastChainExpiryTimestampSeconds, probeSSLLastInformation)
 		probeSSLEarliestCertExpiryGauge.Set(float64(getEarliestCertExpiry(resp.TLS).Unix()))
 		probeTLSVersion.WithLabelValues(getTLSVersion(resp.TLS)).Set(1)
 		probeTLSCipher.WithLabelValues(getTLSCipher(resp.TLS)).Set(1)
+		// Legacy RSA key exchange reports a zero CurveID; omit the group metric then.
+		if resp.TLS.CurveID != 0 {
+			probeTLSGroup.WithLabelValues(getTLSGroupName(resp.TLS), getTLSGroupID(resp.TLS)).Set(1)
+		}
 		probeSSLLastChainExpiryTimestampSeconds.Set(float64(getLastChainExpiry(resp.TLS).Unix()))
 		probeSSLLastInformation.WithLabelValues(getFingerprint(resp.TLS), getSubject(resp.TLS), getIssuer(resp.TLS), getDNSNames(resp.TLS), getSerialNumber(resp.TLS)).Set(1)
 		checkCRL(ctx, resp.TLS, module.HTTP.CheckRevoked, &module.HTTP.HTTPClientConfig.ProxyConfig, registry, logger)

--- a/prober/http_test.go
+++ b/prober/http_test.go
@@ -806,6 +806,54 @@ func TestBasicAuth(t *testing.T) {
 	}
 }
 
+func TestTLSGroupInfo(t *testing.T) {
+	ts := httptest.NewTLSServer(http.HandlerFunc(func(_ http.ResponseWriter, _ *http.Request) {
+	}))
+	defer ts.Close()
+
+	registry := prometheus.NewRegistry()
+	testCTX, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+	result := ProbeHTTP(testCTX, ts.URL,
+		config.Module{Timeout: time.Second, HTTP: config.HTTPProbe{
+			IPProtocolFallback: true,
+			HTTPClientConfig: pconfig.HTTPClientConfig{
+				TLSConfig: pconfig.TLSConfig{InsecureSkipVerify: true},
+			},
+		}}, registry, promslog.NewNopLogger())
+	if !result {
+		t.Fatalf("HTTPS probe failed")
+	}
+
+	mfs, err := registry.Gather()
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, mf := range mfs {
+		if mf.GetName() != "probe_tls_group_info" {
+			continue
+		}
+		ms := mf.GetMetric()
+		if len(ms) == 0 {
+			t.Fatalf("probe_tls_group_info present but has no samples")
+		}
+		var group, id string
+		for _, l := range ms[0].GetLabel() {
+			switch l.GetName() {
+			case "group":
+				group = l.GetValue()
+			case "id":
+				id = l.GetValue()
+			}
+		}
+		if group == "" || id == "" || id == "0" {
+			t.Fatalf("probe_tls_group_info has empty/zero labels: group=%q id=%q", group, id)
+		}
+		return
+	}
+	t.Fatalf("probe_tls_group_info metric not found")
+}
+
 func TestBearerToken(t *testing.T) {
 	ts := httptest.NewServer(http.HandlerFunc(func(_ http.ResponseWriter, _ *http.Request) {
 	}))

--- a/prober/prober.go
+++ b/prober/prober.go
@@ -29,6 +29,7 @@ const (
 	helpSSLChainExpiryInTimeStamp = "Returns last SSL chain expiry in timestamp"
 	helpProbeTLSInfo              = "Returns the TLS version used or NaN when unknown"
 	helpProbeTLSCipher            = "Returns the TLS cipher negotiated during handshake"
+	helpProbeTLSGroup             = "Returns the TLS supported group negotiated for key agreement during handshake"
 )
 
 var (
@@ -50,5 +51,10 @@ var (
 	probeTLSCipherGaugeOpts = prometheus.GaugeOpts{
 		Name: "probe_tls_cipher_info",
 		Help: helpProbeTLSCipher,
+	}
+
+	probeTLSGroupGaugeOpts = prometheus.GaugeOpts{
+		Name: "probe_tls_group_info",
+		Help: helpProbeTLSGroup,
 	}
 )

--- a/prober/tls.go
+++ b/prober/tls.go
@@ -18,6 +18,7 @@ import (
 	"crypto/tls"
 	"encoding/hex"
 	"fmt"
+	"strconv"
 	"strings"
 	"time"
 )
@@ -95,4 +96,17 @@ func getTLSVersion(state *tls.ConnectionState) string {
 
 func getTLSCipher(state *tls.ConnectionState) string {
 	return tls.CipherSuiteName(state.CipherSuite)
+}
+
+// getTLSGroupName returns the name of the supported group negotiated for key
+// agreement, e.g. "X25519MLKEM768". Unknown or private-use codepoints keep a
+// stable hexadecimal representation via tls.CurveID.String().
+func getTLSGroupName(state *tls.ConnectionState) string {
+	return state.CurveID.String()
+}
+
+// getTLSGroupID returns the numeric TLS NamedGroup codepoint of the negotiated
+// group, retaining unknown/private-use values.
+func getTLSGroupID(state *tls.ConnectionState) string {
+	return strconv.FormatUint(uint64(state.CurveID), 10)
 }


### PR DESCRIPTION
## What

Fixes #1654.

Adds `probe_tls_group_info{group,id}` for successful HTTPS probes, following the
existing `probe_tls_version_info` / `probe_tls_cipher_info` pattern:

```text
probe_tls_group_info{group="X25519MLKEM768",id="4588"} 1
```

## How

- `prober/tls.go`: `getTLSGroupName` (via `tls.CurveID.String()`, keeping a stable
  representation for unknown/private-use codepoints) and `getTLSGroupID` (the numeric
  NamedGroup codepoint).
- `prober/http.go`: new gauge vec registered and set from `resp.TLS.CurveID`.
- The metric describes the group selected by the completed handshake. It is absent for
  plaintext probes, failed handshakes, and legacy RSA key exchange (zero `CurveID`).

## Testing

Added `TestTLSGroupInfo`, asserting the metric is present with non-empty, non-zero
`group`/`id` labels for an HTTPS probe. Existing HTTP/TLS tests are unaffected.