### PR TITLE
Cache the OAuth2 token source across HTTP probes

### DIFF
--- a/CONFIGURATION.md
+++ b/CONFIGURATION.md
@@ -197,6 +197,12 @@ then a single address is selected to test, using the following logic:
   oauth2:
       [ <oauth2> ]
 
+  # Whether probes using the same oauth2 settings share one access token,
+  # reusing it until it expires. Set this to false to fetch a token for every
+  # probe, so that each probe also exercises the token endpoint, at the cost
+  # of one token request per probe per target.
+  [ cache_oauth2_token: <bool> | default: true ]
+
   # Whether to enable HTTP2.
   [ enable_http2: <bool> | default: true ]
 
@@ -561,7 +567,10 @@ query_response:
 
 OAuth 2.0 authentication using the client credentials grant type. Blackbox
 exporter fetches an access token from the specified endpoint with the given
-client access and secret keys.
+client access and secret keys. By default the token is shared by every probe
+using the same OAuth 2.0 settings and reused until it expires, so the number
+of token requests does not grow with the number of targets; set
+`cache_oauth2_token` to false to fetch one per probe instead.
 
 NOTE: This is *experimental* in the blackbox exporter and might not be
 reflected properly in the probe metrics at the moment.

--- a/config/config.go
+++ b/config/config.go
@@ -56,6 +56,7 @@ var (
 	DefaultHTTPProbe = HTTPProbe{
 		IPProtocolFallback: true,
 		HTTPClientConfig:   config.DefaultHTTPClientConfig,
+		CacheOAuth2Token:   true,
 	}
 
 	// DefaultGRPCProbe set default value for GRPCProbe
@@ -330,6 +331,10 @@ type HTTPProbe struct {
 	BodySizeLimit                units.Base2Bytes        `yaml:"body_size_limit,omitempty" json:"body_size_limit,omitempty"`
 	UseHTTP3                     bool                    `yaml:"enable_http3,omitempty" json:"enable_http3,omitempty"`
 	CheckRevoked                 bool                    `yaml:"check_revoked,omitempty" json:"check_revoked,omitempty"`
+	// CacheOAuth2Token shares one OAuth2 token between the probes using the
+	// same oauth2 settings. Disable it to mint a token per probe, so that
+	// every probe also exercises the token endpoint.
+	CacheOAuth2Token bool `yaml:"cache_oauth2_token,omitempty" json:"cache_oauth2_token,omitempty"`
 }
 
 type GRPCProbe struct {

--- a/prober/http.go
+++ b/prober/http.go
@@ -446,11 +446,29 @@ func ProbeHTTP(ctx context.Context, target string, module config.Module, registr
 		}
 
 	} else {
+		// A shared OAuth2 token is applied on top of the client rather than by
+		// the client config, which would build a token source per probe.
+		// Cross-host redirects go through noServerName and stay
+		// unauthenticated, as they already did.
+		var oauth2Config *pconfig.OAuth2
+		if httpClientConfig.OAuth2 != nil && httpConfig.CacheOAuth2Token {
+			oauth2Config = httpClientConfig.OAuth2
+			httpClientConfig.OAuth2 = nil
+		}
+
 		// For standard HTTP/HTTPS, create client from config
 		client, err = pconfig.NewClientFromConfig(httpClientConfig, "http_probe", pconfig.WithKeepAlivesDisabled())
 		if err != nil {
 			logger.Error("Error generating HTTP client", "err", err)
 			return false
+		}
+
+		if oauth2Config != nil {
+			client.Transport, err = newOAuth2Transport(oauth2Config, client.Transport)
+			if err != nil {
+				logger.Error("Error generating OAuth2 transport", "err", err)
+				return false
+			}
 		}
 
 		// Create a second transport without ServerName for redirects to different hosts

--- a/prober/http_test.go
+++ b/prober/http_test.go
@@ -33,9 +33,11 @@ import (
 	"net/textproto"
 	"net/url"
 	"os"
+	"path/filepath"
 	"strconv"
 	"strings"
 	"sync"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -2150,4 +2152,241 @@ func setupHTTP3Server(t *testing.T) (*http3.Server, string) {
 		// Server started
 	}
 	return server, serverURL
+}
+
+// oauth2TokenServer serves client credentials tokens and counts how many it
+// has issued.
+func oauth2TokenServer(t *testing.T) (*httptest.Server, *atomic.Int64) {
+	var issued atomic.Int64
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		issued.Add(1)
+		w.Header().Set("Content-Type", "application/json")
+		fmt.Fprintf(w, `{"access_token": "token-%d", "token_type": "Bearer", "expires_in": 3600}`, issued.Load())
+	}))
+	t.Cleanup(ts.Close)
+	return ts, &issued
+}
+
+func oauth2Module(clientID, tokenURL string) config.Module {
+	return config.Module{
+		Timeout: time.Second,
+		HTTP: config.HTTPProbe{
+			IPProtocolFallback: true,
+			CacheOAuth2Token:   true,
+			HTTPClientConfig: pconfig.HTTPClientConfig{
+				OAuth2: &pconfig.OAuth2{
+					ClientID:     clientID,
+					ClientSecret: "secret",
+					TokenURL:     tokenURL,
+				},
+			},
+		},
+	}
+}
+
+func TestHTTPOAuth2TokenIsSharedBetweenProbes(t *testing.T) {
+	tokenServer, issued := oauth2TokenServer(t)
+
+	var (
+		mtx    sync.Mutex
+		tokens []string
+	)
+	record := http.HandlerFunc(func(_ http.ResponseWriter, r *http.Request) {
+		mtx.Lock()
+		defer mtx.Unlock()
+		tokens = append(tokens, r.Header.Get("Authorization"))
+	})
+	target := httptest.NewServer(record)
+	defer target.Close()
+	otherTarget := httptest.NewServer(record)
+	defer otherTarget.Close()
+
+	module := oauth2Module("shared", tokenServer.URL)
+	testCTX, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	for _, url := range []string{target.URL, otherTarget.URL, target.URL} {
+		if !ProbeHTTP(testCTX, url, module, prometheus.NewRegistry(), promslog.NewNopLogger()) {
+			t.Fatalf("probe of %s failed", url)
+		}
+	}
+
+	if got := issued.Load(); got != 1 {
+		t.Fatalf("expected 1 token to be issued, got %d", got)
+	}
+	for _, token := range tokens {
+		if token != "Bearer token-1" {
+			t.Fatalf("unexpected Authorization header %q", token)
+		}
+	}
+}
+
+func TestHTTPOAuth2UnauthorizedRefreshesToken(t *testing.T) {
+	tokenServer, issued := oauth2TokenServer(t)
+	defer func(d time.Duration) { oauth2MinDiscardInterval = d }(oauth2MinDiscardInterval)
+	oauth2MinDiscardInterval = 0
+
+	target := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusUnauthorized)
+	}))
+	defer target.Close()
+
+	module := oauth2Module("unauthorized", tokenServer.URL)
+	testCTX, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	for i := 0; i < 3; i++ {
+		if ProbeHTTP(testCTX, target.URL, module, prometheus.NewRegistry(), promslog.NewNopLogger()) {
+			t.Fatal("probe unexpectedly succeeded")
+		}
+	}
+
+	if got := issued.Load(); got != 3 {
+		t.Fatalf("expected every rejected token to be refreshed, got %d tokens", got)
+	}
+}
+
+func TestHTTPOAuth2DistinctConfigsDoNotShareTokens(t *testing.T) {
+	tokenServer, issued := oauth2TokenServer(t)
+
+	target := httptest.NewServer(http.HandlerFunc(func(http.ResponseWriter, *http.Request) {}))
+	defer target.Close()
+
+	testCTX, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	for _, clientID := range []string{"first", "second"} {
+		module := oauth2Module(clientID, tokenServer.URL)
+		if !ProbeHTTP(testCTX, target.URL, module, prometheus.NewRegistry(), promslog.NewNopLogger()) {
+			t.Fatalf("probe with client ID %s failed", clientID)
+		}
+	}
+
+	if got := issued.Load(); got != 2 {
+		t.Fatalf("expected each config to get its own token, got %d tokens", got)
+	}
+}
+
+func TestHTTPOAuth2UnauthorizedRefreshIsThrottled(t *testing.T) {
+	tokenServer, issued := oauth2TokenServer(t)
+
+	target := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusUnauthorized)
+	}))
+	defer target.Close()
+
+	module := oauth2Module("throttled", tokenServer.URL)
+	testCTX, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	// A target answering 401 for its own reasons must not cost a token per
+	// probe: after the first discard, the next token is kept.
+	for i := 0; i < 5; i++ {
+		if ProbeHTTP(testCTX, target.URL, module, prometheus.NewRegistry(), promslog.NewNopLogger()) {
+			t.Fatal("probe unexpectedly succeeded")
+		}
+	}
+
+	if got := issued.Load(); got != 2 {
+		t.Fatalf("expected the second token to be kept, got %d tokens", got)
+	}
+}
+
+func TestHTTPOAuth2ConcurrentProbesShareOneToken(t *testing.T) {
+	tokenServer, issued := oauth2TokenServer(t)
+
+	target := httptest.NewServer(http.HandlerFunc(func(http.ResponseWriter, *http.Request) {}))
+	defer target.Close()
+
+	module := oauth2Module("concurrent", tokenServer.URL)
+	testCTX, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	// The token source is built on first use, so probes racing to be first
+	// must not each build one.
+	var wg sync.WaitGroup
+	start := make(chan struct{})
+	for i := 0; i < 20; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			<-start
+			if !ProbeHTTP(testCTX, target.URL, module, prometheus.NewRegistry(), promslog.NewNopLogger()) {
+				t.Error("probe failed")
+			}
+		}()
+	}
+	close(start)
+	wg.Wait()
+
+	if got := issued.Load(); got != 1 {
+		t.Fatalf("expected 1 token to be issued, got %d", got)
+	}
+}
+
+func TestHTTPOAuth2RotatedSecretFile(t *testing.T) {
+	tokenServer, issued := oauth2TokenServer(t)
+
+	var secrets []string
+	tokenServer.Config.Handler = http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		secret := r.PostFormValue("client_secret")
+		if _, basic, ok := r.BasicAuth(); ok {
+			secret = basic
+		}
+		secrets = append(secrets, secret)
+		issued.Add(1)
+		w.Header().Set("Content-Type", "application/json")
+		fmt.Fprintf(w, `{"access_token": "token-%d", "token_type": "Bearer", "expires_in": 3600}`, issued.Load())
+	})
+
+	target := httptest.NewServer(http.HandlerFunc(func(http.ResponseWriter, *http.Request) {}))
+	defer target.Close()
+
+	secretFile := filepath.Join(t.TempDir(), "secret")
+	module := oauth2Module("rotating", tokenServer.URL)
+	module.HTTP.HTTPClientConfig.OAuth2.ClientSecret = ""
+	module.HTTP.HTTPClientConfig.OAuth2.ClientSecretFile = secretFile
+
+	testCTX, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	// Two probes per secret: the rotation must be picked up, and only once.
+	for _, secret := range []string{"first", "first", "second", "second"} {
+		if err := os.WriteFile(secretFile, []byte(secret), 0o600); err != nil {
+			t.Fatal(err)
+		}
+		if !ProbeHTTP(testCTX, target.URL, module, prometheus.NewRegistry(), promslog.NewNopLogger()) {
+			t.Fatalf("probe with secret %s failed", secret)
+		}
+	}
+
+	if got := issued.Load(); got != 2 {
+		t.Fatalf("expected one token per secret, got %d tokens", got)
+	}
+	if len(secrets) != 2 || secrets[0] != "first" || secrets[1] != "second" {
+		t.Fatalf("token endpoint saw client secrets %q", secrets)
+	}
+}
+
+func TestHTTPOAuth2CacheCanBeDisabled(t *testing.T) {
+	tokenServer, issued := oauth2TokenServer(t)
+
+	target := httptest.NewServer(http.HandlerFunc(func(http.ResponseWriter, *http.Request) {}))
+	defer target.Close()
+
+	module := oauth2Module("uncached", tokenServer.URL)
+	module.HTTP.CacheOAuth2Token = false
+
+	testCTX, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	for i := 0; i < 3; i++ {
+		if !ProbeHTTP(testCTX, target.URL, module, prometheus.NewRegistry(), promslog.NewNopLogger()) {
+			t.Fatal("probe failed")
+		}
+	}
+
+	if got := issued.Load(); got != 3 {
+		t.Fatalf("expected a token per probe, got %d tokens", got)
+	}
 }

--- a/prober/oauth2.go
+++ b/prober/oauth2.go
@@ -1,0 +1,190 @@
+// Copyright 2026 The Prometheus Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package prober
+
+import (
+	"context"
+	"crypto/sha256"
+	"errors"
+	"fmt"
+	"net/http"
+	"os"
+	"strings"
+	"sync"
+	"time"
+
+	pconfig "github.com/prometheus/common/config"
+	"go.yaml.in/yaml/v3"
+)
+
+// An OAuth2 token depends on the module's oauth2 settings, never on the probe
+// target, but the HTTP client is rebuilt per probe because it does carry
+// per-target state (TLS ServerName). That used to rebuild the token source as
+// well, minting a token per probe per target. Share the OAuth2 round tripper
+// instead; its token source reuses tokens until they expire.
+//
+// Entries are keyed by the oauth2 settings and live for the lifetime of the
+// process, so settings that a reload drops leave their round tripper, and the
+// token it holds, behind.
+var oauth2Cache sync.Map // fingerprint -> *oauth2Entry
+
+// oauth2MinDiscardInterval bounds how often a rejected token is thrown away. A
+// target can answer 401 for reasons that have nothing to do with the token,
+// and because the token is shared, one such target would otherwise cost a
+// token per probe for every target using the same settings. A variable so
+// tests do not have to wait.
+var oauth2MinDiscardInterval = time.Minute
+
+type oauth2BaseKey struct{}
+
+// oauth2Base stands in for the per-probe transport, which is not known when
+// the shared round tripper is built and so travels on the request context.
+type oauth2Base struct{}
+
+func (oauth2Base) RoundTrip(req *http.Request) (*http.Response, error) {
+	base, ok := req.Context().Value(oauth2BaseKey{}).(http.RoundTripper)
+	if !ok {
+		return nil, errors.New("no base transport on request context")
+	}
+	return base.RoundTrip(req)
+}
+
+// oauth2Entry holds the round tripper shared by every probe using one oauth2
+// config, and the client secret it was built for.
+type oauth2Entry struct {
+	mtx         sync.Mutex
+	rt          http.RoundTripper
+	secret      string
+	warm        http.RoundTripper
+	lastDiscard time.Time
+}
+
+// roundTripper returns the shared round tripper, building one if it is missing
+// or was built for an older secret. Rebuilding it here, rather than handing
+// common/config a secret it reloads itself, keeps it from writing to a round
+// tripper that other probes are reading.
+func (e *oauth2Entry) roundTripper(cfg *pconfig.OAuth2, secret string) http.RoundTripper {
+	e.mtx.Lock()
+	defer e.mtx.Unlock()
+	if e.rt == nil || e.secret != secret {
+		e.rt = pconfig.NewOAuth2RoundTripper(pconfig.NewInlineSecret(secret), cfg, oauth2Base{}, pconfig.WithKeepAlivesDisabled())
+		e.secret = secret
+	}
+	return e.rt
+}
+
+// roundTrip serializes the first request through a round tripper, because the
+// token source is built on first use and common/config looks for it without
+// holding its write lock: concurrent first probes would each build one, and
+// each fetch a token.
+func (e *oauth2Entry) roundTrip(rt http.RoundTripper, req *http.Request) (*http.Response, error) {
+	e.mtx.Lock()
+	if e.warm == rt {
+		e.mtx.Unlock()
+		return rt.RoundTrip(req)
+	}
+	defer e.mtx.Unlock()
+	resp, err := rt.RoundTrip(req)
+	if err == nil {
+		e.warm = rt
+	}
+	return resp, err
+}
+
+// discard drops rt so the next probe fetches a new token, unless it has
+// already been replaced or one was discarded too recently.
+func (e *oauth2Entry) discard(rt http.RoundTripper) {
+	e.mtx.Lock()
+	defer e.mtx.Unlock()
+	if e.rt != rt || time.Since(e.lastDiscard) < oauth2MinDiscardInterval {
+		return
+	}
+	e.rt = nil
+	e.lastDiscard = time.Now()
+}
+
+type oauth2Transport struct {
+	entry  *oauth2Entry
+	shared http.RoundTripper
+	base   http.RoundTripper
+}
+
+func (t *oauth2Transport) RoundTrip(req *http.Request) (*http.Response, error) {
+	ctx := context.WithValue(req.Context(), oauth2BaseKey{}, t.base)
+	resp, err := t.entry.roundTrip(t.shared, req.WithContext(ctx))
+	if err == nil && resp.StatusCode == http.StatusUnauthorized {
+		t.entry.discard(t.shared)
+	}
+	return resp, err
+}
+
+// newOAuth2Transport authenticates through the OAuth2 round tripper shared by
+// all probes using cfg, and sends requests through base.
+func newOAuth2Transport(cfg *pconfig.OAuth2, base http.RoundTripper) (http.RoundTripper, error) {
+	key, err := oauth2Fingerprint(cfg)
+	if err != nil {
+		return nil, err
+	}
+	// Resolved on every probe, so a rotated secret is picked up, and outside
+	// the entry lock because it can read a file.
+	secret, err := oauth2Secret(cfg)
+	if err != nil {
+		return nil, err
+	}
+	v, _ := oauth2Cache.LoadOrStore(key, &oauth2Entry{})
+	entry := v.(*oauth2Entry)
+	return &oauth2Transport{entry: entry, shared: entry.roundTripper(cfg, secret), base: base}, nil
+}
+
+// oauth2Secret resolves the client secret in the order common/config does.
+func oauth2Secret(cfg *pconfig.OAuth2) (string, error) {
+	text, file, ref := cfg.ClientSecret, cfg.ClientSecretFile, cfg.ClientSecretRef
+	if cfg.GrantType == "urn:ietf:params:oauth:grant-type:jwt-bearer" {
+		text, file, ref = cfg.ClientCertificateKey, cfg.ClientCertificateKeyFile, cfg.ClientCertificateKeyRef
+	}
+	switch {
+	case text != "":
+		return string(text), nil
+	case file != "":
+		b, err := os.ReadFile(file)
+		if err != nil {
+			return "", fmt.Errorf("unable to read %s: %w", file, err)
+		}
+		return strings.TrimSpace(string(b)), nil
+	case ref != "":
+		return "", errors.New("oauth2 secret references require a secret manager")
+	}
+	return "", nil
+}
+
+// oauth2Fingerprint identifies the token a config yields. Marshalling covers
+// fields added later too, and skips the lazily built proxy function, which
+// would otherwise change the fingerprint after first use.
+func oauth2Fingerprint(cfg *pconfig.OAuth2) (string, error) {
+	y, err := yaml.Marshal(cfg)
+	if err != nil {
+		return "", err
+	}
+	h := sha256.New()
+	h.Write(y)
+	// Marshalling redacts secrets, including a password in proxy_url, so hash
+	// those separately.
+	proxyURL := ""
+	if cfg.ProxyURL.URL != nil {
+		proxyURL = cfg.ProxyURL.String()
+	}
+	fmt.Fprintf(h, "%q%q%q%q%q", cfg.ClientSecret, cfg.ClientCertificateKey,
+		cfg.TLSConfig.Key, proxyURL, cfg.ProxyConnectHeader)
+	return string(h.Sum(nil)), nil
+}


### PR DESCRIPTION
Fixes #1155.

`ProbeHTTP` builds a new `http.Client` per probe, which also builds a new OAuth2 token source, so a new access token is requested from the IdP for every probe of every target. With a few thousand targets this turns into millions of token requests a month against provider quotas sized in the thousands.

The client itself can't be cached: it carries per-target state (TLS `ServerName` derived from the target host or `Host` header, and a per-probe cookiejar). The token, however, depends only on the module's `oauth2` block, so this caches the OAuth2 round tripper instead, keyed by a fingerprint of that block. `common/config`'s OAuth2 round tripper already holds a self-refreshing token source, so tokens are reused until they expire. The round tripper's base is fixed at construction, so the per-probe transport is passed on the request context.

Sharing is the default, but `cache_oauth2_token: false` on a module restores a token per probe. Some setups treat the probe as an end-to-end authentication check and want every probe to exercise the token endpoint, and with a shared token an IdP outage stays invisible until the token expires. Happy to flip the default if you'd rather this be opt-in.

A 401 response drops the cached token so a rejected one is refetched on the next probe, matching the workaround described in the issue, but at most once a minute. A target can answer 401 for reasons that have nothing to do with the token, and since the token is shared, one such target would otherwise cost a token per probe for every target in the module, removing the bound this cache exists to provide.

### Sharing a round tripper concurrently

`oauth2RoundTripper` is safe as `common/config` uses it today, one per client, but sharing one between concurrent probes exposes two writes to `oauth2.Transport.Source`, which `x/oauth2` reads without a lock. Both are reachable through `ProbeHTTP` and both fire under `-race`; this PR avoids them rather than working around them:

- **Secret reload.** `FileSecret` is mutable, so every request re-reads it and a changed value makes that request reconfigure the shared round tripper in place while others are inside it. So the secret is resolved here (in `toSecret` order) and passed as an `InlineSecret`; a rotated secret builds a new round tripper instead of mutating the live one.
- **Lazy init.** The token source is built on first use, and `needsInit` is read under `RLock` which is released before the rebuild, so concurrent first probes each build one and each mint a token. So the first request through a round tripper is serialized; later ones are lock-free.

I'm happy to open a separate issue against prometheus/common for the underlying unsynchronised `Source` access if that's useful - Prometheus itself shares one round tripper across concurrent scrapes, so the reload case looks reachable there too.

### Notes for review

- Applying OAuth2 outside `NewClientFromConfig` moves it from inside the round tripper chain (above `basic_auth`, below headers/user-agent) to the outermost layer. That looks benign here: blackbox_exporter passes no `WithUserAgent`, and sets `User-Agent` on the request itself, so the token client still picks it up; `basic_auth` and `oauth2` are mutually exclusive per `Validate()`.
- The fingerprint marshals the config, so fields added later are covered, and hashes separately the values marshalling redacts: the two client secrets, `tls_config.key`, `proxy_connect_header`, and any password in `proxy_url`.
- Cache entries live for the process lifetime, so oauth2 settings dropped by a reload leave a round tripper and its token behind. Bounded by the number of distinct settings seen; happy to add reload-driven eviction if you'd prefer it.
- Cross-host redirects continue to go through the ServerName-less transport unauthenticated, as before.
- Pre-existing and untouched: the `use_http3` path builds its client directly from an `http3.Transport` and so ignores `oauth2` entirely.

### Tests

Seven cases, each verified to fail if the mechanism it covers is removed: probes of different targets in one module hit the token endpoint once; two modules with different `oauth2` blocks get their own tokens; concurrent first probes still hit it once; a rotated `client_secret_file` is picked up once per secret; a 401 forces a refresh; repeated 401s do not; and `cache_oauth2_token: false` mints one per probe.

Also driven end to end against Keycloak over HTTPS with the real binary built with `-race`: token endpoint verified via `oauth2.tls_config.ca_file` (and correctly refused without it), 1000 targets sharing one token, a rotating `client_secret_file` under concurrent load, a cross-host redirect not carrying the token, and `cache_oauth2_token: false` producing one token per probe.
