### PR TITLE
prober: do not expose probe_ssl_last_chain_expiry_timestamp_seconds when no chain was verified

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ BREAKING CHANGES:
 * [ENHANCEMENT]
 * [BUGFIX]
 * [BUGFIX] Randomize ICMP Echo ID in probes to avoid SNAT session collisions that could drop replies for some clients.
+* [BUGFIX] Stop exposing `probe_ssl_last_chain_expiry_timestamp_seconds` with a large negative value when no certificate chain was verified (e.g. `insecure_skip_verify: true`).
 
 ## 0.28.0 / 2025-12-04
 

--- a/prober/http.go
+++ b/prober/http.go
@@ -768,7 +768,9 @@ func ProbeHTTP(ctx context.Context, target string, module config.Module, registr
 		probeSSLEarliestCertExpiryGauge.Set(float64(getEarliestCertExpiry(resp.TLS).Unix()))
 		probeTLSVersion.WithLabelValues(getTLSVersion(resp.TLS)).Set(1)
 		probeTLSCipher.WithLabelValues(getTLSCipher(resp.TLS)).Set(1)
-		probeSSLLastChainExpiryTimestampSeconds.Set(float64(getLastChainExpiry(resp.TLS).Unix()))
+		if lastChainExpiry := getLastChainExpiry(resp.TLS); !lastChainExpiry.IsZero() {
+			probeSSLLastChainExpiryTimestampSeconds.Set(float64(lastChainExpiry.Unix()))
+		}
 		probeSSLLastInformation.WithLabelValues(getFingerprint(resp.TLS), getSubject(resp.TLS), getIssuer(resp.TLS), getDNSNames(resp.TLS), getSerialNumber(resp.TLS)).Set(1)
 		if httpConfig.FailIfSSL {
 			logger.Error("Final request was over SSL")

--- a/prober/query_response.go
+++ b/prober/query_response.go
@@ -97,7 +97,9 @@ func probeQueryResponses(ctx context.Context, target string, conn net.Conn, modu
 		registry.MustRegister(probeSSLEarliestCertExpiry, probeTLSVersion, probeSSLLastChainExpiryTimestampSeconds, probeSSLLastInformation)
 		probeSSLEarliestCertExpiry.Set(float64(getEarliestCertExpiry(&state).Unix()))
 		probeTLSVersion.WithLabelValues(getTLSVersion(&state)).Set(1)
-		probeSSLLastChainExpiryTimestampSeconds.Set(float64(getLastChainExpiry(&state).Unix()))
+		if lastChainExpiry := getLastChainExpiry(&state); !lastChainExpiry.IsZero() {
+			probeSSLLastChainExpiryTimestampSeconds.Set(float64(lastChainExpiry.Unix()))
+		}
 		probeSSLLastInformation.WithLabelValues(getFingerprint(&state), getSubject(&state), getIssuer(&state), getDNSNames(&state), getSerialNumber(&state)).Set(1)
 	}
 
@@ -194,7 +196,9 @@ func probeQueryResponses(ctx context.Context, target string, conn net.Conn, modu
 			registry.MustRegister(probeSSLEarliestCertExpiry, probeTLSVersion, probeSSLLastChainExpiryTimestampSeconds, probeSSLLastInformation)
 			probeSSLEarliestCertExpiry.Set(float64(getEarliestCertExpiry(&state).Unix()))
 			probeTLSVersion.WithLabelValues(getTLSVersion(&state)).Set(1)
-			probeSSLLastChainExpiryTimestampSeconds.Set(float64(getLastChainExpiry(&state).Unix()))
+			if lastChainExpiry := getLastChainExpiry(&state); !lastChainExpiry.IsZero() {
+				probeSSLLastChainExpiryTimestampSeconds.Set(float64(lastChainExpiry.Unix()))
+			}
 			probeSSLLastInformation.WithLabelValues(getFingerprint(&state), getSubject(&state), getIssuer(&state), getDNSNames(&state), getSerialNumber(&state)).Set(1)
 		}
 	}

--- a/prober/tls.go
+++ b/prober/tls.go
@@ -53,6 +53,12 @@ func getDNSNames(state *tls.ConnectionState) string {
 	return strings.Join(cert.DNSNames, ",")
 }
 
+// getLastChainExpiry returns the expiry of the verified certificate chain
+// that expires soonest, i.e. the "last" time at which the connection can be
+// considered fully trusted. It returns the zero time.Time if state has no
+// verified chains, which happens when certificate verification is skipped
+// (e.g. insecure_skip_verify) or fails to build a trust chain; callers must
+// check IsZero() before using the result.
 func getLastChainExpiry(state *tls.ConnectionState) time.Time {
 	lastChainExpiry := time.Time{}
 	for _, chain := range state.VerifiedChains {

--- a/prober/tls_test.go
+++ b/prober/tls_test.go
@@ -1,0 +1,56 @@
+// Copyright 2016 The Prometheus Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package prober
+
+import (
+	"crypto/tls"
+	"crypto/x509"
+	"testing"
+	"time"
+)
+
+func TestGetLastChainExpiry(t *testing.T) {
+	tests := []struct {
+		name  string
+		state *tls.ConnectionState
+		want  time.Time
+	}{
+		{
+			name:  "no verified chains (e.g. insecure_skip_verify)",
+			state: &tls.ConnectionState{VerifiedChains: nil},
+			want:  time.Time{},
+		},
+		{
+			name: "single verified chain",
+			state: &tls.ConnectionState{
+				VerifiedChains: [][]*x509.Certificate{
+					{{NotAfter: time.Unix(1000, 0)}},
+				},
+			},
+			want: time.Unix(1000, 0),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := getLastChainExpiry(tt.state)
+			if !got.Equal(tt.want) {
+				t.Errorf("getLastChainExpiry() = %v, want %v", got, tt.want)
+			}
+			if tt.want.IsZero() != got.IsZero() {
+				t.Errorf("getLastChainExpiry().IsZero() = %v, want %v", got.IsZero(), tt.want.IsZero())
+			}
+		})
+	}
+}


### PR DESCRIPTION
#### What this PR does / Which issue(s) does the PR fix:

Fixes https://github.com/prometheus/blackbox_exporter/issues/653

`getLastChainExpiry` returns the zero `time.Time` when `tls.ConnectionState` has no `VerifiedChains` — which happens whenever certificate verification is skipped (e.g. `insecure_skip_verify: true`) or fails to build a trust chain. Converting that zero value to Unix seconds produces `-62135596800`, which was being exposed as `probe_ssl_last_chain_expiry_timestamp_seconds` instead of omitting the metric.

This PR skips setting `probe_ssl_last_chain_expiry_timestamp_seconds` at each call site (`prober/http.go`, `prober/query_response.go` x2) when the returned expiry is zero, and documents the zero-value contract on `getLastChainExpiry`.

#### Does this PR introduce a user-facing change?

```release-notes
[BUGFIX] Stop exposing `probe_ssl_last_chain_expiry_timestamp_seconds` with a large negative value when no certificate chain was verified (e.g. `insecure_skip_verify: true`).
```

**Checklist**
- [x] Tests updated
- [ ] Documentation added
- [x] CHANGELOG added in `release-notes` section of PR Desc.
